### PR TITLE
fix(v0.17.14): native mask-inpaint + layers_redraw recontract + paste_back glue

### DIFF
--- a/scripts/claude_orchestrated_pipeline.py
+++ b/scripts/claude_orchestrated_pipeline.py
@@ -1038,13 +1038,24 @@ def process(slug: str, force: bool = False):
         bbox, det_conf = yolo_persons[rank]
         mask, sam_score, bbox_fill, inside_ratio = segment_bbox(sam_pred, bbox)
         pct = mask.sum() / (H * W) * 100
-        print(f"  [P{i}] {label[:30]:30s} {person_detector_used}[{rank}] bbox={bbox} "
-              f"det={det_conf:.2f} sam={sam_score:.2f} pct={pct:.1f}%")
-        record.update({"status": "detected", "detector": person_detector_used,
+        # v0.17.14 — mirror the v0.17.13 transparency gate from the
+        # DINO-object path. Person path had the same silent-success bug:
+        # status: "detected" even on low-confidence SAM masks. The gate
+        # uses the same DINO-tier thresholds calibrated against γ Scottish.
+        quality_flags, status = compute_quality_flags(
+            pct=pct, sam_score=sam_score,
+            bbox_fill=bbox_fill, inside_ratio=inside_ratio,
+        )
+        marker = "?" if quality_flags else " "
+        print(f"  [P{i}]{marker}{label[:30]:30s} {person_detector_used}[{rank}] bbox={bbox} "
+              f"det={det_conf:.2f} sam={sam_score:.2f} pct={pct:.1f}%"
+              + (f" flags={quality_flags}" if quality_flags else ""))
+        record.update({"status": status, "detector": person_detector_used,
                        "bbox": bbox, "det_score": det_conf, "sam_score": sam_score,
                        "pct": round(pct, 2),
                        "bbox_fill": round(bbox_fill, 3),
-                       "inside_ratio": round(inside_ratio, 3)})
+                       "inside_ratio": round(inside_ratio, 3),
+                       "quality_flags": quality_flags})
         detection_report["per_entity"].append(record)
         layers_raw.append({
             "id": i, "label": label, "name": record["name"],

--- a/src/vulca/inpaint.py
+++ b/src/vulca/inpaint.py
@@ -1,36 +1,68 @@
-"""Inpaint API -- partial region redraw with Gemini blend."""
+"""Inpaint API -- partial region redraw with Gemini blend.
+
+v0.17.14 adds a native mask_path branch: callers supply a precision RGBA mask
+(SAM output, layer alpha, HSV filter result) instead of a coarse rectangular
+region. The mask path goes through a provider's mask-aware edit endpoint
+(currently OpenAI /v1/images/edits) and bypasses the legacy
+detect_region → crop → feathered-paste pipeline entirely.
+"""
 from __future__ import annotations
 
 import asyncio
+import logging
 import time
+from pathlib import Path
 
 from vulca.types import InpaintResult
+
+logger = logging.getLogger("vulca.inpaint")
 
 
 async def ainpaint(
     image: str,
     *,
-    region: str,
+    region: str = "",
     instruction: str,
+    mask_path: str = "",
     tradition: str = "default",
-    provider: str = "gemini",
+    provider: str = "openai",
     count: int = 4,
     select: int | None = None,
     output: str = "",
+    output_path: str = "",
     api_key: str = "",
     mock: bool = False,
 ) -> InpaintResult:
     """Inpaint a region of an artwork (async).
 
+    Two branches:
+
+    1. **Native mask** (preferred, v0.17.14+): pass ``mask_path`` to a PNG with
+       an alpha channel where alpha=0 marks pixels to edit and alpha=255 marks
+       pixels to preserve. Uses the provider's mask-aware edit endpoint
+       directly. Currently supported on ``openai`` (gpt-image-2).
+
+    2. **Legacy region**: ``region`` as NL ("fix the sky") or coordinates
+       ("0,0,100,35"). VLM detects bbox → crops → img2img full-canvas regen
+       → feathered rectangular paste. Imprecise — prefer mask_path when
+       available.
+
+    Precedence: ``mask_path`` wins over ``region`` if both are set (a warning
+    is logged).
+
     Args:
         image: Path to the image file.
-        region: NL description ("fix the sky") or coordinates ("0,0,100,35").
-        instruction: What to change in the region.
+        region: Legacy NL/coords region (used only when mask_path is empty).
+        instruction: What to paint in the masked / cropped region.
+        mask_path: PNG with alpha channel (0=edit, 255=preserve).
         tradition: Cultural tradition for style consistency.
-        provider: Image generation provider (e.g. "gemini", "openai").
-        count: Number of repaint variants to generate.
+        provider: Image generation provider. Default ``openai`` because that
+            is the only mask-aware backend right now; legacy callers passing
+            ``gemini`` for the region path still work.
+        count: Number of repaint variants for the legacy region path.
         select: Auto-select variant index (0-based). None = return all.
-        output: Output path for blended image.
+        output: (legacy alias of output_path) Output path for blended image.
+        output_path: Explicit output path. If empty, defaults next to source.
         api_key: API key override.
         mock: Use mock mode (no real API calls).
     """
@@ -42,6 +74,33 @@ async def ainpaint(
     )
 
     t0 = time.monotonic()
+
+    if mask_path and region:
+        logger.warning(
+            "ainpaint: both mask_path and region given — using mask_path "
+            "(precedence rule). Drop region= to silence."
+        )
+
+    if mask_path:
+        return await _ainpaint_with_mask(
+            image=image,
+            mask_path=mask_path,
+            instruction=instruction,
+            tradition=tradition,
+            provider=provider,
+            output_path=output_path or output,
+            api_key=api_key,
+            mock=mock,
+            t0=t0,
+        )
+
+    if not region:
+        raise ValueError(
+            "ainpaint: either mask_path or region is required. "
+            "Pass mask_path=<png> for native mask edits, or region=<NL|x,y,w,h> "
+            "for legacy crop-and-paste."
+        )
+
     phase = InpaintPhase()
 
     # 1. Parse or detect region
@@ -121,33 +180,119 @@ async def ainpaint(
     )
 
 
+async def _ainpaint_with_mask(
+    *,
+    image: str,
+    mask_path: str,
+    instruction: str,
+    tradition: str,
+    provider: str,
+    output_path: str,
+    api_key: str,
+    mock: bool,
+    t0: float,
+) -> InpaintResult:
+    """Native mask-based inpaint via provider edit endpoint."""
+    from PIL import Image as PILImage
+
+    src_p = Path(image)
+    mask_p = Path(mask_path)
+    if not src_p.exists():
+        raise FileNotFoundError(f"image not found: {image}")
+    if not mask_p.exists():
+        raise FileNotFoundError(f"mask_path not found: {mask_path}")
+
+    with PILImage.open(str(src_p)) as src_img:
+        src_img.load()
+        src_size = src_img.size
+    with PILImage.open(str(mask_p)) as mask_img:
+        mask_img.load()
+        mask_size = mask_img.size
+
+    if mask_size != src_size:
+        raise ValueError(
+            f"mask size {mask_size} != image size {src_size}; "
+            "resize mask to match before calling inpaint_artwork(mask_path=...)"
+        )
+
+    # Resolve output path early so mock and real branches share it.
+    out_path = output_path or str(src_p.with_name(f"inpainted_{src_p.stem}.png"))
+
+    if mock:
+        # Mock path: copy source as the "edited" output. Tests assert the
+        # mask path was honored without needing a real provider.
+        with PILImage.open(str(src_p)) as im:
+            im.convert("RGB").save(out_path, "PNG")
+        elapsed = int((time.monotonic() - t0) * 1000)
+        return InpaintResult(
+            bbox={"x": 0, "y": 0, "w": 100, "h": 100},
+            variants=[out_path],
+            selected=0,
+            blended=out_path,
+            original=image,
+            instruction=instruction,
+            tradition=tradition,
+            latency_ms=elapsed,
+            cost_usd=0.0,
+        )
+
+    if provider != "openai":
+        raise NotImplementedError(
+            f"inpaint_artwork(mask_path=...) is only supported on provider='openai' "
+            f"(gpt-image-2). Got provider={provider!r}. Either switch provider, "
+            "or fall back to the legacy region= path which does work for non-OpenAI "
+            "providers (less precise — feathered rectangle paste)."
+        )
+
+    from vulca.providers.openai_provider import OpenAIImageProvider
+
+    prov = OpenAIImageProvider(
+        api_key=api_key,
+        model="gpt-image-2",
+    )
+    result = await prov.inpaint_with_mask(
+        image_path=str(src_p),
+        mask_path=str(mask_p),
+        prompt=instruction,
+        tradition=tradition,
+    )
+
+    import base64
+
+    Path(out_path).parent.mkdir(parents=True, exist_ok=True)
+    Path(out_path).write_bytes(base64.b64decode(result.image_b64))
+
+    elapsed = int((time.monotonic() - t0) * 1000)
+    cost = float(result.metadata.get("cost_usd") or 0.05)
+    return InpaintResult(
+        bbox={"x": 0, "y": 0, "w": 100, "h": 100},
+        variants=[out_path],
+        selected=0,
+        blended=out_path,
+        original=image,
+        instruction=instruction,
+        tradition=tradition,
+        latency_ms=elapsed,
+        cost_usd=cost,
+    )
+
+
 def inpaint(
     image: str,
     *,
-    region: str,
+    region: str = "",
     instruction: str,
+    mask_path: str = "",
     tradition: str = "default",
-    provider: str = "gemini",
+    provider: str = "openai",
     count: int = 4,
     select: int | None = None,
     output: str = "",
+    output_path: str = "",
     api_key: str = "",
     mock: bool = False,
 ) -> InpaintResult:
-    """Inpaint a region of an artwork (sync wrapper).
-
-    Args:
-        image: Path to the image file.
-        region: NL description ("fix the sky") or coordinates ("0,0,100,35").
-        instruction: What to change in the region.
-        tradition: Cultural tradition for style consistency.
-        provider: Image generation provider (e.g. "gemini", "openai").
-        count: Number of repaint variants to generate.
-        select: Auto-select variant index (0-based). None = return all.
-        output: Output path for blended image.
-        api_key: API key override.
-        mock: Use mock mode (no real API calls).
-    """
+    """Inpaint a region of an artwork (sync wrapper). See ``ainpaint``."""
     loop = asyncio.new_event_loop()
     try:
         return loop.run_until_complete(
@@ -155,11 +300,13 @@ def inpaint(
                 image,
                 region=region,
                 instruction=instruction,
+                mask_path=mask_path,
                 tradition=tradition,
                 provider=provider,
                 count=count,
                 select=select,
                 output=output,
+                output_path=output_path,
                 api_key=api_key,
                 mock=mock,
             )

--- a/src/vulca/inpaint.py
+++ b/src/vulca/inpaint.py
@@ -25,7 +25,7 @@ async def ainpaint(
     instruction: str,
     mask_path: str = "",
     tradition: str = "default",
-    provider: str = "openai",
+    provider: str = "",
     count: int = 4,
     select: int | None = None,
     output: str = "",
@@ -81,18 +81,25 @@ async def ainpaint(
             "(precedence rule). Drop region= to silence."
         )
 
+    # Default provider depends on path: openai for mask (only one with native
+    # /v1/images/edits mask-aware editing), gemini for legacy region (the
+    # historical default — codex P2.5 review flagged a silent default flip
+    # that would have rerouted legacy callers' billing).
     if mask_path:
+        resolved_provider = provider or "openai"
         return await _ainpaint_with_mask(
             image=image,
             mask_path=mask_path,
             instruction=instruction,
             tradition=tradition,
-            provider=provider,
+            provider=resolved_provider,
             output_path=output_path or output,
             api_key=api_key,
             mock=mock,
             t0=t0,
         )
+
+    resolved_provider = provider or "gemini"
 
     if not region:
         raise ValueError(
@@ -135,7 +142,7 @@ async def ainpaint(
             crop_path,
             instruction=instruction,
             tradition=tradition,
-            provider=provider,
+            provider=resolved_provider,
             count=count,
             output_dir=crop_dir,
             api_key=api_key,
@@ -180,6 +187,33 @@ async def ainpaint(
     )
 
 
+def _bbox_from_mask_alpha(mask_rgba) -> dict:
+    """Compute percentage bbox of the mask's alpha=0 (editable) region.
+
+    Returns ``{x, y, w, h}`` as integer percentages of the mask canvas.
+    Falls back to the full canvas when the mask is fully opaque (legacy
+    contract — agent gets a non-lying signal that everything was in scope).
+
+    Codex 2026-04-25 P1 finding: pre-revision returned hardcoded
+    {0,0,100,100} regardless of mask shape, which lied to downstream
+    attribution/scoring code.
+    """
+    from PIL import Image
+
+    alpha = mask_rgba.split()[-1]
+    bbox = alpha.point(lambda v: 255 if v < 128 else 0).getbbox()
+    if bbox is None:
+        return {"x": 0, "y": 0, "w": 100, "h": 100}
+    x1, y1, x2, y2 = bbox
+    w_total, h_total = mask_rgba.size
+    return {
+        "x": int(x1 / w_total * 100),
+        "y": int(y1 / h_total * 100),
+        "w": max(1, int((x2 - x1) / w_total * 100)),
+        "h": max(1, int((y2 - y1) / h_total * 100)),
+    }
+
+
 async def _ainpaint_with_mask(
     *,
     image: str,
@@ -208,6 +242,10 @@ async def _ainpaint_with_mask(
     with PILImage.open(str(mask_p)) as mask_img:
         mask_img.load()
         mask_size = mask_img.size
+        # Compute the actually-edited bbox from mask alpha=0 region. Codex
+        # 2026-04-25 P1: hardcoded {0,0,100,100} fabricated a full-canvas
+        # box and would poison downstream attribution / scoring.
+        edit_bbox = _bbox_from_mask_alpha(mask_img.convert("RGBA"))
 
     if mask_size != src_size:
         raise ValueError(
@@ -225,7 +263,7 @@ async def _ainpaint_with_mask(
             im.convert("RGB").save(out_path, "PNG")
         elapsed = int((time.monotonic() - t0) * 1000)
         return InpaintResult(
-            bbox={"x": 0, "y": 0, "w": 100, "h": 100},
+            bbox=edit_bbox,
             variants=[out_path],
             selected=0,
             blended=out_path,
@@ -265,7 +303,7 @@ async def _ainpaint_with_mask(
     elapsed = int((time.monotonic() - t0) * 1000)
     cost = float(result.metadata.get("cost_usd") or 0.05)
     return InpaintResult(
-        bbox={"x": 0, "y": 0, "w": 100, "h": 100},
+        bbox=edit_bbox,
         variants=[out_path],
         selected=0,
         blended=out_path,
@@ -284,7 +322,7 @@ def inpaint(
     instruction: str,
     mask_path: str = "",
     tradition: str = "default",
-    provider: str = "openai",
+    provider: str = "",
     count: int = 4,
     select: int | None = None,
     output: str = "",
@@ -292,7 +330,12 @@ def inpaint(
     api_key: str = "",
     mock: bool = False,
 ) -> InpaintResult:
-    """Inpaint a region of an artwork (sync wrapper). See ``ainpaint``."""
+    """Inpaint a region of an artwork (sync wrapper). See ``ainpaint``.
+
+    ``provider=""`` (default) means: route to ``openai`` when ``mask_path``
+    is set (only mask-aware backend), otherwise route to ``gemini``
+    (legacy region default). Pass an explicit ``provider=`` to override.
+    """
     loop = asyncio.new_event_loop()
     try:
         return loop.run_until_complete(

--- a/src/vulca/layers/composite.py
+++ b/src/vulca/layers/composite.py
@@ -16,31 +16,36 @@ def composite_layers(
     width: int = 1024,
     height: int = 1024,
     output_path: str = "",
+    force_alpha_writeback: bool = False,
 ) -> str:
     """Composite full-canvas RGBA layers with blend mode support.
 
-    Applies alpha extraction (ensure_alpha) to each layer before blending.
-    Alpha extraction is alpha.py's job; blend is blend.py's job.
-    This function orchestrates both.
+    blend_layers() already reads each layer's RGBA from disk and applies the
+    correct blend mode, so for the modern flow this is enough. Alpha
+    extraction (ensure_alpha) is only needed for legacy extract-mode layers
+    that store dominant_colors and rely on chroma keying at composite time.
+
+    v0.17.14: pre-patch behavior unconditionally ran ``ensure_alpha`` and
+    wrote the result back to each ``lr.image_path``, mutating source layers
+    as a side-effect of a nominally read-only preview call (codex finding,
+    2026-04-25 review). Default behavior is now non-destructive — pass
+    ``force_alpha_writeback=True`` to opt back into the legacy in-place
+    rewrite when callers actually want to persist alpha-extracted layers.
 
     Returns output_path.
     """
-    processed: list[LayerResult] = []
-    for lr in layers:
-        try:
-            img = Image.open(lr.image_path)
-        except Exception:
-            processed.append(lr)
-            continue
+    if force_alpha_writeback:
+        for lr in layers:
+            try:
+                img = Image.open(lr.image_path)
+            except Exception:
+                continue
+            if img.size != (width, height):
+                img = img.resize((width, height), Image.LANCZOS)
+            rgba = ensure_alpha(img, lr.info)
+            rgba.save(lr.image_path)
 
-        if img.size != (width, height):
-            img = img.resize((width, height), Image.LANCZOS)
-
-        rgba = ensure_alpha(img, lr.info)
-        rgba.save(lr.image_path)
-        processed.append(lr)
-
-    canvas = blend_layers(processed, width=width, height=height)
+    canvas = blend_layers(layers, width=width, height=height)
     if not output_path:
         # Default: write next to first layer file
         first = layers[0].image_path if layers else "composite.png"

--- a/src/vulca/layers/paste_back.py
+++ b/src/vulca/layers/paste_back.py
@@ -1,0 +1,96 @@
+"""Paste an edited layer back into a foreign source image (open-loop edit).
+
+This is the glue verb for the canonical Vulca workflow
+"decompose source → edit one layer → composite back into source preserving
+everything else". It is intentionally distinct from ``layers_composite``,
+which flattens a manifest stack into a closed-loop Vulca artwork.
+
+Pure PIL — no provider calls, deterministic, fast.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Literal
+
+BlendMode = Literal["alpha", "feathered", "hard"]
+
+
+def paste_back(
+    source_image: str,
+    layer_image: str,
+    *,
+    mask_path: str = "",
+    output_path: str = "",
+    blend_mode: BlendMode = "alpha",
+    feather_px: int = 2,
+) -> dict:
+    """Composite ``layer_image`` onto ``source_image`` using a mask.
+
+    Args:
+        source_image: Original RGB image (e.g. iter0.png).
+        layer_image: Edited layer RGBA (e.g. gongbi_lanterns.png). Its alpha
+            channel is used as the default mask.
+        mask_path: Optional override mask. If empty, layer_image's alpha is
+            used.
+        output_path: Default ``<source_dir>/<source_stem>_with_<layer_stem>.png``.
+        blend_mode: ``"alpha"`` (use mask as-is) | ``"feathered"`` (Gaussian
+            blur of feather_px) | ``"hard"`` (binary threshold at 127).
+        feather_px: Gaussian blur radius for feathered mode.
+
+    Returns:
+        ``{"output_path": str, "blend_mode": str}``.
+    """
+    from PIL import Image, ImageFilter
+
+    src_p = Path(source_image)
+    layer_p = Path(layer_image)
+    if not src_p.exists():
+        raise FileNotFoundError(f"source_image not found: {source_image}")
+    if not layer_p.exists():
+        raise FileNotFoundError(f"layer_image not found: {layer_image}")
+
+    src = Image.open(str(src_p)).convert("RGB")
+    layer = Image.open(str(layer_p)).convert("RGBA")
+
+    if src.size != layer.size:
+        raise ValueError(
+            f"source size {src.size} != layer size {layer.size}; "
+            "resize one of them before paste_back"
+        )
+
+    if mask_path:
+        mask_p = Path(mask_path)
+        if not mask_p.exists():
+            raise FileNotFoundError(f"mask_path not found: {mask_path}")
+        mask = Image.open(str(mask_p)).convert("L")
+        if mask.size != src.size:
+            raise ValueError(
+                f"mask size {mask.size} != source size {src.size}"
+            )
+    else:
+        mask = layer.split()[-1]
+
+    if blend_mode == "alpha":
+        applied_mask = mask
+    elif blend_mode == "feathered":
+        if feather_px < 0:
+            raise ValueError(f"feather_px must be >= 0, got {feather_px}")
+        applied_mask = mask.filter(ImageFilter.GaussianBlur(feather_px))
+    elif blend_mode == "hard":
+        applied_mask = mask.point(lambda x: 255 if x > 127 else 0)
+    else:
+        raise ValueError(
+            f"unknown blend_mode={blend_mode!r}; "
+            "expected one of alpha, feathered, hard"
+        )
+
+    result = Image.composite(layer.convert("RGB"), src, applied_mask)
+
+    if not output_path:
+        output_path = str(
+            src_p.parent / f"{src_p.stem}_with_{layer_p.stem}.png"
+        )
+    Path(output_path).parent.mkdir(parents=True, exist_ok=True)
+    result.save(output_path, "PNG")
+
+    return {"output_path": output_path, "blend_mode": blend_mode}

--- a/src/vulca/layers/paste_back.py
+++ b/src/vulca/layers/paste_back.py
@@ -14,6 +14,11 @@ from typing import Literal
 
 BlendMode = Literal["alpha", "feathered", "hard"]
 
+# Hard-mode mask threshold (PIL convention midpoint). Codex 2026-04-25
+# review P2.4: hoisted from a magic 127 in mask.point() so future tuning
+# is one place to change.
+HARD_THRESHOLD = 127
+
 
 def paste_back(
     source_image: str,
@@ -77,14 +82,21 @@ def paste_back(
             raise ValueError(f"feather_px must be >= 0, got {feather_px}")
         applied_mask = mask.filter(ImageFilter.GaussianBlur(feather_px))
     elif blend_mode == "hard":
-        applied_mask = mask.point(lambda x: 255 if x > 127 else 0)
+        applied_mask = mask.point(lambda x: 255 if x > HARD_THRESHOLD else 0)
     else:
         raise ValueError(
             f"unknown blend_mode={blend_mode!r}; "
             "expected one of alpha, feathered, hard"
         )
 
-    result = Image.composite(layer.convert("RGB"), src, applied_mask)
+    # Codex 2026-04-25 P1: clamp the layer's RGB to the source where the
+    # layer's alpha is 0, so semi-transparent edge pixels of decompose
+    # outputs (which often store BLACK in the alpha=0 zone) do not bleed
+    # darkness into the composite via Image.composite mixing math.
+    layer_alpha = layer.split()[-1]
+    layer_rgb = layer.convert("RGB")
+    layer_clamped = Image.composite(layer_rgb, src, layer_alpha)
+    result = Image.composite(layer_clamped, src, applied_mask)
 
     if not output_path:
         output_path = str(

--- a/src/vulca/layers/redraw.py
+++ b/src/vulca/layers/redraw.py
@@ -1,16 +1,37 @@
-"""Single-layer and multi-layer merge+redraw via img2img."""
+"""Single-layer and multi-layer merge+redraw via img2img.
+
+v0.17.14 recontract (conservative — defaults unchanged for backward-compat):
+
+- ``output_layer_name``: opt-in non-destructive write to a new layer file +
+  manifest entry. Default empty → legacy in-place overwrite (will flip to
+  ``"<layer>_redrawn"`` default in v0.18 after one release cycle).
+- ``background_strategy``: how to flatten the alpha-sparse layer before
+  sending to the provider. ``"transparent"`` (default, legacy) passes the
+  RGBA layer through; ``"cream"`` / ``"white"`` / ``"sample_median"`` paste
+  onto a flat RGB canvas to stop providers hallucinating new content where
+  the layer is empty.
+- ``preserve_alpha``: re-apply the source layer's alpha to the provider
+  output. Default False (legacy).
+- ``provider``-aware api_key: legacy code injected ``GOOGLE_API_KEY`` into
+  every provider; v0.17.14 hands ``api_key=""`` to the provider when the
+  caller did not specify one, letting each provider self-resolve its env
+  var (OPENAI_API_KEY for openai, GOOGLE_API_KEY for gemini, …).
+- Aspect-preserving fit replaces blanket LANCZOS warp on non-square canvases.
+"""
 from __future__ import annotations
 
 import base64
 import json
 import logging
-import os
 import tempfile
 from pathlib import Path
 
 from vulca.layers.types import LayerInfo, LayerResult, LayeredArtwork
 
 logger = logging.getLogger("vulca.layers")
+
+CREAM_BG_RGB = (252, 248, 240)
+WHITE_BG_RGB = (255, 255, 255)
 
 
 def _build_redraw_prompt(
@@ -19,17 +40,154 @@ def _build_redraw_prompt(
     *,
     tradition: str = "default",
     canvas_size: str = "",
+    background_strategy: str = "transparent",
 ) -> str:
-    """Build img2img redraw prompt from instruction + layer descriptions."""
+    """Build img2img redraw prompt from instruction + layer descriptions.
+
+    For non-transparent background_strategy we add a canvas-guard line that
+    explicitly tells the provider the flat color is canvas, not subject —
+    this stops gpt-image-2 from hallucinating buildings into empty regions
+    of an alpha-sparse layer (γ Scottish iter 0 spire bug).
+    """
     parts = [instruction.strip()]
     if descriptions:
         parts.append("Layer context: " + "; ".join(d for d in descriptions if d))
-    parts.append("Generate a complete image filling the entire canvas. Do NOT include any checkerboard pattern, grid, or transparency indicators — output a fully painted image.")
+    if background_strategy != "transparent":
+        parts.append(
+            "The flat background is canvas — do NOT introduce new objects, "
+            "scenes, or elements where the canvas is empty. Preserve the "
+            "original spatial position and bounding box of the visible subject."
+        )
+    parts.append(
+        "Generate a complete image filling the entire canvas. Do NOT include "
+        "any checkerboard pattern, grid, or transparency indicators — output "
+        "a fully painted image."
+    )
     if canvas_size:
         parts.append(f"Canvas size: {canvas_size}.")
     if tradition and tradition != "default":
-        parts.append(f"Maintain the {tradition.replace('_', ' ')} cultural tradition and technique.")
+        parts.append(
+            f"Maintain the {tradition.replace('_', ' ')} cultural tradition "
+            "and technique."
+        )
     return "\n".join(parts)
+
+
+def _sample_median_bg(rgba_img) -> tuple[int, int, int]:
+    """Pick a median-ish RGB from non-transparent pixels.
+
+    Used by background_strategy="sample_median" so the flat canvas matches
+    the dominant tone of the layer's actual pixels (e.g. cream parchment for
+    a Scottish landscape, dark for a Goya).
+    """
+    from PIL import Image
+
+    rgba = rgba_img.convert("RGBA")
+    pixels = list(rgba.getdata())
+    visible = [(r, g, b) for r, g, b, a in pixels if a >= 32]
+    if not visible:
+        return CREAM_BG_RGB
+    visible.sort()
+    return visible[len(visible) // 2]
+
+
+def _flatten_layer(
+    src_rgba,
+    *,
+    background_strategy: str,
+):
+    """Return (flat_image, bg_rgb_or_None) per strategy."""
+    from PIL import Image
+
+    if background_strategy == "transparent":
+        return src_rgba, None
+
+    if background_strategy == "cream":
+        bg = CREAM_BG_RGB
+    elif background_strategy == "white":
+        bg = WHITE_BG_RGB
+    elif background_strategy == "sample_median":
+        bg = _sample_median_bg(src_rgba)
+    else:
+        raise ValueError(
+            f"unknown background_strategy={background_strategy!r}; "
+            "expected one of transparent, cream, white, sample_median"
+        )
+
+    flat = Image.new("RGB", src_rgba.size, bg)
+    flat.paste(src_rgba, (0, 0), src_rgba)  # alpha mask = src alpha
+    return flat, bg
+
+
+def _fit_into_canvas(out_img, target_size: tuple[int, int], bg_rgb):
+    """Aspect-preserving fit. Letterboxes with bg_rgb (or transparent)."""
+    from PIL import Image
+
+    if out_img.size == target_size:
+        return out_img
+
+    tw, th = target_size
+    sw, sh = out_img.size
+    scale = min(tw / sw, th / sh)
+    nw, nh = max(1, int(sw * scale)), max(1, int(sh * scale))
+    resized = out_img.resize((nw, nh), Image.LANCZOS)
+
+    if bg_rgb is None:
+        canvas = Image.new("RGBA", target_size, (0, 0, 0, 0))
+        if resized.mode != "RGBA":
+            resized = resized.convert("RGBA")
+    else:
+        canvas = Image.new("RGB", target_size, bg_rgb)
+        if resized.mode == "RGBA":
+            resized = resized.convert("RGB")
+    canvas.paste(resized, ((tw - nw) // 2, (th - nh) // 2))
+    return canvas
+
+
+def _add_or_replace_layer_in_manifest(
+    artwork_dir: str,
+    *,
+    new_name: str,
+    template: LayerInfo,
+    description: str = "",
+) -> None:
+    """Append a new layer entry mirroring template's metadata.
+
+    Used when output_layer_name diverges from the source layer name. If a
+    layer of the same name already exists, it is replaced (idempotent).
+    """
+    from vulca.layers.manifest import load_manifest, write_manifest
+
+    artwork = load_manifest(artwork_dir)
+    layers = [lr.info for lr in artwork.layers if lr.info.name != new_name]
+    new_z = max((l.z_index for l in layers), default=template.z_index) + 1
+
+    new_info = LayerInfo(
+        name=new_name,
+        description=description or template.description,
+        z_index=new_z,
+        content_type=template.content_type,
+        semantic_path=template.semantic_path,
+        blend_mode=template.blend_mode,
+        visible=True,
+    )
+    layers.append(new_info)
+
+    manifest_path = Path(artwork_dir) / "manifest.json"
+    manifest_data = json.loads(manifest_path.read_text())
+    write_manifest(
+        layers,
+        output_dir=artwork_dir,
+        width=manifest_data.get("width", 1024),
+        height=manifest_data.get("height", 1024),
+        source_image=manifest_data.get("source_image", ""),
+        split_mode=manifest_data.get("split_mode", ""),
+        generation_path=manifest_data.get("generation_path", ""),
+        layerability=manifest_data.get("layerability", ""),
+        partial=manifest_data.get("partial", False),
+        warnings=manifest_data.get("warnings", []),
+        tradition=manifest_data.get("tradition", ""),
+    )
 
 
 async def redraw_layer(
@@ -41,13 +199,22 @@ async def redraw_layer(
     tradition: str = "default",
     api_key: str = "",
     artwork_dir: str,
+    output_layer_name: str = "",
+    background_strategy: str = "transparent",
+    preserve_alpha: bool = False,
 ) -> LayerResult:
     """Redraw a single layer via img2img.
 
-    Finds the target layer by name, uses its existing image as the reference,
-    generates a new image, saves it to {artwork_dir}/{layer_name}.png,
-    and updates the LayerResult in place.
+    Default behavior preserves the legacy contract: writes back to the
+    layer's existing file, transparent background, no alpha re-application.
+    Pass ``output_layer_name`` to opt into non-destructive writes; pass
+    ``background_strategy`` and ``preserve_alpha`` to opt into the
+    hallucination-free path documented for the γ Scottish lanterns flow.
     """
+    import os
+
+    from PIL import Image
+
     from vulca.providers import get_image_provider
 
     # 1. Find target layer
@@ -57,10 +224,11 @@ async def redraw_layer(
             target = lr
             break
     if target is None:
-        raise ValueError(f"Layer {layer_name!r} not found in artwork (available: {[l.info.name for l in artwork.layers]})")
-    # Phase 1.7: respect locked layers (e.g. pipeline-synthesized `residual`
-    # layer from hierarchical overlap resolution). Agents should not be able
-    # to regenerate diagnostic/bookkeeping layers by accident.
+        raise ValueError(
+            f"Layer {layer_name!r} not found in artwork "
+            f"(available: {[l.info.name for l in artwork.layers]})"
+        )
+
     if target.info.locked:
         raise ValueError(
             f"Layer {layer_name!r} is locked and cannot be redrawn "
@@ -68,54 +236,138 @@ async def redraw_layer(
             f"Unlock it explicitly via layers_edit if you really mean to."
         )
 
-    # 2. Build prompt
+    # 2. Read source layer + flatten per strategy
+    src_path = Path(target.image_path)
+    src_rgba = Image.open(str(src_path)).convert("RGBA")
+    src_alpha = src_rgba.split()[-1]
+    flat, bg_rgb = _flatten_layer(src_rgba, background_strategy=background_strategy)
+
+    # 3. Build prompt
+    canvas_size_hint = ""
+    manifest_path = Path(artwork_dir) / "manifest.json"
+    manifest_data = json.loads(manifest_path.read_text())
+    canvas_w = manifest_data.get("width", src_rgba.width)
+    canvas_h = manifest_data.get("height", src_rgba.height)
+    if canvas_w and canvas_h:
+        canvas_size_hint = f"{canvas_w}x{canvas_h}"
     prompt = _build_redraw_prompt(
         instruction,
         [target.info.description],
         tradition=tradition,
+        canvas_size=canvas_size_hint,
+        background_strategy=background_strategy,
     )
 
-    # 3. Encode reference image
-    ref_path = Path(target.image_path)
-    ref_b64 = base64.b64encode(ref_path.read_bytes()).decode()
+    # 4. Encode reference (flat for non-transparent, src_rgba for legacy)
+    with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as fh:
+        flat.save(fh.name, "PNG")
+        ref_b64 = base64.b64encode(Path(fh.name).read_bytes()).decode()
+    try:
+        Path(fh.name).unlink(missing_ok=True)
+    except Exception:
+        pass
 
-    # 4. Call image provider
-    img_provider = get_image_provider(
-        provider,
-        api_key=api_key or os.environ.get("GOOGLE_API_KEY", ""),
-    )
+    # 5. Provider-aware api_key resolution. Bug fix: legacy code passed
+    # GOOGLE_API_KEY to every provider. Now: if caller didn't specify a
+    # key, hand "" to the provider so it self-resolves OPENAI_API_KEY /
+    # GOOGLE_API_KEY / etc from its own __init__.
+    img_provider = get_image_provider(provider, api_key=api_key)
     result = await img_provider.generate(
         prompt,
         tradition=tradition,
         reference_image_b64=ref_b64,
     )
 
-    # 5. Save output as RGBA PNG (match canvas size from manifest)
-    manifest_data = json.loads((Path(artwork_dir) / "manifest.json").read_text())
-    canvas_w = manifest_data.get("width", 1024)
-    canvas_h = manifest_data.get("height", 1024)
+    # 6. Decode + aspect-preserving fit (replaces blanket LANCZOS warp)
+    raw = base64.b64decode(result.image_b64)
+    if result.mime and "svg" in result.mime:
+        # SVG fallback only — preserved for unusual mock branches
+        out_img = Image.new("RGBA", (canvas_w, canvas_h), (0, 0, 0, 0))
+    else:
+        import io as _io
+
+        out_img = Image.open(_io.BytesIO(raw))
+
+    out_img = _fit_into_canvas(out_img, (canvas_w, canvas_h), bg_rgb)
+    rgba = out_img.convert("RGBA")
+
+    # 7. Optionally re-apply original alpha
+    if preserve_alpha:
+        # Resize alpha to match if canvas resized (rare; manifest dims drive both)
+        if src_alpha.size != rgba.size:
+            src_alpha = src_alpha.resize(rgba.size, Image.LANCZOS)
+        rgba.putalpha(src_alpha)
+
+    # 8. Write — default in-place (legacy), opt-in new file
+    if output_layer_name:
+        out_name = output_layer_name
+        out_path = Path(artwork_dir) / f"{out_name}.png"
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        rgba.save(str(out_path), "PNG")
+
+        # 8b. Hybrid alpha mask still applies for legacy `extract`-mode layers
+        # whose dominant_colors are stored — keep behavior parity.
+        _maybe_apply_legacy_color_mask(
+            artwork_dir, manifest_data, target, out_path
+        )
+
+        # 8c. Manifest update: append (idempotent on rewrite)
+        try:
+            _add_or_replace_layer_in_manifest(
+                artwork_dir,
+                new_name=out_name,
+                template=target.info,
+                description=f"Redraw of {layer_name}: {instruction[:60]}",
+            )
+        except Exception as exc:
+            logger.warning("redraw: manifest update failed (non-fatal): %s", exc)
+
+        new_info = LayerInfo(
+            name=out_name,
+            description=target.info.description,
+            z_index=target.info.z_index,
+            content_type=target.info.content_type,
+            semantic_path=target.info.semantic_path,
+            blend_mode=target.info.blend_mode,
+        )
+        return LayerResult(info=new_info, image_path=str(out_path))
+
+    # Legacy in-place path
     out_path = Path(artwork_dir) / f"{layer_name}.png"
-    _save_as_rgba(result.image_b64, result.mime, out_path, width=canvas_w, height=canvas_h)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    rgba.save(str(out_path), "PNG")
+    _maybe_apply_legacy_color_mask(artwork_dir, manifest_data, target, out_path)
 
-    # 5b. Apply alpha mask from source image if available (hybrid: Gemini content + extract alpha)
-    source_img_name = manifest_data.get("source_image", "")
-    if source_img_name and target.info.dominant_colors:
-        source_path = Path(artwork_dir) / source_img_name
-        if not source_path.exists():
-            source_path = Path(artwork_dir).parent / source_img_name
-        if source_path.exists():
-            from vulca.layers.mask import build_color_mask
-            from PIL import Image as _PIL
-            source_img = _PIL.open(str(source_path))
-            gen_img = _PIL.open(str(out_path))
-            mask = build_color_mask(source_img, target.info, tolerance=30)
-            r, g, b, _ = gen_img.convert("RGBA").split()
-            hybrid = _PIL.merge("RGBA", (r, g, b, mask))
-            hybrid.save(str(out_path))
-
-    # 6. Update target and return
     target.image_path = str(out_path)
     return target
+
+
+def _maybe_apply_legacy_color_mask(
+    artwork_dir: str, manifest_data: dict, target: LayerResult, out_path: Path
+) -> None:
+    """Hybrid alpha mask for legacy `extract`-mode layers (dominant_colors).
+
+    Lifted verbatim from the old redraw_layer body so the legacy path stays
+    bit-identical for backwards compatibility.
+    """
+    source_img_name = manifest_data.get("source_image", "")
+    if not (source_img_name and target.info.dominant_colors):
+        return
+    source_path = Path(artwork_dir) / source_img_name
+    if not source_path.exists():
+        source_path = Path(artwork_dir).parent / source_img_name
+    if not source_path.exists():
+        return
+    from PIL import Image as _PIL
+
+    from vulca.layers.mask import build_color_mask
+
+    source_img = _PIL.open(str(source_path))
+    gen_img = _PIL.open(str(out_path))
+    mask = build_color_mask(source_img, target.info, tolerance=30)
+    r, g, b, _ = gen_img.convert("RGBA").split()
+    hybrid = _PIL.merge("RGBA", (r, g, b, mask))
+    hybrid.save(str(out_path))
 
 
 async def redraw_merged(
@@ -139,7 +391,6 @@ async def redraw_merged(
     from vulca.layers.blend import blend_layers
     from vulca.providers import get_image_provider
 
-    # 1. Find selected layers (preserve order by z_index)
     name_set = set(layer_names)
     selected: list[LayerResult] = [lr for lr in artwork.layers if lr.info.name in name_set]
     found_names = {lr.info.name for lr in selected}
@@ -150,13 +401,11 @@ async def redraw_merged(
             f"(available: {[l.info.name for l in artwork.layers]})"
         )
 
-    # 2. Read manifest for canvas dimensions
     manifest_path = Path(artwork_dir) / "manifest.json"
     manifest = json.loads(manifest_path.read_text())
     width = manifest.get("width", 1024)
     height = manifest.get("height", 1024)
 
-    # 3. Composite selected layers into temp file
     merged_img = blend_layers(selected, width=width, height=height)
     tmp_file = tempfile.NamedTemporaryFile(suffix=".png", delete=False)
     try:
@@ -164,7 +413,6 @@ async def redraw_merged(
         tmp_file.close()
         ref_b64 = base64.b64encode(Path(tmp_file.name).read_bytes()).decode()
 
-        # 4. Build prompt
         descriptions = [lr.info.description for lr in selected]
         prompt = _build_redraw_prompt(
             instruction,
@@ -173,28 +421,22 @@ async def redraw_merged(
             canvas_size=f"{width}x{height}",
         )
 
-        # 5. Call image provider
-        img_provider = get_image_provider(
-            provider,
-            api_key=api_key or os.environ.get("GOOGLE_API_KEY", ""),
-        )
+        # Provider-aware api_key (Patch 6 from spec, folded in)
+        img_provider = get_image_provider(provider, api_key=api_key)
         result = await img_provider.generate(
             prompt,
             tradition=tradition,
             reference_image_b64=ref_b64,
         )
     finally:
-        # 6. Cleanup temp file
         try:
             Path(tmp_file.name).unlink(missing_ok=True)
         except Exception:
             pass
 
-    # 7. Save output as RGBA PNG (match canvas size)
     out_path = Path(artwork_dir) / f"{merged_name}.png"
     _save_as_rgba(result.image_b64, result.mime, out_path, width=width, height=height)
 
-    # 8. Create new LayerInfo with merged_name, min z_index, content_type="subject"
     min_z = min(lr.info.z_index for lr in selected)
     merged_info = LayerInfo(
         name=merged_name,
@@ -205,7 +447,6 @@ async def redraw_merged(
     if not re_split:
         return LayerResult(info=merged_info, image_path=str(out_path))
 
-    # Re-split: analyze the merged result and split into extract mode layers
     from vulca.layers.analyze import analyze_layers
     from vulca.layers.split import split_extract
     import shutil
@@ -214,7 +455,6 @@ async def redraw_merged(
     resplit_dir = Path(artwork_dir) / f"_resplit_{merged_name}"
     results = split_extract(str(out_path), new_layers, output_dir=str(resplit_dir))
 
-    # Move re-split layer files to artwork_dir
     final_results = []
     for r in results:
         dest = Path(artwork_dir) / Path(r.image_path).name
@@ -223,7 +463,6 @@ async def redraw_merged(
         r.image_path = str(dest)
         final_results.append(r)
 
-    # Cleanup temp dir and merged file
     shutil.rmtree(str(resplit_dir), ignore_errors=True)
     out_path.unlink(missing_ok=True)
 
@@ -253,7 +492,6 @@ def _save_as_rgba(
         img = Image.open(io.BytesIO(raw))
 
     img = img.convert("RGBA")
-    # Ensure output matches canvas size (providers may return different sizes)
     if width and height and img.size != (width, height):
         img = img.resize((width, height), Image.LANCZOS)
     out_path.parent.mkdir(parents=True, exist_ok=True)

--- a/src/vulca/layers/redraw.py
+++ b/src/vulca/layers/redraw.py
@@ -79,6 +79,11 @@ def _sample_median_bg(rgba_img) -> tuple[int, int, int]:
     Used by background_strategy="sample_median" so the flat canvas matches
     the dominant tone of the layer's actual pixels (e.g. cream parchment for
     a Scottish landscape, dark for a Goya).
+
+    Fallback: when fewer than 0.1% of pixels meet the alpha>=32 visibility
+    threshold (essentially fully-transparent layer), we log a warning and
+    return CREAM. Codex 2026-04-25 review flagged the silent fallback as a
+    "silent lie"; the warning is the agent's signal to inspect.
     """
     from PIL import Image
 
@@ -86,6 +91,11 @@ def _sample_median_bg(rgba_img) -> tuple[int, int, int]:
     pixels = list(rgba.getdata())
     visible = [(r, g, b) for r, g, b, a in pixels if a >= 32]
     if not visible:
+        logger.warning(
+            "redraw: sample_median found no visible pixels (alpha>=32) — "
+            "falling back to cream background. Layer may be effectively "
+            "transparent; consider background_strategy='cream' explicitly."
+        )
         return CREAM_BG_RGB
     visible.sort()
     return visible[len(visible) // 2]
@@ -150,11 +160,16 @@ def _add_or_replace_layer_in_manifest(
     new_name: str,
     template: LayerInfo,
     description: str = "",
-) -> None:
+) -> int:
     """Append a new layer entry mirroring template's metadata.
 
     Used when output_layer_name diverges from the source layer name. If a
     layer of the same name already exists, it is replaced (idempotent).
+
+    Returns the z_index assigned to the new layer so the caller's
+    in-memory ``LayerResult`` agrees with what was just written to disk
+    (P1.1 from 2026-04-25 review — disagreement caused the layer to
+    silently move on the next ``load_manifest``).
     """
     from vulca.layers.manifest import load_manifest, write_manifest
 
@@ -188,6 +203,7 @@ def _add_or_replace_layer_in_manifest(
         warnings=manifest_data.get("warnings", []),
         tradition=manifest_data.get("tradition", ""),
     )
+    return new_z
 
 
 async def redraw_layer(
@@ -311,9 +327,13 @@ async def redraw_layer(
             artwork_dir, manifest_data, target, out_path
         )
 
-        # 8c. Manifest update: append (idempotent on rewrite)
+        # 8c. Manifest update: append (idempotent on rewrite). Capture the
+        # assigned z_index so the in-memory LayerResult agrees with disk —
+        # otherwise next load_manifest silently moves the layer (P1 finding,
+        # 2026-04-25 review).
+        assigned_z = target.info.z_index
         try:
-            _add_or_replace_layer_in_manifest(
+            assigned_z = _add_or_replace_layer_in_manifest(
                 artwork_dir,
                 new_name=out_name,
                 template=target.info,
@@ -325,7 +345,7 @@ async def redraw_layer(
         new_info = LayerInfo(
             name=out_name,
             description=target.info.description,
-            z_index=target.info.z_index,
+            z_index=assigned_z,
             content_type=target.info.content_type,
             semantic_path=target.info.semantic_path,
             blend_mode=target.info.blend_mode,
@@ -435,7 +455,14 @@ async def redraw_merged(
             pass
 
     out_path = Path(artwork_dir) / f"{merged_name}.png"
-    _save_as_rgba(result.image_b64, result.mime, out_path, width=width, height=height)
+    # Aspect-preserving fit (codex 2026-04-25 P2 — redraw_merged was using
+    # blanket LANCZOS warp via _save_as_rgba, asymmetric with the new
+    # redraw_layer fit logic). Letterbox transparent so merged result keeps
+    # alpha-stack semantics for downstream composite.
+    _save_as_rgba_fit(
+        result.image_b64, result.mime, out_path,
+        width=width, height=height,
+    )
 
     min_z = min(lr.info.z_index for lr in selected)
     merged_info = LayerInfo(
@@ -477,7 +504,12 @@ def _save_as_rgba(
     image_b64: str, mime: str, out_path: Path,
     *, width: int = 0, height: int = 0,
 ) -> None:
-    """Decode image_b64, convert to RGBA, resize to canvas if needed, save as PNG."""
+    """Decode image_b64, convert to RGBA, resize to canvas if needed, save as PNG.
+
+    Legacy helper — uses LANCZOS warp on size mismatch. Kept for any
+    out-of-tree callers; new code should use _save_as_rgba_fit which is
+    aspect-preserving.
+    """
     from PIL import Image
     import io
 
@@ -494,5 +526,31 @@ def _save_as_rgba(
     img = img.convert("RGBA")
     if width and height and img.size != (width, height):
         img = img.resize((width, height), Image.LANCZOS)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    img.save(str(out_path), format="PNG")
+
+
+def _save_as_rgba_fit(
+    image_b64: str, mime: str, out_path: Path,
+    *, width: int = 0, height: int = 0,
+) -> None:
+    """Aspect-preserving variant of _save_as_rgba — letterboxes with alpha=0
+    when provider output's aspect differs from the canvas. Symmetric with
+    redraw_layer's flow."""
+    from PIL import Image
+    import io
+
+    raw = base64.b64decode(image_b64)
+
+    if mime and "svg" in mime:
+        w = width or 100
+        h = height or 100
+        img = Image.new("RGBA", (w, h), (0, 0, 0, 0))
+    else:
+        img = Image.open(io.BytesIO(raw))
+
+    img = img.convert("RGBA")
+    if width and height and img.size != (width, height):
+        img = _fit_into_canvas(img, (width, height), bg_rgb=None)
     out_path.parent.mkdir(parents=True, exist_ok=True)
     img.save(str(out_path), format="PNG")

--- a/src/vulca/mcp_server.py
+++ b/src/vulca/mcp_server.py
@@ -1118,6 +1118,53 @@ async def layers_composite(artwork_dir: str, output_path: str = "") -> dict:
 
 
 @mcp.tool()
+async def layers_paste_back(
+    source_image: str,
+    layer_image: str,
+    mask_path: str = "",
+    output_path: str = "",
+    blend_mode: str = "alpha",
+    feather_px: int = 2,
+) -> dict:
+    """Paste an edited layer back into a foreign source image — open-loop edit.
+
+    Use after editing a single layer (via layers_redraw, inpaint_artwork, or
+    out-of-band tooling) to composite the edit back into the original source
+    image while preserving every other pixel. Distinct from layers_composite,
+    which flattens a manifest stack into a closed-loop Vulca artwork.
+
+    Pure PIL — no provider calls, deterministic, fast.
+
+    Args:
+        source_image: Original RGB image (e.g. iter0.png). Read-only.
+        layer_image: Edited layer RGBA (e.g. gongbi_lanterns.png). Its alpha
+            channel is the default mask.
+        mask_path: Optional override mask (8-bit grayscale or alpha PNG).
+            If empty, layer_image's alpha is used.
+        output_path: Default <source_dir>/<source_stem>_with_<layer_stem>.png.
+        blend_mode: "alpha" (mask as-is) | "feathered" (Gaussian blur) |
+            "hard" (binary threshold at 127).
+        feather_px: Gaussian blur radius for feathered mode.
+
+    Returns:
+        output_path, blend_mode.
+    """
+    from vulca.layers.paste_back import paste_back
+
+    try:
+        return paste_back(
+            source_image,
+            layer_image,
+            mask_path=mask_path,
+            output_path=output_path,
+            blend_mode=blend_mode,
+            feather_px=feather_px,
+        )
+    except Exception as exc:
+        return {"error": str(exc)}
+
+
+@mcp.tool()
 async def layers_export(
     artwork_dir: str,
     export_format: str = "png",

--- a/src/vulca/mcp_server.py
+++ b/src/vulca/mcp_server.py
@@ -573,7 +573,7 @@ async def inpaint_artwork(
     instruction: str = "",
     mask_path: str = "",
     tradition: str = "default",
-    provider: str = "openai",
+    provider: str = "",
     output_path: str = "",
 ) -> dict:
     """Repaint part of an image — native mask (precise) or NL region (legacy, imprecise).
@@ -593,7 +593,9 @@ async def inpaint_artwork(
         instruction: What to paint in the masked / cropped region.
         mask_path: PNG with alpha (0=edit, 255=preserve). Must match image size.
         tradition: Cultural tradition for style consistency.
-        provider: Image provider. Default "openai" (only one with native mask).
+        provider: Image provider. Empty (default) routes mask_path to "openai"
+            (only mask-aware backend) and region to "gemini" (legacy default).
+            Pass explicit "openai"/"gemini"/"comfyui" to override.
         output_path: Explicit output PNG path. Default: <image_dir>/inpainted_<stem>.png.
 
     Returns:

--- a/src/vulca/mcp_server.py
+++ b/src/vulca/mcp_server.py
@@ -569,32 +569,51 @@ async def archive_session(
 @mcp.tool()
 async def inpaint_artwork(
     image_path: str,
-    region: str,
-    instruction: str,
+    region: str = "",
+    instruction: str = "",
+    mask_path: str = "",
     tradition: str = "default",
+    provider: str = "openai",
+    output_path: str = "",
 ) -> dict:
-    """Repaint a specific region of an image — targeted fix without re-generating the whole artwork.
+    """Repaint part of an image — native mask (precise) or NL region (legacy, imprecise).
 
-    Use after evaluate_artwork identifies a problem area, or after view_image reveals a regional flaw.
-    For whole-image changes, use generate_image instead.
+    Two modes:
+    - **mask_path** (preferred): RGBA PNG where alpha=0 marks pixels to edit and
+      alpha=255 marks pixels to preserve. Routed to provider /v1/images/edits.
+      Currently OpenAI gpt-image-2 only; Gemini/ComfyUI raise NotImplementedError.
+    - **region** (legacy): NL ("fix the sky") or "x,y,w,h". Detects bbox via VLM,
+      crops, regenerates, feathers a rectangular paste. Imprecise — prefer mask_path.
+
+    Precedence: mask_path > region. Setting both logs a warning and uses mask_path.
 
     Args:
         image_path: Path to the image file.
-        region: Natural language ("fix the sky") or pixel coordinates ("0,0,100,35").
-        instruction: What to paint in the region.
+        region: Legacy NL/coords region. Ignored when mask_path is set.
+        instruction: What to paint in the masked / cropped region.
+        mask_path: PNG with alpha (0=edit, 255=preserve). Must match image size.
         tradition: Cultural tradition for style consistency.
+        provider: Image provider. Default "openai" (only one with native mask).
+        output_path: Explicit output PNG path. Default: <image_dir>/inpainted_<stem>.png.
 
     Returns:
-        image_path: Path to the blended result. bbox: Painted region. cost_usd, latency_ms.
+        image_path: Path to the blended result. bbox: Painted region (mask path
+        returns full canvas {0,0,100,100}). cost_usd, latency_ms.
     """
     from vulca.inpaint import ainpaint
+
+    if not mask_path and not region:
+        return {"error": "inpaint_artwork: pass mask_path=<png> or region=<NL|x,y,w,h>"}
 
     try:
         result = await ainpaint(
             image_path,
             region=region,
             instruction=instruction,
+            mask_path=mask_path,
             tradition=tradition,
+            provider=provider,
+            output_path=output_path,
             count=1,
             select=0,
         )

--- a/src/vulca/mcp_server.py
+++ b/src/vulca/mcp_server.py
@@ -759,11 +759,20 @@ async def layers_redraw(
     merged_name: str = "merged",
     provider: str = "gemini",
     tradition: str = "default",
+    output_layer_name: str = "",
+    background_strategy: str = "transparent",
+    preserve_alpha: bool = False,
 ) -> dict:
     """Redraw a layer via img2img with explicit content/style instructions — targeted layer regeneration.
 
     Use after layers_list identifies a weak layer, or after evaluate_artwork flags a specific issue.
     Be specific about position ("upper 30%"), scale ("covering 20%"), and style ("lighter ink wash").
+
+    v0.17.14: opt into the hallucination-free flow by passing
+    ``background_strategy="cream"`` (or "white"/"sample_median") plus
+    ``preserve_alpha=True``; pass ``output_layer_name="..."`` to write a new
+    layer file + manifest entry instead of overwriting in place. Defaults
+    keep the legacy contract for back-compat.
 
     Args:
         artwork_dir: Directory with layer PNGs + manifest.
@@ -774,6 +783,14 @@ async def layers_redraw(
         merged_name: Name for the merged output layer.
         provider: Image provider.
         tradition: Cultural tradition.
+        output_layer_name: NEW v0.17.14 — non-destructive: write to a new
+            layer file (default empty = overwrite source layer in place).
+        background_strategy: NEW v0.17.14 — flatten alpha-sparse layer
+            before sending to provider. "transparent" (default, legacy) |
+            "cream" | "white" | "sample_median". Non-transparent strategies
+            stop providers from hallucinating new content into empty regions.
+        preserve_alpha: NEW v0.17.14 — re-apply source layer's alpha to the
+            provider output. Default False (legacy).
 
     Returns:
         name, file, z_index, content_type of the redrawn layer.
@@ -798,6 +815,9 @@ async def layers_redraw(
             artwork, layer_name=layer,
             instruction=instruction, provider=provider,
             tradition=tradition, artwork_dir=artwork_dir,
+            output_layer_name=output_layer_name,
+            background_strategy=background_strategy,
+            preserve_alpha=preserve_alpha,
         )
     else:
         return {"error": "Specify 'layer' or 'layers' with merge=true"}

--- a/src/vulca/providers/openai_provider.py
+++ b/src/vulca/providers/openai_provider.py
@@ -375,15 +375,9 @@ class OpenAIImageProvider:
     ) -> ImageResult:
         """Mask-aware inpaint via /v1/images/edits.
 
-        Convention: mask alpha=0 => editable, alpha=255 => preserved. This
-        matches PIL alpha semantics for SAM / layer-derived masks. (OpenAI
-        documents the inverse semantically — "transparent areas of the mask
-        will be edited" — so PNG alpha=0 in our mask becomes a transparent
-        area when the mask is uploaded as RGBA. We pass it through unchanged.)
-
-        Only supported on gpt-image-* models — DALL-E-2's /edits requires a
-        square PNG and returns URLs by default. Caller is expected to have
-        constructed this provider with model='gpt-image-2'.
+        Mask convention (alpha=0 = edit, alpha=255 = preserve) maps directly
+        onto OpenAI's transparency semantic — the mask is uploaded as PNG
+        unchanged. Only supported on gpt-image-* models.
         """
         if not self.api_key:
             raise ValueError(
@@ -405,7 +399,7 @@ class OpenAIImageProvider:
             )
 
         # Probe mask size; pick a supported edit size near it.
-        from PIL import Image as PILImage  # noqa: F401 — local import to keep deps lazy
+        from PIL import Image as PILImage
         with open(image_path, "rb") as fh_img, open(mask_path, "rb") as fh_mask:
             image_bytes = fh_img.read()
             mask_bytes = fh_mask.read()

--- a/src/vulca/providers/openai_provider.py
+++ b/src/vulca/providers/openai_provider.py
@@ -363,3 +363,144 @@ class OpenAIImageProvider:
             max_delay_ms=16_000,
             retryable_check=_is_retryable,
         )
+
+    async def inpaint_with_mask(
+        self,
+        *,
+        image_path: str,
+        mask_path: str,
+        prompt: str,
+        tradition: str = "default",
+        size: str = "",
+    ) -> ImageResult:
+        """Mask-aware inpaint via /v1/images/edits.
+
+        Convention: mask alpha=0 => editable, alpha=255 => preserved. This
+        matches PIL alpha semantics for SAM / layer-derived masks. (OpenAI
+        documents the inverse semantically — "transparent areas of the mask
+        will be edited" — so PNG alpha=0 in our mask becomes a transparent
+        area when the mask is uploaded as RGBA. We pass it through unchanged.)
+
+        Only supported on gpt-image-* models — DALL-E-2's /edits requires a
+        square PNG and returns URLs by default. Caller is expected to have
+        constructed this provider with model='gpt-image-2'.
+        """
+        if not self.api_key:
+            raise ValueError(
+                "OpenAI API key required. Set OPENAI_API_KEY env var "
+                "or pass api_key to OpenAIImageProvider()."
+            )
+        if not self.model.startswith("gpt-image"):
+            raise ValueError(
+                f"inpaint_with_mask requires a gpt-image-* model "
+                f"(current model={self.model!r})."
+            )
+
+        import httpx
+
+        full_prompt = prompt
+        if tradition and tradition != "default":
+            full_prompt = (
+                f"{prompt} (cultural tradition: {tradition.replace('_', ' ')})"
+            )
+
+        # Probe mask size; pick a supported edit size near it.
+        from PIL import Image as PILImage  # noqa: F401 — local import to keep deps lazy
+        with open(image_path, "rb") as fh_img, open(mask_path, "rb") as fh_mask:
+            image_bytes = fh_img.read()
+            mask_bytes = fh_mask.read()
+
+        if not size:
+            with PILImage.open(image_path) as src_img:
+                w, h = src_img.size
+            allowed_sizes = {
+                (1024, 1024),
+                (1024, 1536),
+                (1536, 1024),
+            }
+            size = f"{w}x{h}" if (w, h) in allowed_sizes else "1024x1024"
+
+        async def _call() -> ImageResult:
+            async with httpx.AsyncClient(timeout=180) as client:
+                headers = {"Authorization": f"Bearer {self.api_key}"}
+                files = {
+                    "image": ("image.png", image_bytes, "image/png"),
+                    "mask": ("mask.png", mask_bytes, "image/png"),
+                }
+                form = {
+                    "model": self.model,
+                    "prompt": full_prompt,
+                    "n": "1",
+                    "size": size,
+                }
+                resp = await client.post(
+                    "https://api.openai.com/v1/images/edits",
+                    headers=headers, files=files, data=form,
+                )
+
+                body_text = ""
+                try:
+                    body_text = (resp.text or "")[:500]
+                except Exception:
+                    body_text = ""
+                body_lower = body_text.lower()
+
+                if resp.status_code == 403 and "organization must be verified" in body_lower:
+                    raise RuntimeError(
+                        f"OpenAI model {self.model!r} requires Org verification at "
+                        "https://platform.openai.com/settings/organization/general."
+                    )
+                if resp.status_code == 402:
+                    raise RuntimeError(
+                        "OpenAI billing blocked: insufficient credits or "
+                        "payment failure."
+                    )
+                if resp.status_code == 400 and (
+                    "content_policy_violation" in body_lower
+                    or "safety" in body_lower
+                ):
+                    raise RuntimeError(
+                        "OpenAI content policy blocked the inpaint request."
+                    )
+                if resp.status_code == 429:
+                    raise RuntimeError("OpenAI rate limit hit. rate limit hit")
+                resp.raise_for_status()
+                data = resp.json()
+
+            img_b64 = data["data"][0].get("b64_json") or data["data"][0].get("b64", "")
+            metadata = {
+                "model": self.model,
+                "endpoint": "edits",
+                "mode": "inpaint_with_mask",
+            }
+            cost_usd = _extract_cost_usd(
+                model=self.model, data=data, size=size, quality=None,
+            )
+            if cost_usd is not None:
+                metadata["cost_usd"] = cost_usd
+            if data.get("usage"):
+                metadata["usage"] = data["usage"]
+            return ImageResult(
+                image_b64=img_b64,
+                mime="image/png",
+                metadata=metadata,
+            )
+
+        def _is_retryable(exc: Exception) -> bool:
+            response = getattr(exc, "response", None)
+            if response is not None:
+                status = getattr(response, "status_code", None)
+                return status in (429, 500, 503)
+            if isinstance(exc, RuntimeError) and "rate limit hit" in str(exc).lower():
+                return True
+            if isinstance(exc, (httpx.TimeoutException, httpx.ConnectError)):
+                return True
+            return False
+
+        return await with_retry(
+            _call,
+            max_retries=3,
+            base_delay_ms=500,
+            max_delay_ms=16_000,
+            retryable_check=_is_retryable,
+        )

--- a/tests/test_composite_nondestructive.py
+++ b/tests/test_composite_nondestructive.py
@@ -1,0 +1,70 @@
+"""v0.17.14 — composite_layers must not mutate source layer files by default.
+
+Codex finding from the parallel review of 2026-04-25: pre-v0.17.14
+``composite_layers`` unconditionally ran ``ensure_alpha`` and wrote the
+result back to each ``lr.image_path``. A "preview" call thereby mutated
+the user's source layers — destructive, surprising, and the kind of
+side-effect that makes layered editing flows brittle.
+
+Default is now non-destructive; legacy mutation is opt-in via
+``force_alpha_writeback=True``.
+"""
+from __future__ import annotations
+
+import os
+import tempfile
+
+from PIL import Image
+
+from vulca.layers.composite import composite_layers
+from vulca.layers.types import LayerInfo, LayerResult
+
+
+def _make_layer_file(color, z_index=0):
+    fd, path = tempfile.mkstemp(suffix=".png")
+    os.close(fd)
+    Image.new("RGBA", (50, 50), color).save(path)
+    info = LayerInfo(
+        name=f"layer_{z_index}",
+        description="t", z_index=z_index, blend_mode="normal",
+    )
+    return LayerResult(info=info, image_path=path)
+
+
+def test_default_does_not_overwrite_source_layer_files(tmp_path):
+    """Hash before == hash after when force_alpha_writeback unset."""
+    layer = _make_layer_file((123, 45, 67, 200))
+    before_bytes = open(layer.image_path, "rb").read()
+
+    out_path = str(tmp_path / "preview.png")
+    composite_layers(
+        [layer], width=50, height=50, output_path=out_path,
+    )
+
+    after_bytes = open(layer.image_path, "rb").read()
+    assert after_bytes == before_bytes, (
+        "v0.17.14: composite_layers must not mutate source layer files in "
+        "preview mode (default force_alpha_writeback=False)"
+    )
+
+
+def test_force_alpha_writeback_true_does_mutate(tmp_path):
+    """Opt-in: force_alpha_writeback=True allows the legacy in-place rewrite.
+
+    For ordinary RGBA layers ensure_alpha is essentially a re-encode, which
+    can change the on-disk bytes (timestamps, IDAT layout). We assert the
+    file still exists and is a valid PNG; bit-identity isn't required for
+    the legacy path.
+    """
+    layer = _make_layer_file((123, 45, 67, 200))
+
+    out_path = str(tmp_path / "writeback.png")
+    composite_layers(
+        [layer], width=50, height=50, output_path=out_path,
+        force_alpha_writeback=True,
+    )
+
+    # Layer file still loads
+    re_opened = Image.open(layer.image_path)
+    assert re_opened.size == (50, 50)
+    assert re_opened.mode == "RGBA"

--- a/tests/test_inpaint_mask.py
+++ b/tests/test_inpaint_mask.py
@@ -37,10 +37,12 @@ def _write_mask(path: Path, size=(100, 100)) -> str:
 
 class TestMaskPathPrecedence:
     def test_mask_path_overrides_region(self, tmp_path, caplog):
-        """Both set → mask wins, warning logged."""
+        """Both set → mask wins, warning logged. bbox reflects mask alpha=0
+        region (codex P1 — was hardcoded 100x100 pre-revision)."""
         from vulca.inpaint import ainpaint
 
         img = _write_rgb(tmp_path / "src.png")
+        # _write_mask creates inner 50x50 alpha=0 square at (25,25)
         mask = _write_mask(tmp_path / "mask.png")
 
         with caplog.at_level("WARNING", logger="vulca.inpaint"):
@@ -53,8 +55,8 @@ class TestMaskPathPrecedence:
                     mock=True,
                 )
             )
-        # bbox of mask path is full-canvas, not the legacy 50x50 region
-        assert result.bbox == {"x": 0, "y": 0, "w": 100, "h": 100}
+        # bbox follows the mask's alpha=0 region, NOT the ignored region= arg
+        assert result.bbox == {"x": 25, "y": 25, "w": 50, "h": 50}
         # Warning fired
         assert any(
             "mask_path and region" in rec.message
@@ -197,6 +199,86 @@ class TestLegacyRegionPath:
         img = _write_rgb(tmp_path / "src.png")
         with pytest.raises(ValueError, match="mask_path or region"):
             _run(ainpaint(img, instruction="x", mock=True))
+
+
+class TestBboxFromMask:
+    def test_bbox_reflects_actual_alpha_zero_region(self, tmp_path):
+        """Codex P1: bbox must come from the mask's editable region, not
+        a hardcoded full-canvas {0,0,100,100}."""
+        from vulca.inpaint import ainpaint
+
+        img = _write_rgb(tmp_path / "src.png", size=(100, 100))
+        # Mask: only middle 50% (25-75) is editable (alpha=0)
+        mask_p = tmp_path / "mask.png"
+        mask = Image.new("RGBA", (100, 100), (0, 0, 0, 255))
+        for y in range(25, 75):
+            for x in range(25, 75):
+                mask.putpixel((x, y), (0, 0, 0, 0))
+        mask.save(str(mask_p))
+
+        result = _run(
+            ainpaint(
+                img, mask_path=str(mask_p),
+                instruction="x", mock=True,
+            )
+        )
+        # bbox should be roughly {x=25, y=25, w=50, h=50}, not full canvas
+        assert result.bbox["x"] == 25
+        assert result.bbox["y"] == 25
+        assert result.bbox["w"] == 50
+        assert result.bbox["h"] == 50
+
+    def test_bbox_full_canvas_when_mask_fully_opaque(self, tmp_path):
+        """Edge case: fully-opaque mask (no alpha=0 pixels) returns full
+        canvas as a non-lying signal that nothing was actually editable."""
+        from vulca.inpaint import ainpaint
+
+        img = _write_rgb(tmp_path / "src.png")
+        mask_p = tmp_path / "mask.png"
+        Image.new("RGBA", (100, 100), (0, 0, 0, 255)).save(str(mask_p))
+
+        result = _run(
+            ainpaint(
+                img, mask_path=str(mask_p),
+                instruction="x", mock=True,
+            )
+        )
+        assert result.bbox == {"x": 0, "y": 0, "w": 100, "h": 100}
+
+
+class TestProviderDefaults:
+    def test_legacy_region_defaults_to_gemini(self, tmp_path, monkeypatch):
+        """P2.5 review: legacy region= callers must keep their pre-v0.17.14
+        gemini default. Silent flip to openai would reroute billing."""
+        captured: dict = {}
+
+        # Stub phase.repaint to capture provider arg
+        from vulca.studio.phases import inpaint as phase_mod
+
+        async def stub_repaint(*args, **kwargs):
+            captured["provider"] = kwargs.get("provider")
+            return [str(tmp_path / "v.png")]
+
+        monkeypatch.setattr(phase_mod.InpaintPhase, "repaint", stub_repaint)
+        # Stub blend so we don't actually try to open a fake variant
+        async def stub_blend(*args, **kwargs):
+            return str(tmp_path / "blended.png")
+        monkeypatch.setattr(phase_mod.InpaintPhase, "blend", stub_blend)
+
+        from vulca.inpaint import ainpaint
+
+        img = _write_rgb(tmp_path / "src.png")
+        # Save a stub variant + blended to make life easy
+        Image.new("RGB", (50, 50), (0, 0, 0)).save(str(tmp_path / "v.png"))
+        Image.new("RGB", (50, 50), (0, 0, 0)).save(str(tmp_path / "blended.png"))
+
+        _run(
+            ainpaint(
+                img, region="0,0,50,50", instruction="x",
+                mock=False,  # need real branch to see resolved_provider
+            )
+        )
+        assert captured["provider"] == "gemini"
 
 
 class TestOutputPath:

--- a/tests/test_inpaint_mask.py
+++ b/tests/test_inpaint_mask.py
@@ -1,0 +1,225 @@
+"""v0.17.14 — native mask path for inpaint_artwork.
+
+Patch 1 contract: ``inpaint_artwork(mask_path=...)`` routes through the
+provider's edit endpoint with precision masks (SAM, layer alpha, HSV filter).
+The legacy region= path stays unchanged for backward-compat.
+"""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+from PIL import Image
+
+
+def _run(coro):
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
+
+
+def _write_rgb(path: Path, size=(100, 100), color=(200, 100, 50)) -> str:
+    Image.new("RGB", size, color).save(str(path))
+    return str(path)
+
+
+def _write_mask(path: Path, size=(100, 100)) -> str:
+    """Mask: outer ring alpha=255 (preserve), inner square alpha=0 (edit)."""
+    mask = Image.new("RGBA", size, (0, 0, 0, 255))
+    inner = Image.new("RGBA", (size[0] // 2, size[1] // 2), (0, 0, 0, 0))
+    mask.paste(inner, (size[0] // 4, size[1] // 4))
+    mask.save(str(path))
+    return str(path)
+
+
+class TestMaskPathPrecedence:
+    def test_mask_path_overrides_region(self, tmp_path, caplog):
+        """Both set → mask wins, warning logged."""
+        from vulca.inpaint import ainpaint
+
+        img = _write_rgb(tmp_path / "src.png")
+        mask = _write_mask(tmp_path / "mask.png")
+
+        with caplog.at_level("WARNING", logger="vulca.inpaint"):
+            result = _run(
+                ainpaint(
+                    img,
+                    region="0,0,50,50",
+                    mask_path=mask,
+                    instruction="repaint",
+                    mock=True,
+                )
+            )
+        # bbox of mask path is full-canvas, not the legacy 50x50 region
+        assert result.bbox == {"x": 0, "y": 0, "w": 100, "h": 100}
+        # Warning fired
+        assert any(
+            "mask_path and region" in rec.message
+            for rec in caplog.records
+        )
+
+
+class TestMaskPathOpenAI:
+    def test_mask_path_openai_native_mock(self, tmp_path):
+        """Mock=True path: produces an output PNG without hitting OpenAI."""
+        from vulca.inpaint import ainpaint
+
+        img = _write_rgb(tmp_path / "src.png")
+        mask = _write_mask(tmp_path / "mask.png")
+        out = tmp_path / "out.png"
+
+        result = _run(
+            ainpaint(
+                img,
+                mask_path=mask,
+                instruction="cinnabar lanterns",
+                provider="openai",
+                output_path=str(out),
+                mock=True,
+            )
+        )
+        assert result.blended == str(out)
+        assert out.exists()
+        # In mock mode no real cost is incurred
+        assert result.cost_usd == 0.0
+
+
+class TestMaskPathValidation:
+    def test_mask_path_size_mismatch_raises(self, tmp_path):
+        from vulca.inpaint import ainpaint
+
+        img = _write_rgb(tmp_path / "src.png", size=(100, 100))
+        mask_p = tmp_path / "mask.png"
+        mask = Image.new("RGBA", (50, 50), (0, 0, 0, 0))
+        mask.save(str(mask_p))
+
+        with pytest.raises(ValueError, match="mask size"):
+            _run(
+                ainpaint(
+                    str(img),
+                    mask_path=str(mask_p),
+                    instruction="x",
+                    mock=True,
+                )
+            )
+
+    def test_mask_path_missing_file_raises(self, tmp_path):
+        from vulca.inpaint import ainpaint
+
+        img = _write_rgb(tmp_path / "src.png")
+
+        with pytest.raises(FileNotFoundError, match="mask_path"):
+            _run(
+                ainpaint(
+                    str(img),
+                    mask_path=str(tmp_path / "does-not-exist.png"),
+                    instruction="x",
+                    mock=True,
+                )
+            )
+
+    def test_image_path_missing_file_raises(self, tmp_path):
+        from vulca.inpaint import ainpaint
+
+        mask = _write_mask(tmp_path / "mask.png")
+        with pytest.raises(FileNotFoundError, match="image"):
+            _run(
+                ainpaint(
+                    str(tmp_path / "missing.png"),
+                    mask_path=mask,
+                    instruction="x",
+                    mock=True,
+                )
+            )
+
+
+class TestMaskPathProviderGate:
+    def test_gemini_raises_with_hint(self, tmp_path):
+        """Gemini fail-loud — no silent fallback to legacy crop path."""
+        from vulca.inpaint import ainpaint
+
+        img = _write_rgb(tmp_path / "src.png")
+        mask = _write_mask(tmp_path / "mask.png")
+
+        with pytest.raises(NotImplementedError, match="openai"):
+            _run(
+                ainpaint(
+                    img,
+                    mask_path=mask,
+                    instruction="x",
+                    provider="gemini",
+                    mock=False,
+                )
+            )
+
+    def test_comfyui_raises_with_hint(self, tmp_path):
+        """ComfyUI fail-loud."""
+        from vulca.inpaint import ainpaint
+
+        img = _write_rgb(tmp_path / "src.png")
+        mask = _write_mask(tmp_path / "mask.png")
+
+        with pytest.raises(NotImplementedError, match="openai"):
+            _run(
+                ainpaint(
+                    img,
+                    mask_path=mask,
+                    instruction="x",
+                    provider="comfyui",
+                    mock=False,
+                )
+            )
+
+
+class TestLegacyRegionPath:
+    def test_legacy_region_unchanged(self, tmp_path):
+        """Old caller passing region= still works (mock path)."""
+        from vulca.inpaint import ainpaint
+
+        img = _write_rgb(tmp_path / "src.png")
+        result = _run(
+            ainpaint(
+                img,
+                region="0,0,50,50",
+                instruction="x",
+                mock=True,
+            )
+        )
+        assert result.bbox == {"x": 0, "y": 0, "w": 50, "h": 50}
+        assert result.blended  # blended path produced
+
+    def test_neither_mask_nor_region_raises(self, tmp_path):
+        from vulca.inpaint import ainpaint
+
+        img = _write_rgb(tmp_path / "src.png")
+        with pytest.raises(ValueError, match="mask_path or region"):
+            _run(ainpaint(img, instruction="x", mock=True))
+
+
+class TestOutputPath:
+    def test_output_path_not_in_place(self, tmp_path):
+        """Original image file unchanged after inpaint."""
+        from vulca.inpaint import ainpaint
+
+        img = tmp_path / "src.png"
+        Image.new("RGB", (100, 100), (10, 20, 30)).save(str(img))
+        before = img.read_bytes()
+        mask = _write_mask(tmp_path / "mask.png")
+
+        out = tmp_path / "edited.png"
+        _run(
+            ainpaint(
+                str(img),
+                mask_path=mask,
+                instruction="x",
+                output_path=str(out),
+                mock=True,
+            )
+        )
+        # Original bytes preserved
+        assert img.read_bytes() == before
+        # Output written
+        assert out.exists()

--- a/tests/test_layers_redraw.py
+++ b/tests/test_layers_redraw.py
@@ -1,0 +1,293 @@
+"""v0.17.14 — layers_redraw recontract tests.
+
+Patch 2 contract: opt-in non-destructive output, configurable background
+strategy (cream/white/sample_median/transparent), preserve_alpha,
+provider-aware api_key wiring, aspect-preserving fit (no LANCZOS warp on
+non-square canvases).
+"""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+from PIL import Image
+
+from vulca.layers.manifest import write_manifest, load_manifest
+from vulca.layers.types import LayerInfo
+
+
+def _run(coro):
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
+
+
+def _setup_one_layer(tmp_path: Path, *, size=(100, 100), color=(180, 64, 32, 200)) -> Path:
+    Image.new("RGBA", size, color).save(str(tmp_path / "fg.png"))
+    Image.new("RGB", size, (100, 100, 100)).save(str(tmp_path / "source.png"))
+
+    fg = LayerInfo(
+        name="fg", description="foreground", z_index=1, content_type="subject"
+    )
+    write_manifest(
+        [fg],
+        output_dir=str(tmp_path),
+        width=size[0],
+        height=size[1],
+        source_image="source.png",
+    )
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# Non-destructive output
+# ---------------------------------------------------------------------------
+
+class TestNonDestructiveOutput:
+    def test_default_inplace_for_backcompat(self, tmp_path):
+        """Default (no output_layer_name) writes back to <layer>.png."""
+        from vulca.layers.redraw import redraw_layer
+
+        _setup_one_layer(tmp_path)
+        artwork = load_manifest(str(tmp_path))
+        before_other_files = set(p.name for p in tmp_path.iterdir())
+
+        _run(
+            redraw_layer(
+                artwork, layer_name="fg", instruction="brighter",
+                provider="mock", artwork_dir=str(tmp_path),
+            )
+        )
+        after = set(p.name for p in tmp_path.iterdir())
+        # No new layer file created
+        assert after == before_other_files
+        # fg.png still exists (in-place rewrite)
+        assert (tmp_path / "fg.png").exists()
+
+    def test_custom_output_name_creates_new_file(self, tmp_path):
+        """output_layer_name='foo' writes foo.png and leaves fg.png alone."""
+        from vulca.layers.redraw import redraw_layer
+
+        _setup_one_layer(tmp_path)
+        before_fg_bytes = (tmp_path / "fg.png").read_bytes()
+        artwork = load_manifest(str(tmp_path))
+
+        result = _run(
+            redraw_layer(
+                artwork, layer_name="fg", instruction="brighter",
+                provider="mock", artwork_dir=str(tmp_path),
+                output_layer_name="fg_redrawn",
+            )
+        )
+        # New file present
+        assert (tmp_path / "fg_redrawn.png").exists()
+        # Old file untouched
+        assert (tmp_path / "fg.png").read_bytes() == before_fg_bytes
+        # Returned LayerResult points at new file
+        assert result.info.name == "fg_redrawn"
+        assert result.image_path == str(tmp_path / "fg_redrawn.png")
+
+    def test_custom_output_appends_manifest_entry(self, tmp_path):
+        """Manifest gets a new layer entry for output_layer_name."""
+        from vulca.layers.redraw import redraw_layer
+
+        _setup_one_layer(tmp_path)
+        artwork = load_manifest(str(tmp_path))
+
+        _run(
+            redraw_layer(
+                artwork, layer_name="fg", instruction="brighter",
+                provider="mock", artwork_dir=str(tmp_path),
+                output_layer_name="fg_redrawn",
+            )
+        )
+        new_artwork = load_manifest(str(tmp_path))
+        names = {lr.info.name for lr in new_artwork.layers}
+        assert "fg" in names
+        assert "fg_redrawn" in names
+
+
+# ---------------------------------------------------------------------------
+# Background strategy
+# ---------------------------------------------------------------------------
+
+class TestBackgroundStrategy:
+    def test_cream_bg_no_hallucination_marker(self, tmp_path):
+        """Cream BG strategy adds canvas-guard prompt line.
+
+        We can't observe pixel hallucination with a mock provider, so we
+        verify the prompt-construction path injects the canvas-guard.
+        """
+        from vulca.layers.redraw import _build_redraw_prompt
+
+        prompt = _build_redraw_prompt(
+            "redraw lanterns",
+            ["cinnabar paper lanterns"],
+            background_strategy="cream",
+        )
+        assert "do NOT introduce new objects" in prompt
+
+    def test_transparent_bg_omits_canvas_guard(self):
+        """Legacy transparent strategy keeps the legacy prompt unchanged."""
+        from vulca.layers.redraw import _build_redraw_prompt
+
+        prompt = _build_redraw_prompt(
+            "redraw lanterns",
+            ["cinnabar paper lanterns"],
+            background_strategy="transparent",
+        )
+        assert "do NOT introduce new objects" not in prompt
+
+    def test_unknown_background_strategy_raises(self, tmp_path):
+        """Unrecognized background strategy fails loud."""
+        from vulca.layers.redraw import redraw_layer
+
+        _setup_one_layer(tmp_path)
+        artwork = load_manifest(str(tmp_path))
+
+        with pytest.raises(ValueError, match="background_strategy"):
+            _run(
+                redraw_layer(
+                    artwork, layer_name="fg", instruction="x",
+                    provider="mock", artwork_dir=str(tmp_path),
+                    background_strategy="rainbow",
+                )
+            )
+
+    def test_sample_median_picks_visible_pixel(self, tmp_path):
+        """sample_median bg samples from non-transparent layer pixels."""
+        from vulca.layers.redraw import _sample_median_bg
+
+        # Layer with two opaque colors and transparent corners
+        img = Image.new("RGBA", (10, 10), (0, 0, 0, 0))
+        for y in range(2, 8):
+            for x in range(2, 8):
+                img.putpixel((x, y), (200, 100, 50, 255))
+        bg = _sample_median_bg(img)
+        assert bg == (200, 100, 50)
+
+    def test_sample_median_falls_back_when_all_transparent(self):
+        """sample_median on fully-transparent layer falls back to cream."""
+        from vulca.layers.redraw import _sample_median_bg, CREAM_BG_RGB
+
+        img = Image.new("RGBA", (10, 10), (0, 0, 0, 0))
+        bg = _sample_median_bg(img)
+        assert bg == CREAM_BG_RGB
+
+
+# ---------------------------------------------------------------------------
+# preserve_alpha
+# ---------------------------------------------------------------------------
+
+class TestPreserveAlpha:
+    def test_preserve_alpha_true_matches_source_alpha(self, tmp_path):
+        """preserve_alpha=True → output alpha matches source alpha."""
+        from vulca.layers.redraw import redraw_layer
+
+        _setup_one_layer(tmp_path, color=(180, 64, 32, 100))
+        src_alpha = Image.open(str(tmp_path / "fg.png")).split()[-1]
+        artwork = load_manifest(str(tmp_path))
+
+        _run(
+            redraw_layer(
+                artwork, layer_name="fg", instruction="x",
+                provider="mock", artwork_dir=str(tmp_path),
+                preserve_alpha=True,
+            )
+        )
+        out_alpha = Image.open(str(tmp_path / "fg.png")).split()[-1]
+        # Compare alpha channels
+        assert list(out_alpha.getdata()) == list(src_alpha.getdata())
+
+    def test_preserve_alpha_false_default_unchanged(self, tmp_path):
+        """preserve_alpha=False (default) — output is opaque RGBA."""
+        from vulca.layers.redraw import redraw_layer
+
+        _setup_one_layer(tmp_path)
+        artwork = load_manifest(str(tmp_path))
+
+        _run(
+            redraw_layer(
+                artwork, layer_name="fg", instruction="x",
+                provider="mock", artwork_dir=str(tmp_path),
+                preserve_alpha=False,
+            )
+        )
+        # Mock provider returns opaque (alpha=255 across canvas)
+        out = Image.open(str(tmp_path / "fg.png"))
+        alphas = set(out.split()[-1].getdata())
+        # Allow some room — mock canvas is single solid color → all alphas equal
+        assert max(alphas) == 255
+
+
+# ---------------------------------------------------------------------------
+# Provider-aware api_key wiring
+# ---------------------------------------------------------------------------
+
+class TestProviderApiKeyWiring:
+    def test_openai_does_not_receive_google_api_key(
+        self, tmp_path, monkeypatch
+    ):
+        """Bug fix: OPENAI provider must self-resolve OPENAI_API_KEY,
+        not be force-fed GOOGLE_API_KEY by the redraw helper."""
+        captured: dict = {}
+
+        # Stub get_image_provider on its source module — redraw.py
+        # imports it lazily, so we patch the canonical home.
+        from vulca.providers.mock import MockImageProvider
+        import vulca.providers as providers_mod
+
+        def stub_get_image_provider(name, **kwargs):
+            captured["name"] = name
+            captured["api_key"] = kwargs.get("api_key", "")
+            return MockImageProvider(**kwargs)
+
+        monkeypatch.setattr(
+            providers_mod, "get_image_provider", stub_get_image_provider,
+        )
+        monkeypatch.setenv("GOOGLE_API_KEY", "google-secret-do-not-leak")
+        monkeypatch.setenv("OPENAI_API_KEY", "openai-key")
+
+        _setup_one_layer(tmp_path)
+        from vulca.layers.redraw import redraw_layer
+        artwork = load_manifest(str(tmp_path))
+        _run(
+            redraw_layer(
+                artwork, layer_name="fg", instruction="x",
+                provider="openai", artwork_dir=str(tmp_path),
+            )
+        )
+        assert captured["name"] == "openai"
+        # The redraw helper no longer pre-resolves GOOGLE_API_KEY for
+        # non-gemini providers — let the provider self-resolve.
+        assert "google" not in captured["api_key"].lower()
+
+
+# ---------------------------------------------------------------------------
+# Aspect preservation
+# ---------------------------------------------------------------------------
+
+class TestAspectPreservation:
+    def test_fit_preserves_aspect_letterbox(self):
+        """1024x1536 source target → 1024x1024 provider output centered."""
+        from vulca.layers.redraw import _fit_into_canvas
+
+        src = Image.new("RGB", (1024, 1024), (200, 100, 50))
+        out = _fit_into_canvas(src, (1024, 1536), bg_rgb=(252, 248, 240))
+        assert out.size == (1024, 1536)
+        # Top center should be cream (letterbox), middle should be subject
+        top = out.getpixel((512, 10))
+        middle = out.getpixel((512, 768))
+        assert top[:3] == (252, 248, 240), f"expected cream top, got {top}"
+        assert middle[:3] == (200, 100, 50), f"expected subject middle, got {middle}"
+
+    def test_fit_no_resize_when_match(self):
+        """Identity case: source size matches target — return as-is."""
+        from vulca.layers.redraw import _fit_into_canvas
+
+        src = Image.new("RGB", (100, 100), (50, 50, 50))
+        out = _fit_into_canvas(src, (100, 100), bg_rgb=(0, 0, 0))
+        assert out.size == (100, 100)

--- a/tests/test_layers_redraw.py
+++ b/tests/test_layers_redraw.py
@@ -109,6 +109,31 @@ class TestNonDestructiveOutput:
         assert "fg" in names
         assert "fg_redrawn" in names
 
+    def test_z_index_in_memory_matches_manifest(self, tmp_path):
+        """P1.1 review: returned LayerResult.z_index must equal the z that
+        was actually written to the manifest. Pre-fix the in-memory result
+        kept the source z while the manifest got max(existing)+1, causing
+        the layer to silently move on next load_manifest()."""
+        from vulca.layers.redraw import redraw_layer
+
+        _setup_one_layer(tmp_path)
+        artwork = load_manifest(str(tmp_path))
+
+        result = _run(
+            redraw_layer(
+                artwork, layer_name="fg", instruction="x",
+                provider="mock", artwork_dir=str(tmp_path),
+                output_layer_name="fg_v2",
+            )
+        )
+
+        loaded = load_manifest(str(tmp_path))
+        manifest_layer = next(lr for lr in loaded.layers if lr.info.name == "fg_v2")
+        assert result.info.z_index == manifest_layer.info.z_index, (
+            f"in-memory z_index {result.info.z_index} != manifest z_index "
+            f"{manifest_layer.info.z_index} — agent and disk would disagree"
+        )
+
 
 # ---------------------------------------------------------------------------
 # Background strategy
@@ -184,13 +209,43 @@ class TestBackgroundStrategy:
 
 class TestPreserveAlpha:
     def test_preserve_alpha_true_matches_source_alpha(self, tmp_path):
-        """preserve_alpha=True → output alpha matches source alpha."""
+        """preserve_alpha=True → output alpha matches source alpha.
+
+        Uses a NON-UNIFORM alpha pattern (left half opaque, right half
+        partial) so the assertion can only succeed if the helper actually
+        re-applied the source alpha. A uniform-alpha source could pass by
+        accident if the mock returned uniform alpha (P1.2 from review).
+        """
         from vulca.layers.redraw import redraw_layer
 
-        _setup_one_layer(tmp_path, color=(180, 64, 32, 100))
-        src_alpha = Image.open(str(tmp_path / "fg.png")).split()[-1]
-        artwork = load_manifest(str(tmp_path))
+        # Build a non-uniform-alpha source layer
+        Image.new("RGB", (50, 50), (100, 100, 100)).save(
+            str(tmp_path / "source.png")
+        )
+        layer_img = Image.new("RGBA", (50, 50), (180, 64, 32, 0))
+        for y in range(50):
+            for x in range(25):  # left half opaque
+                layer_img.putpixel((x, y), (180, 64, 32, 255))
+            for x in range(25, 50):  # right half partial
+                layer_img.putpixel((x, y), (180, 64, 32, 80))
+        layer_img.save(str(tmp_path / "fg.png"))
 
+        fg = LayerInfo(
+            name="fg", description="non-uniform alpha", z_index=1,
+            content_type="subject",
+        )
+        from vulca.layers.manifest import write_manifest
+        write_manifest(
+            [fg], output_dir=str(tmp_path), width=50, height=50,
+            source_image="source.png",
+        )
+
+        src_alpha = Image.open(str(tmp_path / "fg.png")).split()[-1]
+        # Sanity check the fixture itself has the variation we need
+        assert src_alpha.getpixel((10, 10)) == 255
+        assert src_alpha.getpixel((40, 10)) == 80
+
+        artwork = load_manifest(str(tmp_path))
         _run(
             redraw_layer(
                 artwork, layer_name="fg", instruction="x",
@@ -199,7 +254,12 @@ class TestPreserveAlpha:
             )
         )
         out_alpha = Image.open(str(tmp_path / "fg.png")).split()[-1]
-        # Compare alpha channels
+        assert out_alpha.getpixel((10, 10)) == 255, (
+            "left half (originally fully opaque) must stay opaque"
+        )
+        assert out_alpha.getpixel((40, 10)) == 80, (
+            "right half (originally alpha=80) must keep alpha=80"
+        )
         assert list(out_alpha.getdata()) == list(src_alpha.getdata())
 
     def test_preserve_alpha_false_default_unchanged(self, tmp_path):

--- a/tests/test_paste_back.py
+++ b/tests/test_paste_back.py
@@ -46,17 +46,24 @@ class TestAlphaMode:
 
 class TestFeatheredMode:
     def test_feathered_softens_edges(self, tmp_path):
+        """Feathered should differ from hard near the alpha boundary.
+
+        After the v0.17.14 RGB-clamp fix, "feather" softens transitions
+        inside the layer's alpha region (where layer_alpha=255 but the
+        blurred applied_mask is intermediate), not outside it. Outside
+        the boundary the layer's alpha=0 region is clamped to source —
+        intentional, prevents the codex-flagged black bleed. So we check
+        a pixel JUST INSIDE (26,50) where the soft transition lives.
+        """
         from vulca.layers.paste_back import paste_back
 
         src = _write_rgb(tmp_path / "src.png", color=(0, 255, 0))
         layer = _write_layer_with_alpha_square(tmp_path / "layer.png")
 
-        # Feathered: alpha mask blurred so boundary leaks softly outward
         feathered = paste_back(
-            src, layer, blend_mode="feathered", feather_px=4,
+            src, layer, blend_mode="feathered", feather_px=6,
             output_path=str(tmp_path / "feathered.png"),
         )
-        # Hard: binary threshold — boundary stays sharp
         hard = paste_back(
             src, layer, blend_mode="hard",
             output_path=str(tmp_path / "hard.png"),
@@ -65,17 +72,24 @@ class TestFeatheredMode:
         f_img = Image.open(feathered["output_path"]).convert("RGB")
         h_img = Image.open(hard["output_path"]).convert("RGB")
 
-        # Center stays red in both
+        # Center stays red in both modes
         assert f_img.getpixel((50, 50))[0] > 200
         assert h_img.getpixel((50, 50))[0] > 200
 
-        # At a pixel JUST outside the opaque square (24,50): hard returns
-        # pure source green; feathered shows softened green (some blur).
-        f_edge = f_img.getpixel((24, 50))
-        h_edge = h_img.getpixel((24, 50))
-        assert h_edge == (0, 255, 0), f"hard edge should be source, got {h_edge}"
-        assert f_edge[1] < 255, f"feathered green should be softened, got {f_edge}"
-        assert f_edge != h_edge, "feathered and hard must differ at the edge"
+        # Just inside the alpha boundary (26,50): hard is full red; feathered
+        # is partially mixed because blurred mask is below 255 here.
+        f_inside = f_img.getpixel((26, 50))
+        h_inside = h_img.getpixel((26, 50))
+        assert h_inside == (255, 0, 0), (
+            f"hard should keep pure red just inside boundary, got {h_inside}"
+        )
+        assert f_inside != h_inside, (
+            f"feathered must differ from hard near boundary, got "
+            f"f={f_inside} h={h_inside}"
+        )
+        assert f_inside[1] > 0, (
+            f"feathered green should leak into red region near edge, got {f_inside}"
+        )
 
 
 class TestHardMode:
@@ -158,6 +172,45 @@ class TestSizeMismatch:
 
         with pytest.raises(ValueError, match="mask size"):
             paste_back(src, layer, mask_path=str(mask_p))
+
+
+class TestRgbClampOnAlphaZero:
+    def test_alpha_zero_rgb_does_not_bleed(self, tmp_path):
+        """Codex P1: decompose-output layers commonly store BLACK (0,0,0)
+        in alpha=0 regions. Pre-fix Image.composite(layer_rgb, src, mask)
+        would mix black RGB with source at semi-transparent edges,
+        darkening fringes. Post-fix the layer's RGB is clamped to source
+        wherever the layer's alpha is 0, eliminating the bleed."""
+        from vulca.layers.paste_back import paste_back
+
+        # Source: bright red
+        src = _write_rgb(tmp_path / "src.png", color=(255, 0, 0))
+
+        # Layer: opaque green square in center 25-75; alpha=0 black elsewhere
+        layer_img = Image.new("RGBA", (100, 100), (0, 0, 0, 0))
+        for y in range(25, 75):
+            for x in range(25, 75):
+                layer_img.putpixel((x, y), (0, 255, 0, 255))
+        layer_p = tmp_path / "layer.png"
+        layer_img.save(str(layer_p))
+
+        # External mask covers the entire canvas (so alpha-zero RGB would
+        # leak into the composite if not clamped)
+        mask_p = tmp_path / "mask.png"
+        Image.new("L", (100, 100), 255).save(str(mask_p))
+
+        result = paste_back(
+            src, str(layer_p), mask_path=str(mask_p), blend_mode="alpha"
+        )
+        out = Image.open(result["output_path"]).convert("RGB")
+
+        # Inside layer's opaque region: green
+        assert out.getpixel((50, 50)) == (0, 255, 0)
+        # Outside layer's opaque region but inside the external mask:
+        # source (red) MUST show through despite the mask saying "edit here"
+        assert out.getpixel((0, 0)) == (255, 0, 0), (
+            "alpha=0 region in layer must not bleed black into composite"
+        )
 
 
 class TestDefaults:

--- a/tests/test_paste_back.py
+++ b/tests/test_paste_back.py
@@ -1,0 +1,195 @@
+"""v0.17.14 — layers_paste_back glue verb tests.
+
+Patch 3 contract: composite an edited RGBA layer onto a foreign RGB source
+image using the layer's alpha (or an explicit mask). Distinct from
+layers_composite (manifest-stack flatten).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from PIL import Image
+
+
+def _write_rgb(p: Path, *, size=(100, 100), color=(50, 50, 50)) -> str:
+    Image.new("RGB", size, color).save(str(p))
+    return str(p)
+
+
+def _write_layer_with_alpha_square(p: Path, *, size=(100, 100)) -> str:
+    """Layer: red square 25-75 fully opaque, rest fully transparent."""
+    img = Image.new("RGBA", size, (0, 0, 0, 0))
+    for y in range(25, 75):
+        for x in range(25, 75):
+            img.putpixel((x, y), (255, 0, 0, 255))
+    img.save(str(p))
+    return str(p)
+
+
+class TestAlphaMode:
+    def test_alpha_mode_preserves_source_outside_mask(self, tmp_path):
+        from vulca.layers.paste_back import paste_back
+
+        src = _write_rgb(tmp_path / "src.png", color=(20, 20, 20))
+        layer = _write_layer_with_alpha_square(tmp_path / "layer.png")
+
+        result = paste_back(src, layer, blend_mode="alpha")
+        out = Image.open(result["output_path"]).convert("RGB")
+
+        # Inside mask → red layer
+        assert out.getpixel((50, 50)) == (255, 0, 0)
+        # Outside mask → original gray
+        assert out.getpixel((0, 0)) == (20, 20, 20)
+        assert out.getpixel((90, 90)) == (20, 20, 20)
+
+
+class TestFeatheredMode:
+    def test_feathered_softens_edges(self, tmp_path):
+        from vulca.layers.paste_back import paste_back
+
+        src = _write_rgb(tmp_path / "src.png", color=(0, 255, 0))
+        layer = _write_layer_with_alpha_square(tmp_path / "layer.png")
+
+        # Feathered: alpha mask blurred so boundary leaks softly outward
+        feathered = paste_back(
+            src, layer, blend_mode="feathered", feather_px=4,
+            output_path=str(tmp_path / "feathered.png"),
+        )
+        # Hard: binary threshold — boundary stays sharp
+        hard = paste_back(
+            src, layer, blend_mode="hard",
+            output_path=str(tmp_path / "hard.png"),
+        )
+
+        f_img = Image.open(feathered["output_path"]).convert("RGB")
+        h_img = Image.open(hard["output_path"]).convert("RGB")
+
+        # Center stays red in both
+        assert f_img.getpixel((50, 50))[0] > 200
+        assert h_img.getpixel((50, 50))[0] > 200
+
+        # At a pixel JUST outside the opaque square (24,50): hard returns
+        # pure source green; feathered shows softened green (some blur).
+        f_edge = f_img.getpixel((24, 50))
+        h_edge = h_img.getpixel((24, 50))
+        assert h_edge == (0, 255, 0), f"hard edge should be source, got {h_edge}"
+        assert f_edge[1] < 255, f"feathered green should be softened, got {f_edge}"
+        assert f_edge != h_edge, "feathered and hard must differ at the edge"
+
+
+class TestHardMode:
+    def test_hard_threshold_no_partial_pixels(self, tmp_path):
+        """Hard mode: every pixel is either source-color or layer-color, never blended."""
+        from vulca.layers.paste_back import paste_back
+
+        src = _write_rgb(tmp_path / "src.png", color=(0, 0, 255))
+        # Build a layer whose alpha has soft edges
+        layer_img = Image.new("RGBA", (100, 100), (0, 0, 0, 0))
+        for y in range(40, 60):
+            for x in range(40, 60):
+                # Inner 100% alpha
+                layer_img.putpixel((x, y), (255, 0, 0, 255))
+        # Add a fuzzy edge
+        for y in (39, 60):
+            for x in range(40, 60):
+                layer_img.putpixel((x, y), (255, 0, 0, 100))  # mid-alpha
+        layer_p = tmp_path / "layer.png"
+        layer_img.save(str(layer_p))
+
+        result = paste_back(
+            str(_write_rgb(tmp_path / "src.png", color=(0, 0, 255))),
+            str(layer_p),
+            blend_mode="hard",
+        )
+        out = Image.open(result["output_path"]).convert("RGB")
+
+        # Inner: pure red
+        assert out.getpixel((50, 50)) == (255, 0, 0)
+        # Mid-alpha edge under hard mode: thresholded — alpha 100 < 127 → drops to source
+        assert out.getpixel((50, 39)) == (0, 0, 255)
+
+
+class TestExplicitMaskOverride:
+    def test_explicit_mask_overrides_alpha(self, tmp_path):
+        """mask_path replaces the layer's alpha channel."""
+        from vulca.layers.paste_back import paste_back
+
+        src = _write_rgb(tmp_path / "src.png", color=(50, 50, 50))
+        # Layer alpha covers center 25-75
+        layer = _write_layer_with_alpha_square(tmp_path / "layer.png")
+        # External mask covers ONLY top-left quadrant
+        mask = Image.new("L", (100, 100), 0)
+        for y in range(0, 50):
+            for x in range(0, 50):
+                mask.putpixel((x, y), 255)
+        mask_p = tmp_path / "mask.png"
+        mask.save(str(mask_p))
+
+        result = paste_back(
+            src, layer, mask_path=str(mask_p), blend_mode="alpha"
+        )
+        out = Image.open(result["output_path"]).convert("RGB")
+
+        # Top-left center (25,25) — covered by external mask AND layer alpha → red
+        assert out.getpixel((25, 25)) == (255, 0, 0)
+        # Bottom-right (75,75) — outside external mask → source
+        assert out.getpixel((75, 75)) == (50, 50, 50)
+
+
+class TestSizeMismatch:
+    def test_size_mismatch_raises(self, tmp_path):
+        from vulca.layers.paste_back import paste_back
+
+        src = _write_rgb(tmp_path / "src.png", size=(100, 100))
+        layer_p = tmp_path / "layer.png"
+        Image.new("RGBA", (50, 50), (255, 0, 0, 255)).save(str(layer_p))
+
+        with pytest.raises(ValueError, match="size"):
+            paste_back(src, str(layer_p))
+
+    def test_explicit_mask_size_mismatch_raises(self, tmp_path):
+        from vulca.layers.paste_back import paste_back
+
+        src = _write_rgb(tmp_path / "src.png", size=(100, 100))
+        layer = _write_layer_with_alpha_square(tmp_path / "layer.png")
+        mask_p = tmp_path / "mask.png"
+        Image.new("L", (60, 60), 255).save(str(mask_p))
+
+        with pytest.raises(ValueError, match="mask size"):
+            paste_back(src, layer, mask_path=str(mask_p))
+
+
+class TestDefaults:
+    def test_default_output_name(self, tmp_path):
+        """Default output: <src_dir>/<src_stem>_with_<layer_stem>.png."""
+        from vulca.layers.paste_back import paste_back
+
+        src = _write_rgb(tmp_path / "iter0.png")
+        layer = _write_layer_with_alpha_square(tmp_path / "lanterns.png")
+
+        result = paste_back(src, layer)
+        assert Path(result["output_path"]).name == "iter0_with_lanterns.png"
+        assert Path(result["output_path"]).exists()
+
+    def test_unknown_blend_mode_raises(self, tmp_path):
+        from vulca.layers.paste_back import paste_back
+
+        src = _write_rgb(tmp_path / "src.png")
+        layer = _write_layer_with_alpha_square(tmp_path / "layer.png")
+        with pytest.raises(ValueError, match="blend_mode"):
+            paste_back(src, layer, blend_mode="rainbow")
+
+    def test_missing_source_raises(self, tmp_path):
+        from vulca.layers.paste_back import paste_back
+
+        layer = _write_layer_with_alpha_square(tmp_path / "layer.png")
+        with pytest.raises(FileNotFoundError, match="source_image"):
+            paste_back(str(tmp_path / "missing.png"), layer)
+
+    def test_missing_layer_raises(self, tmp_path):
+        from vulca.layers.paste_back import paste_back
+
+        src = _write_rgb(tmp_path / "src.png")
+        with pytest.raises(FileNotFoundError, match="layer_image"):
+            paste_back(src, str(tmp_path / "missing.png"))

--- a/tests/test_quality_gate.py
+++ b/tests/test_quality_gate.py
@@ -9,6 +9,9 @@ lanterns themselves, but manifest reported success_rate 1.0.
 Fix: mirror the hint-path quality gate into a pure helper, apply uniformly.
 These tests pin the threshold calibration (8 clean γ Scottish entities pass,
 lanterns fails) so future refactors can't silently widen or narrow the gate.
+
+v0.17.14 extends coverage to the person path (was the same silent-success
+bug as the DINO-object path that v0.17.13 closed).
 """
 from __future__ import annotations
 
@@ -124,3 +127,48 @@ def test_threshold_calibration_pins_for_v0_17_13():
     assert "empty_mask" in flags
     flags, _ = cop.compute_quality_flags(pct=0.05, sam_score=0.9, bbox_fill=0.5, inside_ratio=0.9)
     assert "empty_mask" not in flags
+
+
+# ---------------------------------------------------------------------------
+# v0.17.14 — person-path gate symmetry
+# ---------------------------------------------------------------------------
+
+def test_person_path_invokes_compute_quality_flags():
+    """Source-level invariant: the person loop in process() must call
+    compute_quality_flags so low-confidence person masks no longer slip
+    through as status: "detected" (mirrors the v0.17.13 DINO-object fix).
+    """
+    import inspect
+
+    src = inspect.getsource(cop.process)
+    # Locate the person loop
+    person_marker = "for rank, (i, entity) in enumerate(person_ents_sorted)"
+    hint_marker = "for i, entity in hint_entities"
+    assert person_marker in src, (
+        "person loop signature changed; update this test to match"
+    )
+    assert hint_marker in src, "hint loop signature changed"
+
+    person_start = src.index(person_marker)
+    hint_start = src.index(hint_marker)
+    person_block = src[person_start:hint_start]
+
+    assert "compute_quality_flags" in person_block, (
+        "v0.17.14: person path must invoke compute_quality_flags() — "
+        "previously this loop unconditionally wrote status: 'detected', "
+        "letting low-confidence person masks slip through silently."
+    )
+
+
+def test_person_path_low_confidence_flips_to_suspect():
+    """Threshold-symmetric: a low-confidence person input through the same
+    helper must produce status='suspect' just like the DINO-object path.
+    """
+    flags, status = cop.compute_quality_flags(
+        # Plausible bad-person scenario: SAM weakly responded, bbox half-filled
+        pct=2.5, sam_score=0.55, bbox_fill=0.20, inside_ratio=0.45,
+    )
+    assert status == "suspect"
+    assert "low_sam_score" in flags
+    assert "low_bbox_fill" in flags
+    assert "mask_outside_bbox" in flags


### PR DESCRIPTION
## Summary

Surgical patch release closing the 3 P0 gaps + 2 secondary fixes surfaced
by the parallel codex + superpowers review of the γ Scottish carousel
workflow on 2026-04-25. Without these, agents calling our MCP tools
cannot reproduce the carousel without out-of-band Python scaffolding.

Spec: ``project_v0_17_14_spec`` (memory).

## Patches

- **P1** ``inpaint_artwork(mask_path=…)`` — native precision-mask path via
  OpenAI ``/v1/images/edits``. Gemini/ComfyUI fail loud. Legacy
  ``region=`` path unchanged.
- **P2** ``layers_redraw`` recontract — opt-in non-destructive output,
  configurable background_strategy (cream/white/sample_median/transparent),
  preserve_alpha flag, provider-aware api_key wiring (closes the
  ``GOOGLE_API_KEY`` leak into every provider), aspect-preserving fit.
  Defaults preserve legacy contract for back-compat.
- **P3** ``layers_paste_back`` — new glue verb for the open-loop
  "edit one layer, paste back into source" flow that previously required
  manual ``Image.composite()`` in Python. Distinct from layers_composite
  which flattens a closed-loop manifest stack.
- **P4** Person-path quality gate — mirror v0.17.13 ``compute_quality_flags``
  into ``claude_orchestrated_pipeline.process()``'s person loop. Same
  silent-success bug as the DINO-object path that v0.17.13 closed.
- **P5** ``layers_composite`` non-destructive — gate the
  ``ensure_alpha`` writeback behind ``force_alpha_writeback=True``. A
  preview call no longer mutates source layer files.

## Stats

- 5 commits, one per patch (rebase merge to keep them as discrete units)
- 12 files changed; +1670/-115
- 35 new tests across 4 test files
- 77 passed / 0 failed across the v0.17.14 surface (excludes 2 pre-existing
  env-baseline failures: TestInpaintCLI requires installed entry point;
  test_composite_node requires pytest-asyncio plugin — both unrelated)

## Test plan

- [x] ``pytest tests/test_inpaint_mask.py`` — 10/10
- [x] ``pytest tests/test_layers_redraw.py tests/test_layers_v2_redraw.py`` — 20/20
- [x] ``pytest tests/test_paste_back.py`` — 10/10
- [x] ``pytest tests/test_quality_gate.py`` — 10/10
- [x] ``pytest tests/test_composite_nondestructive.py tests/test_layers_v2_composite.py tests/test_composite_alpha.py`` — 10/10
- [ ] Parallel review (codex + superpowers code-reviewer) — to be dispatched
- [ ] Real-OpenAI smoke: rerun γ Scottish slide-4 mask flow via native MCP

🤖 Generated with [Claude Code](https://claude.com/claude-code)