### PR TITLE
[codex] reposition vulca product workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,36 @@
 [![CI](https://github.com/vulca-org/vulca/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/vulca-org/vulca/actions/workflows/ci.yml)
 [![MCP Tools](https://img.shields.io/badge/MCP_tools-current-blueviolet.svg)](https://github.com/vulca-org/vulca-plugin)
 
-**Agents can plan image edits but can't cut pixels. Vulca is the hands — semantic layer splits, cultural scoring, inpainting, structured prompt composition, and visual discovery — as MCP tools for Claude Code.**
+**Vulca turns fuzzy visual intent into controlled creative production.**
 
-> *Below: Michelangelo's *Creation of Adam* → 5 semantic layers via `/decompose` (background · adam · god_and_angels · red_cloak · green_ground), decomposed locally on Apple Silicon (ComfyUI + Ollama) with zero cloud API calls. SDK surface: MCP tools plus agent skills, validated by the test suite.*
+Discover the direction, compile the brief, route the model, edit the pixels,
+and evaluate the result — as agent-native artifacts and MCP tools.
+
+One-click models are getting stronger. Vulca does not try to beat them at raw
+generation. Vulca sits around them: it helps agents clarify what should be made,
+choose and constrain the right provider, preserve non-target pixels during edits,
+and record why a result does or does not fit the cultural and visual brief.
+
+```text
+fuzzy intent
+  -> /visual-discovery
+  -> /visual-brainstorm
+  -> /visual-spec
+  -> /visual-plan
+  -> generate / decompose / edit / evaluate
+  -> archived artifacts
+```
+
+| Stage | What Vulca gives the agent | Status |
+|---|---|---|
+| Discover | Taste/culture profile, direction cards, sketch prompts | PR-ready |
+| Specify | `proposal.md`, `design.md`, `plan.md` | Current |
+| Generate | Provider-routed image calls across OpenAI, Gemini, ComfyUI, mock | Current |
+| Edit | Semantic layers, masks, redraw, inpaint, composite, paste-back | Current + v0.22 hardening |
+| Evaluate | L1-L5 cultural and visual scoring | Tool current, skill next |
+| Archive | Prompts, masks, layers, evaluations, errors, user overrides | Current |
+
+> *Concrete demo below: Michelangelo's *Creation of Adam* → 5 semantic layers via `/decompose` (background · adam · god_and_angels · red_cloak · green_ground), decomposed locally on Apple Silicon (ComfyUI + Ollama) with zero cloud API calls. SDK surface: MCP tools plus agent skills, validated by the test suite.*
 
 ## What happens when you run `/decompose`
 

--- a/docs/product/2026-04-30-product-positioning-brief.md
+++ b/docs/product/2026-04-30-product-positioning-brief.md
@@ -1,0 +1,238 @@
+# Vulca Product Positioning Brief
+
+**Date:** 2026-04-30
+**Status:** Decision support for product repositioning
+**Branch:** `codex/product-positioning-plan`
+**Depends on:** `codex/visual-discovery` / PR #21
+
+## Executive Decision
+
+Vulca should reposition from "Claude Code image tools" to:
+
+> **Agent-native visual control layer for creative direction, generation routing, pixel editing, and cultural evaluation.**
+
+The product should not compete with one-click image/video generators on base-model quality. GPT Image, Gemini / Nano Banana, Seedance-style models, Midjourney, Firefly, and similar systems will keep improving. Vulca's defensible role is to make those models usable inside a serious creative workflow:
+
+```text
+fuzzy intent
+-> taste / cultural tendency analysis
+-> direction cards and sketch prompts
+-> proposal.md / design.md / plan.md
+-> provider-routed generation
+-> semantic layers / inpaint / redraw / composite
+-> L1-L5 evaluation and provenance
+```
+
+The product bet is not "better prompt text." The bet is **auditable creative control**.
+
+## Why This Is Timely
+
+Recent platform moves validate the direction:
+
+- Anthropic is pushing Claude into creative work through connectors with Blender, Autodesk, Adobe, Ableton, Splice, and other creative tools. Their framing is integration with tools creatives already use, not a single model-only workflow. Source: [Claude for Creative Work](https://www.anthropic.com/news/claude-for-creative-work), 2026-04-28.
+- Anthropic's Claude Design research preview explicitly targets wide exploration, brand/design-system reuse, fine-grained controls, export, and handoff to Claude Code. Source: [Introducing Claude Design](https://www.anthropic.com/news/claude-design-anthropic-labs), 2026-04-17.
+- OpenAI now lists GPT Image 2 as a state-of-the-art image generation and editing model with Image API and edit endpoint support. Source: [GPT Image 2 model page](https://developers.openai.com/api/docs/models/gpt-image-2).
+- Google is productizing Gemini / Nano Banana as developer-facing image generation and editing infrastructure through Gemini API, AI Studio, and Vertex AI, including Gemini 3 Pro Image / Nano Banana Pro. Source: [Build with Nano Banana Pro](https://blog.google/innovation-and-ai/technology/developers-tools/gemini-3-pro-image-developers/).
+- Claude Code's MCP model is explicitly for connecting tools and data sources so Claude can act in external systems. Source: [Claude Code MCP docs](https://code.claude.com/docs/en/mcp).
+
+Conclusion: the market is moving toward **creative agents connected to toolchains**. Vulca should be the visual-control toolchain for culturally aware, layer-aware creative work.
+
+## What Exists Today
+
+### Shipped or PR-Ready
+
+- `/decompose`: agent-facing semantic layer extraction with real transparent layer artifacts.
+- MCP image/pixel tools: `layers_split`, `layers_list`, `layers_edit`, `layers_transform`, `layers_redraw`, `layers_composite`, `layers_export`, `layers_evaluate`, `layers_paste_back`, `inpaint_artwork`, `view_image`.
+- Provider layer: `mock`, `gemini`, `nb2`, `openai`, `comfyui`.
+- OpenAI provider capability gating: model-aware edit capabilities, `quality`, `output_format`, and MIME handling; `input_fidelity` gated by model support.
+- Cultural substrate: 13 traditions, tradition guides, L1-L5 evaluation framework, VULCA research basis.
+- Visual workflow skills: `/visual-brainstorm`, `/visual-spec`, `/visual-plan`.
+- `/visual-discovery` in PR #21: upstream fuzzy-intent layer with taste profile, direction cards, provider prompt artifacts, safe discovery artifacts, and `/visual-brainstorm` handoff.
+
+### In Parallel
+
+- v0.22 mask/refinement work is running separately in `/Users/yhryzy/dev/vulca/.worktrees/v0-22-mask-refinement`.
+- That branch should own redraw robustness, target-aware mask refinement, and local quality gates.
+- This product-positioning branch should not touch redraw internals.
+
+## What Vulca Is Not
+
+Vulca is not:
+
+- a hosted image foundation model;
+- a "prompt enhancer" that only rewrites user text;
+- a Claude-only wrapper;
+- a generic design app competing with Figma, Canva, or Adobe;
+- a final-image one-shot interface.
+
+Vulca is:
+
+- a workflow and control layer that can run inside Claude Code now;
+- a provider router across OpenAI, Gemini, ComfyUI, mock, and future backends;
+- a structured artifact pipeline for creative decisions;
+- a pixel-editing layer between model output and usable deliverables;
+- a cultural evaluation system that gives Vulca a more defensible niche than generic image tooling.
+
+## Platform Strategy
+
+### Recommended Order
+
+1. **Claude Code first.** This is the wedge because MCP + skills + artifacts match Vulca's existing architecture.
+2. **OpenAI / Codex second.** Treat OpenAI as both a provider backend and an agent surface. GPT Image 2 should be supported as a provider, while product docs should avoid depending on a single model ID.
+3. **Gemini third.** Gemini / Nano Banana is a strong sketch and image-editing backend, especially for low-cost exploration and personalized/reference-heavy image workflows.
+4. **Web / Studio later.** A UI becomes important once users need visual card comparison, sketch grids, layer viewers, and evaluation dashboards.
+
+### Do Not Choose Only Claude
+
+Claude is the best initial distribution channel, not the whole product. Vulca's durable asset is the artifact contract:
+
+```text
+discovery.md
+taste_profile.json
+direction_cards.json
+proposal.md
+design.md
+plan.md
+manifest.json
+evaluation.json
+```
+
+Those artifacts should remain platform-independent so the workflow can run under Claude Code, Codex, Gemini/Antigravity-like agents, or a future Vulca Studio UI.
+
+## Where Vulca Can Intervene Around One-Click Models
+
+One-click models reduce the value of raw generation wrappers. They do not remove the need for Vulca.
+
+| Stage | One-click model behavior | Vulca intervention |
+|---|---|---|
+| Before generation | User prompt is vague; model commits too early | `/visual-discovery`, taste/culture profile, direction cards |
+| Prompt compilation | Model receives a flat prompt | structured prompt artifacts, avoid lists, visual ops, provider-specific variants |
+| Provider choice | User picks one model manually | provider capability matrix, cost/quality routing, local/cloud fallback |
+| Image editing | Model edits entire image or follows vague region prompt | masks, semantic layers, target-aware redraw, paste-back |
+| Evaluation | User judges subjectively | L1-L5 cultural scoring, visual quality gates, artifact provenance |
+| Iteration | User rerolls blindly | plan.md iterations, selected direction history, comparison artifacts |
+
+## Product Pillars
+
+1. **Discover:** clarify fuzzy intent and cultural/taste tendencies before pixels.
+2. **Direct:** convert direction into provider-specific constraints and prompts.
+3. **Generate:** route to OpenAI, Gemini, ComfyUI, mock, and future providers.
+4. **Control:** decompose, inpaint, redraw, composite, and preserve non-target pixels.
+5. **Evaluate:** score cultural/visual quality and record rationale.
+6. **Archive:** keep decisions, prompts, images, masks, layers, and evaluations reviewable.
+
+## Required Experiments
+
+The cultural/taste-analysis claim must be proven, not asserted.
+
+### Experiment 1: Do Cultural Terms Help?
+
+Run the same project across providers with four prompt conditions:
+
+- A: naive user prompt only.
+- B: user prompt + cultural terms.
+- C: user prompt + cultural terms + visual operations.
+- D: full direction-card prompt with avoid list, evaluation focus, and provider-specific form.
+
+Measure:
+
+- human preference;
+- L1-L5 rubric alignment;
+- prompt adherence;
+- cultural cliche avoidance;
+- editability / layer separability;
+- cost and latency.
+
+### Experiment 2: Does Discovery Improve User Choice?
+
+Compare:
+
+- one-shot generation from fuzzy prompt;
+- `/visual-discovery` direction cards without sketches;
+- `/visual-discovery` direction cards with low-cost sketch prompts;
+- full discovery -> brainstorm -> spec -> plan chain.
+
+Measure:
+
+- number of rerolls;
+- time to approved direction;
+- user's confidence in selected direction;
+- final evaluation score;
+- ability to explain why the result fits the brief.
+
+### Experiment 3: Which Provider Owns Which Job?
+
+Benchmark OpenAI, Gemini, and ComfyUI across:
+
+- text rendering;
+- reference preservation;
+- local edits;
+- cultural style adherence;
+- transparent outputs;
+- mask compliance;
+- cost/latency;
+- failure modes.
+
+The product should route by evidence, not by platform preference.
+
+## README Repositioning
+
+The README first viewport should stop leading only with `/decompose`. Decompose remains the most concrete demo, but the product story should be broader:
+
+```text
+Vulca turns fuzzy visual intent into controlled creative production.
+
+Discover the direction, compile the brief, route the model, edit the pixels,
+and evaluate the result — all as agent-native artifacts and MCP tools.
+```
+
+Recommended first-screen order:
+
+1. One-line product thesis.
+2. Workflow diagram: Discover -> Spec -> Generate -> Edit -> Evaluate.
+3. Short "Why Vulca exists" paragraph: one-click models generate; Vulca controls.
+4. Current capability matrix.
+5. Quick start with Claude Code.
+6. Provider support matrix.
+7. Decompose showcase.
+8. Visual discovery example.
+9. Roadmap with current vs next vs experiments.
+
+## Roadmap
+
+### Now: Product Coherence
+
+- Write product positioning spec.
+- Rewrite README around the full workflow.
+- Add platform/provider decision matrix.
+- Add benchmark plan for cultural-term efficacy.
+- Keep redraw robustness in the separate v0.22 branch.
+
+### Next: Evaluation Skill
+
+- Ship `/evaluate` as the next user-facing skill.
+- Convert existing `evaluate_artwork` and traditions into an agent workflow.
+- Use evaluation as the proof layer for cultural/taste analysis.
+
+### Next: Redraw Productization
+
+- Merge v0.22 target-aware mask refinement after verification.
+- Expose `/inpaint` or `/redraw-layer` as a skill once the underlying route is robust.
+- Update README with honest boundaries: sparse multi-instance edits are harder than single-object edits.
+
+### Then: Benchmark and Studio
+
+- Run cultural-term efficacy experiments.
+- Build a lightweight local visual review surface only after artifact contracts are stable.
+- Consider marketplace/distribution: Claude plugin directory first, then OpenAI/Codex-facing docs, then Gemini/Antigravity-facing examples.
+
+## Strategic Risks
+
+- **Generic creative platforms absorb the workflow.** Claude Design, Figma, Canva, Adobe, and Gemini will keep adding agentic creative loops. Vulca must stay focused on layer control + cultural evaluation, not generic design generation.
+- **Cultural analysis may not improve generation.** This is why experiments are required. If culture terms alone do not help, product language must emphasize visual operations and evaluation rather than cultural vocabulary.
+- **README overclaims.** Public docs must distinguish implemented, PR-ready, parallel work, and roadmap.
+- **Provider drift.** Model IDs and supported parameters change. Product docs should describe provider capabilities, while implementation keeps capability gates.
+
+## Decision
+
+Proceed with a product-positioning and README plan. Treat `/visual-discovery` as the upstream entry point of the complete workflow, not as the final product. Keep the platform strategy multi-provider and agent-surface-neutral, with Claude Code as the first wedge.

--- a/docs/product/experiments/cultural-term-efficacy.md
+++ b/docs/product/experiments/cultural-term-efficacy.md
@@ -1,0 +1,61 @@
+# Cultural-Term Efficacy Experiment
+
+**Status:** Experiment protocol
+**Last updated:** 2026-04-30
+
+## Question
+
+Do cultural and taste terms improve generated visual outputs, or do concrete visual operations and avoid lists carry most of the signal?
+
+## Prompt Conditions
+
+| Condition | Prompt shape |
+|---|---|
+| A | User prompt only |
+| B | User prompt + cultural terms |
+| C | User prompt + cultural terms + visual operations |
+| D | Full direction-card prompt with avoid list and evaluation focus |
+
+## Providers
+
+- OpenAI GPT Image provider.
+- Gemini image provider.
+- ComfyUI local provider.
+
+`mock` may validate artifact structure but must not be used for quality conclusions.
+
+## Projects
+
+Run at least three domains:
+
+- premium tea packaging with xieyi restraint;
+- editorial poster with spiritual but non-religious atmosphere;
+- product campaign visual with culturally specific material references.
+
+## Metrics
+
+- Human preference.
+- L1-L5 cultural/evaluation score.
+- Cliche avoidance.
+- Prompt adherence.
+- Editability and layer separability.
+- Cost and latency.
+- Failure class.
+
+## Output Artifacts
+
+Each run writes:
+
+```text
+docs/product/experiments/results/<date>-<slug>/
+  prompts/
+  images/
+  evaluations/
+  human_ranking.json
+  provider_costs.json
+  summary.md
+```
+
+## Decision Rule
+
+If condition D does not outperform A/B/C on at least two of three domains for human preference and cliche avoidance, product language must shift from "culture terms guide models" to "Vulca converts culture analysis into visual operations and evaluation criteria."

--- a/docs/product/provider-capabilities.md
+++ b/docs/product/provider-capabilities.md
@@ -1,0 +1,33 @@
+# Vulca Provider and Platform Capability Matrix
+
+**Status:** Public product guide
+**Last updated:** 2026-04-30
+
+Vulca separates agent surfaces from image providers.
+
+## Agent Surfaces
+
+| Surface | Role | Status |
+|---|---|---|
+| Claude Code | Primary agent surface for MCP tools and skills | Current |
+| OpenAI Codex / ChatGPT developer surfaces | Future agent surface; OpenAI is already a provider backend | Planned |
+| Gemini / Antigravity-like developer agents | Future agent surface for Google-native workflows | Planned |
+| Python SDK / CLI | Power-user and test harness path | Current |
+| Vulca Studio UI | Review surface for cards, sketches, layers, and evaluations | Later |
+
+## Image Providers
+
+| Provider | Current role | Use it for | Avoid using it for |
+|---|---|---|---|
+| `mock` | Cost-free artifact validation | tests, discovery sketch records, workflow dry-runs | quality claims |
+| `openai` | High-quality generation/editing backend | final candidates, image edits, text-heavy visuals when model supports it | assuming every model supports every edit knob |
+| `gemini` / `nb2` | Gemini image backend | sketching, reference-heavy exploration, alternative provider comparisons | treating marketing names as implementation IDs |
+| `comfyui` | Local generation/editing backend | local-first workflows, inspectable pipelines, advanced users | assuming cloud-model prompt behavior |
+
+## Documentation Rules
+
+- Describe capability classes in public prose.
+- Put model IDs in examples and matrices.
+- Keep capability gates in code.
+- Do not write fixed MCP tool counts in public docs.
+- Treat real-provider discovery sketches as explicit opt-in.

--- a/docs/product/roadmap.md
+++ b/docs/product/roadmap.md
@@ -1,0 +1,39 @@
+# Vulca Product Roadmap
+
+**Status:** Public product roadmap
+**Last updated:** 2026-04-30
+
+Vulca is an agent-native visual control layer. The product turns fuzzy visual intent into controlled creative production through reviewable artifacts, provider-routed generation, semantic pixel editing, and cultural evaluation.
+
+## Current
+
+- `/decompose`: semantic layer extraction into transparent PNG artifacts.
+- `/visual-discovery`: fuzzy intent -> taste profile -> direction cards -> discovery artifacts.
+- `/visual-brainstorm`, `/visual-spec`, `/visual-plan`: proposal/design/plan workflow for controlled generation.
+- Provider registry: `mock`, `gemini`, `nb2`, `openai`, `comfyui`.
+- MCP tools for image generation, image viewing, evaluation, inpainting, layers, redraw, compositing, paste-back, and Tool Protocol analysis.
+- 13 cultural traditions and L1-L5 evaluation framework.
+
+## Next
+
+- README repositioning around the full Discover -> Spec -> Generate -> Edit -> Evaluate workflow.
+- `/evaluate` skill packaging on top of existing `evaluate_artwork`.
+- Provider capability matrix for public docs.
+- Cultural-term efficacy benchmark.
+
+## In Parallel
+
+- v0.22 target-aware mask refinement in `.worktrees/v0-22-mask-refinement`.
+- This work owns redraw robustness and should land before `/inpaint` or `/redraw-layer` is marketed as a polished user-facing skill.
+
+## Later
+
+- `/inpaint` or `/redraw-layer` skill once redraw routes are robust.
+- OpenAI/Codex and Gemini-facing usage guides.
+- Lightweight Studio review UI for direction cards, sketch grids, layers, and evaluation reports.
+
+## Non-Goals
+
+- Hosting a foundation image/video model.
+- Competing with one-click image models on raw generation quality.
+- Building a general-purpose design app before artifact contracts stabilize.

--- a/docs/superpowers/plans/2026-04-30-product-positioning-readme-platform.md
+++ b/docs/superpowers/plans/2026-04-30-product-positioning-readme-platform.md
@@ -1,0 +1,436 @@
+# Product Positioning README + Platform Plan Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Reposition Vulca's public product story around the complete Discover -> Spec -> Generate -> Edit -> Evaluate workflow, while documenting platform/provider strategy and validation experiments.
+
+**Architecture:** This is a docs-first product coherence pass. It must not touch redraw internals or provider runtime behavior. It creates stable product docs, rewrites README around the workflow, and adds tests that prevent stale public claims about model IDs, MCP tool counts, and implemented-vs-roadmap status.
+
+**Tech Stack:** Markdown docs, pytest doc truth tests, existing Vulca skills/docs, current provider registry, current README.
+
+---
+
+## Source Inputs
+
+- Product brief: `docs/product/2026-04-30-product-positioning-brief.md`
+- Design spec: `docs/superpowers/specs/2026-04-30-product-positioning-platform-design.md`
+- Existing README: `README.md`
+- Visual discovery spec: `docs/superpowers/specs/2026-04-29-visual-discovery-design.md`
+- Visual discovery skill: `.agents/skills/visual-discovery/SKILL.md`
+- Competitive landscape: `docs/superpowers/specs/2026-04-20-competitive-landscape.md`
+- Redraw plan, for boundaries only: `docs/superpowers/plans/2026-04-28-v0.21-redraw-recontract.md`
+
+## File Structure
+
+- Create: `docs/product/roadmap.md`
+  - Public product roadmap: current, next, later, experiments.
+- Create: `docs/product/provider-capabilities.md`
+  - Provider/backend matrix for OpenAI, Gemini, ComfyUI, mock, and agent surfaces.
+- Create: `docs/product/experiments/cultural-term-efficacy.md`
+  - Benchmark protocol for testing whether culture/taste analysis improves generation.
+- Modify: `README.md`
+  - Reposition first viewport and capability matrix.
+- Modify: `tests/test_visual_discovery_docs_truth.py`
+  - Add public-doc truth tests for stale tool counts and implemented/roadmap phrasing.
+- Optional Modify: `pyproject.toml`
+  - Only if public package description still contradicts the new product thesis.
+
+---
+
+## Task 1: Product Roadmap Doc
+
+**Files:**
+- Create: `docs/product/roadmap.md`
+
+- [ ] **Step 1: Write the roadmap doc**
+
+Create `docs/product/roadmap.md` with:
+
+```markdown
+# Vulca Product Roadmap
+
+**Status:** Public product roadmap
+**Last updated:** 2026-04-30
+
+Vulca is an agent-native visual control layer. The product turns fuzzy visual intent into controlled creative production through reviewable artifacts, provider-routed generation, semantic pixel editing, and cultural evaluation.
+
+## Current
+
+- `/decompose`: semantic layer extraction into transparent PNG artifacts.
+- `/visual-discovery`: fuzzy intent -> taste profile -> direction cards -> discovery artifacts.
+- `/visual-brainstorm`, `/visual-spec`, `/visual-plan`: proposal/design/plan workflow for controlled generation.
+- Provider registry: `mock`, `gemini`, `nb2`, `openai`, `comfyui`.
+- MCP tools for image generation, image viewing, evaluation, inpainting, layers, redraw, compositing, paste-back, and Tool Protocol analysis.
+- 13 cultural traditions and L1-L5 evaluation framework.
+
+## Next
+
+- README repositioning around the full Discover -> Spec -> Generate -> Edit -> Evaluate workflow.
+- `/evaluate` skill packaging on top of existing `evaluate_artwork`.
+- Provider capability matrix for public docs.
+- Cultural-term efficacy benchmark.
+
+## In Parallel
+
+- v0.22 target-aware mask refinement in `.worktrees/v0-22-mask-refinement`.
+- This work owns redraw robustness and should land before `/inpaint` or `/redraw-layer` is marketed as a polished user-facing skill.
+
+## Later
+
+- `/inpaint` or `/redraw-layer` skill once redraw routes are robust.
+- OpenAI/Codex and Gemini-facing usage guides.
+- Lightweight Studio review UI for direction cards, sketch grids, layers, and evaluation reports.
+
+## Non-Goals
+
+- Hosting a foundation image/video model.
+- Competing with one-click image models on raw generation quality.
+- Building a general-purpose design app before artifact contracts stabilize.
+```
+
+- [ ] **Step 2: Verify no unfinished markers**
+
+Run:
+
+```bash
+grep -nE "TB[D]|TO[D]O|coming soo[n]|lo[r]em" docs/product/roadmap.md
+```
+
+Expected: no matches.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/product/roadmap.md
+git commit -m "docs(product): add vulca roadmap"
+```
+
+---
+
+## Task 2: Provider Capability Doc
+
+**Files:**
+- Create: `docs/product/provider-capabilities.md`
+
+- [ ] **Step 1: Write the provider matrix**
+
+Create `docs/product/provider-capabilities.md` with:
+
+```markdown
+# Vulca Provider and Platform Capability Matrix
+
+**Status:** Public product guide
+**Last updated:** 2026-04-30
+
+Vulca separates agent surfaces from image providers.
+
+## Agent Surfaces
+
+| Surface | Role | Status |
+|---|---|---|
+| Claude Code | Primary agent surface for MCP tools and skills | Current |
+| OpenAI Codex / ChatGPT developer surfaces | Future agent surface; OpenAI is already a provider backend | Planned |
+| Gemini / Antigravity-like developer agents | Future agent surface for Google-native workflows | Planned |
+| Python SDK / CLI | Power-user and test harness path | Current |
+| Vulca Studio UI | Review surface for cards, sketches, layers, and evaluations | Later |
+
+## Image Providers
+
+| Provider | Current role | Use it for | Avoid using it for |
+|---|---|---|---|
+| `mock` | Cost-free artifact validation | tests, discovery sketch records, workflow dry-runs | quality claims |
+| `openai` | High-quality generation/editing backend | final candidates, image edits, text-heavy visuals when model supports it | assuming every model supports every edit knob |
+| `gemini` / `nb2` | Gemini image backend | sketching, reference-heavy exploration, alternative provider comparisons | treating marketing names as implementation IDs |
+| `comfyui` | Local generation/editing backend | local-first workflows, inspectable pipelines, advanced users | assuming cloud-model prompt behavior |
+
+## Documentation Rules
+
+- Describe capability classes in public prose.
+- Put model IDs in examples and matrices.
+- Keep capability gates in code.
+- Do not write fixed MCP tool counts in public docs.
+- Treat real-provider discovery sketches as explicit opt-in.
+```
+
+- [ ] **Step 2: Verify current provider IDs**
+
+Run:
+
+```bash
+PYTHONPATH=src python3 - <<'PY'
+import vulca.providers as providers
+providers._lazy_load_providers()
+print(sorted(providers._IMAGE_PROVIDERS))
+PY
+```
+
+Expected includes `comfyui`, `gemini`, `mock`, `nb2`, `openai`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/product/provider-capabilities.md
+git commit -m "docs(product): add provider capability matrix"
+```
+
+---
+
+## Task 3: Cultural-Term Efficacy Benchmark Doc
+
+**Files:**
+- Create: `docs/product/experiments/cultural-term-efficacy.md`
+
+- [ ] **Step 1: Write the experiment protocol**
+
+Create `docs/product/experiments/cultural-term-efficacy.md` with:
+
+```markdown
+# Cultural-Term Efficacy Experiment
+
+**Status:** Experiment protocol
+**Last updated:** 2026-04-30
+
+## Question
+
+Do cultural and taste terms improve generated visual outputs, or do concrete visual operations and avoid lists carry most of the signal?
+
+## Prompt Conditions
+
+| Condition | Prompt shape |
+|---|---|
+| A | User prompt only |
+| B | User prompt + cultural terms |
+| C | User prompt + cultural terms + visual operations |
+| D | Full direction-card prompt with avoid list and evaluation focus |
+
+## Providers
+
+- OpenAI GPT Image provider.
+- Gemini image provider.
+- ComfyUI local provider.
+
+`mock` may validate artifact structure but must not be used for quality conclusions.
+
+## Projects
+
+Run at least three domains:
+
+- premium tea packaging with xieyi restraint;
+- editorial poster with spiritual but non-religious atmosphere;
+- product campaign visual with culturally specific material references.
+
+## Metrics
+
+- Human preference.
+- L1-L5 cultural/evaluation score.
+- Cliche avoidance.
+- Prompt adherence.
+- Editability and layer separability.
+- Cost and latency.
+- Failure class.
+
+## Output Artifacts
+
+Each run writes:
+
+```text
+docs/product/experiments/results/<date>-<slug>/
+  prompts/
+  images/
+  evaluations/
+  human_ranking.json
+  provider_costs.json
+  summary.md
+```
+
+## Decision Rule
+
+If condition D does not outperform A/B/C on at least two of three domains for human preference and cliche avoidance, product language must shift from "culture terms guide models" to "Vulca converts culture analysis into visual operations and evaluation criteria."
+```
+
+- [ ] **Step 2: Verify no quality claim without experiment**
+
+Run:
+
+```bash
+grep -nE "proves|guarantees|always improves|best" docs/product/experiments/cultural-term-efficacy.md
+```
+
+Expected: no matches.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/product/experiments/cultural-term-efficacy.md
+git commit -m "docs(product): define cultural term efficacy experiment"
+```
+
+---
+
+## Task 4: README Repositioning
+
+**Files:**
+- Modify: `README.md`
+- Test: `tests/test_visual_discovery_docs_truth.py`
+
+- [ ] **Step 1: Add README truth tests**
+
+Extend `tests/test_visual_discovery_docs_truth.py` with:
+
+```python
+def test_readme_leads_with_full_visual_workflow():
+    readme = (ROOT / "README.md").read_text(encoding="utf-8")
+    first_screen = readme[:2500].lower()
+
+    assert "discover" in first_screen
+    assert "generate" in first_screen
+    assert "edit" in first_screen
+    assert "evaluate" in first_screen
+    assert "one-click" in first_screen or "one shot" in first_screen
+
+
+def test_public_docs_do_not_overclaim_cultural_terms():
+    public_text = "\n".join(
+        [
+            (ROOT / "README.md").read_text(encoding="utf-8"),
+            (ROOT / "docs" / "product" / "roadmap.md").read_text(encoding="utf-8"),
+            (ROOT / "docs" / "product" / "experiments" / "cultural-term-efficacy.md").read_text(encoding="utf-8"),
+        ]
+    ).lower()
+
+    forbidden = [
+        "culture terms guarantee",
+        "cultural terms guarantee",
+        "always improves generation",
+        "proves cultural prompting",
+    ]
+    for phrase in forbidden:
+        assert phrase not in public_text
+```
+
+- [ ] **Step 2: Run tests to verify they fail before README changes**
+
+Run:
+
+```bash
+PYTHONPATH=src pytest tests/test_visual_discovery_docs_truth.py -q
+```
+
+Expected: FAIL on `test_readme_leads_with_full_visual_workflow`.
+
+- [ ] **Step 3: Rewrite README first viewport**
+
+Replace the current headline paragraph and early `/decompose`-first framing with:
+
+```markdown
+**Vulca turns fuzzy visual intent into controlled creative production.**
+
+Discover the direction, compile the brief, route the model, edit the pixels,
+and evaluate the result — as agent-native artifacts and MCP tools.
+
+One-click models are getting stronger. Vulca does not try to beat them at raw
+generation. Vulca sits around them: it helps agents clarify what should be made,
+choose and constrain the right provider, preserve non-target pixels during edits,
+and record why a result does or does not fit the cultural and visual brief.
+
+```text
+fuzzy intent
+  -> /visual-discovery
+  -> /visual-brainstorm
+  -> /visual-spec
+  -> /visual-plan
+  -> generate / decompose / edit / evaluate
+  -> archived artifacts
+```
+```
+
+Keep the existing `/decompose` showcase, but move it below the product thesis and capability matrix.
+
+- [ ] **Step 4: Add product capability matrix**
+
+Add near the top:
+
+```markdown
+| Stage | What Vulca gives the agent | Status |
+|---|---|---|
+| Discover | Taste/culture profile, direction cards, sketch prompts | PR-ready |
+| Specify | `proposal.md`, `design.md`, `plan.md` | Current |
+| Generate | Provider-routed image calls across OpenAI, Gemini, ComfyUI, mock | Current |
+| Edit | Semantic layers, masks, redraw, inpaint, composite, paste-back | Current + v0.22 hardening |
+| Evaluate | L1-L5 cultural and visual scoring | Tool current, skill next |
+| Archive | Prompts, masks, layers, evaluations, errors, user overrides | Current |
+```
+
+- [ ] **Step 5: Run README tests**
+
+Run:
+
+```bash
+PYTHONPATH=src pytest tests/test_visual_discovery_docs_truth.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add README.md tests/test_visual_discovery_docs_truth.py
+git commit -m "docs: reposition readme around visual control workflow"
+```
+
+---
+
+## Task 5: Final Verification
+
+**Files:**
+- Verify all product docs and README tests.
+
+- [ ] **Step 1: Run focused docs tests**
+
+Run:
+
+```bash
+PYTHONPATH=src pytest tests/test_visual_discovery_docs_truth.py tests/test_visual_discovery_skill_contract.py -q
+```
+
+Expected: all pass.
+
+- [ ] **Step 2: Run unfinished-marker scan**
+
+Run:
+
+```bash
+grep -RInE "TB[D]|TO[D]O|lo[r]em|coming soo[n]" docs/product docs/superpowers/specs/2026-04-30-product-positioning-platform-design.md docs/superpowers/plans/2026-04-30-product-positioning-readme-platform.md README.md
+```
+
+Expected: no matches. If there is a match, inspect and remove it unless it is historical context.
+
+- [ ] **Step 3: Confirm no redraw internals changed**
+
+Run:
+
+```bash
+git diff --name-only master...HEAD | grep -E '^src/vulca/layers|^tests/test_layers_redraw|^src/vulca/providers/openai_provider.py' || true
+```
+
+Expected: no matches from this branch's new commits. If matches appear only because this branch is stacked on `codex/visual-discovery`, note that in the PR body; do not edit redraw internals here.
+
+- [ ] **Step 4: Open draft PR**
+
+Run:
+
+```bash
+git push -u origin codex/product-positioning-plan
+gh pr create --draft --base codex/visual-discovery --head codex/product-positioning-plan --title "[codex] reposition vulca product workflow" --body "Docs-first product positioning plan. Base is codex/visual-discovery because it depends on PR #21."
+```
+
+Expected: draft PR URL.
+
+---
+
+## Execution Options
+
+Plan complete. Two execution options:
+
+1. **Subagent-Driven (recommended)** - dispatch a fresh worker per task and review after each.
+2. **Inline Execution** - execute docs tasks in this session with checkpoints.

--- a/docs/superpowers/specs/2026-04-30-product-positioning-platform-design.md
+++ b/docs/superpowers/specs/2026-04-30-product-positioning-platform-design.md
@@ -1,0 +1,336 @@
+# Vulca Product Positioning + Platform Intervention Design Spec
+
+**Date:** 2026-04-30
+**Status:** Draft for product review
+**Scope:** Product positioning, README rewrite, platform strategy, and validation experiments
+**Branch:** `codex/product-positioning-plan`
+**Depends on:** `codex/visual-discovery` / PR #21
+
+This spec defines how Vulca should reposition after the `/visual-discovery` work. `/visual-discovery` is not the whole product. It is the upstream entry point in a larger agent-native visual control workflow.
+
+---
+
+## 1. Product Thesis
+
+Vulca should be positioned as:
+
+```text
+Agent-native visual control layer for creative direction, provider-routed generation,
+semantic pixel editing, and cultural evaluation.
+```
+
+The product should not compete directly with one-click image/video models on final image quality. Instead, Vulca should intervene around those models:
+
+- before generation, by clarifying fuzzy intent and cultural/taste tendencies;
+- during generation, by compiling provider-specific prompts and routing by capability;
+- after generation, by decomposing, editing, redrawing, compositing, evaluating, and archiving artifacts.
+
+The defensible product value is **controlled creative workflow**, not "better prompt wording."
+
+---
+
+## 2. External Platform Signals
+
+### 2.1 Anthropic / Claude
+
+Anthropic's April 2026 creative push validates agent-native creative workflows:
+
+- [Claude for Creative Work](https://www.anthropic.com/news/claude-for-creative-work) frames Claude as a connector to tools creatives already use, including Blender, Autodesk, Adobe, Ableton, Splice, Affinity, SketchUp, and Resolume.
+- [Claude Design](https://www.anthropic.com/news/claude-design-anthropic-labs) targets polished visual work, broad exploration, brand/design-system reuse, fine-grained controls, export to Canva/PDF/PPTX/HTML, and handoff to Claude Code.
+- [Claude Code MCP docs](https://code.claude.com/docs/en/mcp) position MCP as the way Claude connects to external tools and acts directly in those systems.
+- [Claude Code subagents docs](https://code.claude.com/docs/en/sub-agents) reinforce the pattern of specialized workers with separate context windows and tool access.
+
+Implication: Claude is the best initial distribution wedge for Vulca, but the real market movement is "creative agent + connected toolchain."
+
+### 2.2 OpenAI
+
+OpenAI is simultaneously a provider backend and an agent platform:
+
+- [GPT Image 2](https://developers.openai.com/api/docs/models/gpt-image-2) is now listed as an image generation and editing model with Image API and edit endpoint support.
+- [OpenAI image generation guide](https://developers.openai.com/api/docs/guides/image-generation) distinguishes Image API and Responses API flows and supports customizable quality, size, format, compression, and transparency depending on model support.
+- [OpenAI developers homepage](https://developers.openai.com/) positions Codex, Apps SDK, MCP, and GPT Image 2 as developer-facing surfaces.
+
+Implication: Vulca should support GPT Image 2 as a provider where available, but public product language should describe capability classes rather than overfitting to one model ID.
+
+### 2.3 Google / Gemini
+
+Google is turning Gemini image models into developer infrastructure:
+
+- [Gemini 3](https://blog.google/products-and-platforms/products/gemini/gemini-3/) emphasizes multimodal reasoning, planning, AI Studio, Vertex AI, and agentic workflows.
+- [Nano Banana Pro / Gemini 3 Pro Image](https://blog.google/innovation-and-ai/technology/developers-tools/gemini-3-pro-image-developers/) is positioned for developers through Gemini API, AI Studio, and Vertex AI, with higher-fidelity images, better text rendering, and creative platform integrations.
+
+Implication: Gemini should remain a first-class provider path, especially for low-cost sketching, reference-heavy generation, and future integration with agentic developer platforms.
+
+---
+
+## 3. Current Vulca Assets
+
+### 3.1 Implemented or PR-Ready
+
+- `/decompose`: semantic layer extraction skill and showcase.
+- `/visual-discovery`: PR #21 upstream fuzzy-intent workflow with taste profiles, direction cards, prompt artifacts, and discovery handoff.
+- `/visual-brainstorm`, `/visual-spec`, `/visual-plan`: artifact-based production chain.
+- MCP tools for generation, evaluation, image viewing, layer operations, inpainting, redraw, paste-back, and Tool Protocol analyzers.
+- Provider registry: `mock`, `gemini`, `nb2`, `openai`, `comfyui`.
+- OpenAI capability gating and output MIME handling.
+- Cultural foundation: 13 traditions, L1-L5 framework, research-backed evaluation.
+
+### 3.2 Parallel Work
+
+- v0.22 target-aware mask refinement runs in `/Users/yhryzy/dev/vulca/.worktrees/v0-22-mask-refinement`.
+- This spec does not change redraw internals. It should reference the redraw branch as a dependency for later `/inpaint` or `/redraw-layer` productization.
+
+### 3.3 Gaps
+
+- README still leads with `/decompose`, which undersells the full workflow.
+- `/evaluate` is not yet packaged as a user-facing skill.
+- There is no public product document explaining Vulca's relationship to Claude Design, OpenAI image models, Gemini / Nano Banana, or future studio UI.
+- Cultural/taste-analysis value has not been benchmarked across providers.
+- Provider capability matrix is mostly implicit in code and scattered docs.
+
+---
+
+## 4. Product Architecture
+
+### 4.1 Workflow
+
+```text
+User fuzzy intent
+  -> /visual-discovery
+  -> direction cards + taste profile
+  -> /visual-brainstorm
+  -> proposal.md
+  -> /visual-spec
+  -> design.md
+  -> /visual-plan
+  -> plan.md + generation/evaluation iterations
+  -> layer edit / redraw / inpaint as needed
+  -> archive
+```
+
+### 4.2 Product Pillars
+
+1. **Discovery:** infer taste, cultural tendency, audience, uncertainty, and direction alternatives.
+2. **Specification:** turn selected direction into reviewable proposal/design/plan artifacts.
+3. **Provider routing:** choose OpenAI, Gemini, ComfyUI, mock, or future providers by capability and cost.
+4. **Pixel control:** decompose, mask, inpaint, redraw, composite, and paste back without destroying non-target regions.
+5. **Evaluation:** apply L1-L5 cultural and visual scoring to generated or edited outputs.
+6. **Provenance:** preserve prompts, masks, layers, model IDs, costs, failures, and user overrides.
+
+### 4.3 Data Artifacts
+
+The following artifacts are platform-independent and should become the product contract:
+
+```text
+discovery.md
+taste_profile.json
+direction_cards.json
+sketch_prompts.json
+proposal.md
+design.md
+plan.md
+manifest.json
+evaluation.json
+errors.json
+```
+
+Agent surfaces may differ. These artifacts should not.
+
+---
+
+## 5. Platform Strategy
+
+### 5.1 Agent Surfaces
+
+| Surface | Priority | Role |
+|---|---:|---|
+| Claude Code | 1 | Current wedge: MCP + skills + artifacts are already native. |
+| OpenAI Codex / ChatGPT developer surfaces | 2 | Future agent surface and distribution path; OpenAI is also a provider backend. |
+| Gemini / Antigravity-like developer agents | 3 | Future agent surface for Google-native image and developer workflows. |
+| Local CLI / Python SDK | 4 | Power-user and test harness path. |
+| Vulca Studio UI | 5 | Needed after artifacts stabilize; not first. |
+
+### 5.2 Provider Backends
+
+| Provider | Product role | Current posture |
+|---|---|---|
+| `openai` | high-quality final image/edit provider | support GPT Image 2 where available; keep capability gates |
+| `gemini` / `nb2` | low-cost sketching and image editing path | keep as first-class sketch/final candidate |
+| `comfyui` | local-first, inspectable generation/editing | critical for offline and advanced users |
+| `mock` | test, artifact, and cost-free workflow validation | must remain default for discovery sketches |
+
+### 5.3 Key Rule
+
+Do not choose "Claude only" or "OpenAI only." Choose **Claude-first distribution** and **multi-provider execution**.
+
+---
+
+## 6. README Rewrite Design
+
+The README should move from "decompose showcase first" to "full visual control workflow first."
+
+### 6.1 First Viewport
+
+Recommended headline:
+
+```text
+Vulca turns fuzzy visual intent into controlled creative production.
+```
+
+Recommended subheadline:
+
+```text
+Discover the direction, compile the brief, route the model, edit the pixels,
+and evaluate the result — as agent-native artifacts and MCP tools.
+```
+
+### 6.2 README Sections
+
+1. Product thesis and workflow diagram.
+2. "Why Vulca exists": one-click models generate, Vulca controls.
+3. Current capability matrix: Discovery, Spec, Generate, Edit, Evaluate, Archive.
+4. Quick start for Claude Code.
+5. Provider matrix.
+6. `/decompose` concrete showcase.
+7. `/visual-discovery` example.
+8. Layer/edit/redraw status with honest boundaries.
+9. Evaluation and cultural framework.
+10. Roadmap and experiments.
+
+### 6.3 Documentation Rules
+
+- Do not write fixed MCP tool counts in public docs.
+- Separate "implemented", "PR-ready", "parallel branch", and "roadmap."
+- Use provider capability language in public docs; keep model IDs in matrices and examples.
+- Explicitly state that real provider sketching in discovery is opt-in.
+- Do not claim cultural terms improve generation until experiments support it.
+
+---
+
+## 7. Experiment Design
+
+### 7.1 Cultural Term Efficacy
+
+Question: do cultural/taste terms actually guide generation, or do visual operations do the work?
+
+Conditions:
+
+- A: naive prompt.
+- B: naive prompt + cultural terms.
+- C: cultural terms + visual operations.
+- D: full direction-card prompt with avoid list and evaluation focus.
+
+Providers:
+
+- OpenAI GPT Image 2 or current GPT Image provider.
+- Gemini / Nano Banana provider.
+- ComfyUI local provider.
+- Mock only for artifact validation, not quality measurement.
+
+Measures:
+
+- human preference;
+- L1-L5 score;
+- cliche avoidance;
+- instruction adherence;
+- editability/layer separability;
+- cost and latency;
+- failure class.
+
+### 7.2 Discovery Loop Efficacy
+
+Question: does `/visual-discovery` reduce rerolls and increase user confidence?
+
+Compare:
+
+- direct one-shot prompt;
+- direction cards without sketches;
+- direction cards with sketch prompts;
+- full discovery -> brainstorm -> spec -> plan.
+
+Measures:
+
+- turns to approved direction;
+- number of generated images;
+- user confidence;
+- final score;
+- explainability of final result.
+
+### 7.3 Provider Capability Benchmark
+
+Question: which provider should own which creative job?
+
+Tasks:
+
+- text rendering;
+- reference preservation;
+- mask compliance;
+- local edits;
+- cultural style adherence;
+- transparency/background handling;
+- multi-image input;
+- cost/latency.
+
+Output:
+
+- provider capability matrix;
+- route recommendations;
+- README support table.
+
+---
+
+## 8. Roadmap
+
+### Phase 0: Product Coherence
+
+- Create product positioning brief.
+- Create this design spec.
+- Create implementation plan for README/platform docs.
+- Keep redraw implementation in its separate v0.22 branch.
+
+### Phase 1: Public Narrative
+
+- Rewrite README around the full workflow.
+- Add docs/product/roadmap.md.
+- Add docs/product/provider-capabilities.md.
+- Add docs/product/experiments/cultural-term-efficacy.md.
+
+### Phase 2: Skill Packaging
+
+- Ship `/evaluate`.
+- Productize `/inpaint` or `/redraw-layer` after v0.22 lands.
+- Update `using-vulca-skills` routing once these skills exist.
+
+### Phase 3: Evidence and Distribution
+
+- Run benchmark experiments.
+- Publish before/after case studies.
+- Submit/update Claude plugin distribution.
+- Create OpenAI/Codex and Gemini-facing usage guides.
+
+### Phase 4: Studio UI
+
+- Build only after artifact contracts and benchmarks stabilize.
+- Initial UI should be a review surface for direction cards, sketch grids, layers, and evaluation, not a full design app.
+
+---
+
+## 9. Acceptance Criteria
+
+The product-positioning work is complete when:
+
+- README first viewport explains the full Vulca workflow, not only `/decompose`.
+- A product roadmap doc states current vs next vs later without overclaiming.
+- A provider capability doc explains OpenAI/Gemini/ComfyUI/mock roles.
+- A benchmark doc defines how to test cultural/taste-analysis impact.
+- Public docs cite current platform facts and avoid stale model/tool claims.
+- No redraw internals are changed in this branch.
+
+---
+
+## 10. Open Questions
+
+- Should the public tagline emphasize "creative direction" or "visual control" first?
+- Should `/evaluate` ship before README rewrite lands, or can README list it as next?
+- Should the first Studio UI be a local static HTML report generator instead of a hosted app?
+- Should `gpt-image-2` be the default OpenAI final provider after capability/cost checks, or stay an explicit model override?

--- a/tests/test_visual_discovery_docs_truth.py
+++ b/tests/test_visual_discovery_docs_truth.py
@@ -28,3 +28,41 @@ def test_readme_mentions_visual_discovery_and_mock_boundary():
     assert "/visual-discovery" in readme
     assert "mock sketch" in readme.lower()
     assert "real provider sketch" in readme.lower()
+
+
+def test_readme_leads_with_full_visual_workflow():
+    readme = (ROOT / "README.md").read_text(encoding="utf-8")
+    first_screen = readme[:2500].lower()
+
+    assert "discover" in first_screen
+    assert "generate" in first_screen
+    assert "edit" in first_screen
+    assert "evaluate" in first_screen
+    assert "one-click" in first_screen or "one shot" in first_screen
+
+
+def test_public_docs_do_not_overclaim_cultural_terms():
+    public_text = "\n".join(
+        [
+            (ROOT / "README.md").read_text(encoding="utf-8"),
+            (ROOT / "docs" / "product" / "roadmap.md").read_text(
+                encoding="utf-8"
+            ),
+            (
+                ROOT
+                / "docs"
+                / "product"
+                / "experiments"
+                / "cultural-term-efficacy.md"
+            ).read_text(encoding="utf-8"),
+        ]
+    ).lower()
+
+    forbidden = [
+        "culture terms guarantee",
+        "cultural terms guarantee",
+        "always improves generation",
+        "proves cultural prompting",
+    ]
+    for phrase in forbidden:
+        assert phrase not in public_text


### PR DESCRIPTION
Docs-first product positioning plan. Base is codex/visual-discovery because it depends on PR #21.\n\nSummary:\n- Reframe README around the full Discover -> Spec -> Generate -> Edit -> Evaluate workflow.\n- Add public roadmap, provider/platform capability matrix, and cultural-term efficacy experiment protocol.\n- Add doc truth tests to prevent stale workflow and cultural-claim overreach.\n\nValidation:\n- PYTHONPATH=src pytest tests/test_visual_discovery_docs_truth.py tests/test_visual_discovery_skill_contract.py -q -> 7 passed\n- Unfinished-marker scan clean\n- git diff --check codex/visual-discovery..HEAD clean\n- codex/visual-discovery..HEAD touches only README/docs/doc tests, no redraw/provider runtime internals.