### PR TITLE
chore: add .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,32 @@
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.egg-info/
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+build/
+dist/
+
+# Virtualenvs
+.venv/
+venv/
+env/
+
+# Env / secrets
+.env
+.env.*
+!.env.example
+
+# Editor / OS
+.vscode/
+.idea/
+.DS_Store
+
+# Claude Code local session data
+.claude/
+
+# Vulca pipeline outputs dropped at repo root
+/vulca-*.png
+/vulca-*.jpg


### PR DESCRIPTION
## Summary
- Adds a .gitignore covering Python build artifacts (__pycache__, *.pyc, egg-info, build/dist), virtualenvs, editor/OS cruft, .env files, .claude/ session data, and vulca-*.{png,jpg} pipeline outputs at the repo root.
- Repo previously had no .gitignore, so every session started with a wall of untracked noise in git status.

## Test plan
- [x] git status -s clean after applying
- [x] No previously tracked files are newly ignored (verified via git ls-files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)