### PR TITLE
[codex] add evaluate skill

### DIFF
--- a/.agents/skills/evaluate/SKILL.md
+++ b/.agents/skills/evaluate/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: evaluate
+description: Evaluate an existing visual artifact against a tradition, intent, and L1-L5 cultural/visual rubric.
+---
+
+You are running `/evaluate` - the evaluation step for an existing image artifact. Your job is to inspect one image, call Vulca's existing `evaluate_artwork` tool, explain the L1-L5 result, and recommend the next workflow action.
+
+## Triggers
+
+- Slash command: `/evaluate <image_path>` or `/evaluate <slug>`
+- Chinese aliases: `评价这张图`, `文化评分`, `L1-L5 评分`, `帮我判断这张图`
+- Intent auto-match: the user asks whether an image fits a tradition, brief, culture, or visual direction; asks for cultural critique; asks for L1-L5 scoring; or asks what to improve after generation.
+
+## Scope
+
+Evaluate one existing image. Do not generate, edit, redraw, decompose, or composite images.
+
+## Inputs
+
+- Required: `image_path` or `slug`.
+- Optional: `tradition`, `intent`, `mode`, `mock`, `vlm_model`, `write_artifacts`.
+- `mode`: `strict`, `reference`, or `rubric_only`.
+- `mock`: only for no-cost shape checks and tests. Never present mock scores as real quality evidence.
+
+## Path Resolution
+
+If the user provides a file path, verify it exists before calling any tool.
+
+If the user provides a slug, search in this order:
+
+1. `docs/visual-specs/<slug>/iters/**/gen_*`
+2. `docs/visual-specs/<slug>/iters/**/*.{png,jpg,jpeg,webp}`
+3. `docs/visual-specs/<slug>/source.{png,jpg,jpeg,webp}`
+
+If more than one image is found, ask the user which image to evaluate.
+
+## Allowed Tools
+
+- `view_image`
+- `get_tradition_guide`
+- `evaluate_artwork`
+- Read/write project docs
+
+## Forbidden Tools
+
+- `generate_image`
+- `create_artwork`
+- `generate_concepts`
+- `inpaint_artwork`
+- `layers_*`
+
+If the evaluation recommends an edit, explain the next action. You must not execute pixel edits from this skill.
+
+## Workflow
+
+1. Resolve and verify the image path.
+2. If a tradition is provided, call `get_tradition_guide(tradition)` and use it to explain L1-L5 context.
+3. Call `view_image(image_path)` when visual grounding is useful.
+4. Call `evaluate_artwork(image_path, tradition=<tradition>, intent=<intent>, mode=<mode>, mock=<mock>, vlm_model=<vlm_model>)`.
+5. Extract `score`, `tradition`, `dimensions`, `rationales`, `recommendations`, `risk_flags`, and `risk_level`.
+6. If all L1-L5 scores are zero or missing, mark the result as suspect and recommend rerunning with a real VLM or checking credentials.
+7. Explain strongest dimensions, weakest dimensions, and concrete next action.
+8. When a slug is known or `write_artifacts=true`, write:
+   - `docs/visual-specs/<slug>/evaluation.md`
+   - `docs/visual-specs/<slug>/evaluation.json`
+
+## User-Facing Response
+
+Include:
+
+- image path
+- tradition and mode
+- overall score
+- L1-L5 summary
+- strongest dimensions
+- weakest dimensions
+- recommendations
+- risk flags
+- next action
+
+Next action must be one of:
+
+- `accept`
+- `revise prompt`
+- `rerun /visual-plan`
+- `redraw target after v0.22 route is available`
+- `run /visual-discovery`
+
+## Artifact Contract
+
+`evaluation.md`:
+
+```markdown
+# Evaluation: <slug or image stem>
+
+## Status
+evaluated
+
+## Image
+<path>
+
+## Tradition
+<tradition>
+
+## Mode
+<mode>
+
+## Overall Score
+<score or unavailable>
+
+## L1-L5
+<table>
+
+## Recommendations
+<bullets>
+
+## Risk Flags
+<bullets or none>
+
+## Next Action
+<decision>
+```
+
+`evaluation.json`:
+
+```json
+{
+  "schema_version": "0.1",
+  "image_path": "...",
+  "tradition": "...",
+  "mode": "...",
+  "intent": "...",
+  "evaluate_artwork": {}
+}
+```

--- a/.agents/skills/using-vulca-skills/SKILL.md
+++ b/.agents/skills/using-vulca-skills/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: using-vulca-skills
-description: Use when starting any conversation about Vulca visual workflows — establishes auto-invoke discipline for the discovery → brainstorm → spec → plan chain. Preload via SessionStart hook so the agent matches user intent without requiring slash commands.
+description: Use when starting any conversation about Vulca visual workflows - establishes auto-invoke discipline for the discovery -> brainstorm -> spec -> plan -> evaluate chain. Preload via SessionStart hook so the agent matches user intent without requiring slash commands.
 ---
 
 <SUBAGENT-STOP>
@@ -28,6 +28,7 @@ If the user says "skip the brainstorm, just generate" — that's an explicit ins
 | explore fuzzy visual direction, taste, culture tendency, "抽卡", "方向探索", "审美分析", "文化倾向分析"; no discovery artifacts yet | `visual-discovery` |
 | define / scope / brainstorm a 2D visual project (poster / illustration / packaging / brand / editorial / photo brief / hero art); no proposal.md yet | `visual-brainstorm` |
 | derive technical decisions (provider, prompt, L1-L5 weights, thresholds, cost) from an existing `proposal.md` with `status: ready` | `visual-spec` |
+| evaluate an existing image against a tradition/brief, ask for L1-L5 scoring, cultural critique, "评价这张图", "文化评分"; image already exists | `evaluate` |
 | review the derived plan.md AND execute the real generate+evaluate loop for an existing `design.md` with `status: resolved` | `visual-plan` |
 | decompose a given image into semantic layers | `decompose` |
 
@@ -72,4 +73,5 @@ Then follow the skill's body exactly.
 - `.agents/skills/visual-brainstorm/SKILL.md`
 - `.agents/skills/visual-spec/SKILL.md`
 - `.agents/skills/visual-plan/SKILL.md`
+- `.agents/skills/evaluate/SKILL.md`
 - Sibling pattern: `superpowers:using-superpowers` (Superpowers' meta-skill this one is modeled on).

--- a/.claude/skills/evaluate/SKILL.md
+++ b/.claude/skills/evaluate/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: evaluate
+description: Evaluate an existing visual artifact against a tradition, intent, and L1-L5 cultural/visual rubric.
+---
+
+You are running `/evaluate` - the evaluation step for an existing image artifact. Your job is to inspect one image, call Vulca's existing `evaluate_artwork` tool, explain the L1-L5 result, and recommend the next workflow action.
+
+## Triggers
+
+- Slash command: `/evaluate <image_path>` or `/evaluate <slug>`
+- Chinese aliases: `评价这张图`, `文化评分`, `L1-L5 评分`, `帮我判断这张图`
+- Intent auto-match: the user asks whether an image fits a tradition, brief, culture, or visual direction; asks for cultural critique; asks for L1-L5 scoring; or asks what to improve after generation.
+
+## Scope
+
+Evaluate one existing image. Do not generate, edit, redraw, decompose, or composite images.
+
+## Inputs
+
+- Required: `image_path` or `slug`.
+- Optional: `tradition`, `intent`, `mode`, `mock`, `vlm_model`, `write_artifacts`.
+- `mode`: `strict`, `reference`, or `rubric_only`.
+- `mock`: only for no-cost shape checks and tests. Never present mock scores as real quality evidence.
+
+## Path Resolution
+
+If the user provides a file path, verify it exists before calling any tool.
+
+If the user provides a slug, search in this order:
+
+1. `docs/visual-specs/<slug>/iters/**/gen_*`
+2. `docs/visual-specs/<slug>/iters/**/*.{png,jpg,jpeg,webp}`
+3. `docs/visual-specs/<slug>/source.{png,jpg,jpeg,webp}`
+
+If more than one image is found, ask the user which image to evaluate.
+
+## Allowed Tools
+
+- `view_image`
+- `get_tradition_guide`
+- `evaluate_artwork`
+- Read/write project docs
+
+## Forbidden Tools
+
+- `generate_image`
+- `create_artwork`
+- `generate_concepts`
+- `inpaint_artwork`
+- `layers_*`
+
+If the evaluation recommends an edit, explain the next action. You must not execute pixel edits from this skill.
+
+## Workflow
+
+1. Resolve and verify the image path.
+2. If a tradition is provided, call `get_tradition_guide(tradition)` and use it to explain L1-L5 context.
+3. Call `view_image(image_path)` when visual grounding is useful.
+4. Call `evaluate_artwork(image_path, tradition=<tradition>, intent=<intent>, mode=<mode>, mock=<mock>, vlm_model=<vlm_model>)`.
+5. Extract `score`, `tradition`, `dimensions`, `rationales`, `recommendations`, `risk_flags`, and `risk_level`.
+6. If all L1-L5 scores are zero or missing, mark the result as suspect and recommend rerunning with a real VLM or checking credentials.
+7. Explain strongest dimensions, weakest dimensions, and concrete next action.
+8. When a slug is known or `write_artifacts=true`, write:
+   - `docs/visual-specs/<slug>/evaluation.md`
+   - `docs/visual-specs/<slug>/evaluation.json`
+
+## User-Facing Response
+
+Include:
+
+- image path
+- tradition and mode
+- overall score
+- L1-L5 summary
+- strongest dimensions
+- weakest dimensions
+- recommendations
+- risk flags
+- next action
+
+Next action must be one of:
+
+- `accept`
+- `revise prompt`
+- `rerun /visual-plan`
+- `redraw target after v0.22 route is available`
+- `run /visual-discovery`
+
+## Artifact Contract
+
+`evaluation.md`:
+
+```markdown
+# Evaluation: <slug or image stem>
+
+## Status
+evaluated
+
+## Image
+<path>
+
+## Tradition
+<tradition>
+
+## Mode
+<mode>
+
+## Overall Score
+<score or unavailable>
+
+## L1-L5
+<table>
+
+## Recommendations
+<bullets>
+
+## Risk Flags
+<bullets or none>
+
+## Next Action
+<decision>
+```
+
+`evaluation.json`:
+
+```json
+{
+  "schema_version": "0.1",
+  "image_path": "...",
+  "tradition": "...",
+  "mode": "...",
+  "intent": "...",
+  "evaluate_artwork": {}
+}
+```

--- a/.claude/skills/using-vulca-skills/SKILL.md
+++ b/.claude/skills/using-vulca-skills/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: using-vulca-skills
-description: Use when starting any conversation about Vulca visual workflows — establishes auto-invoke discipline for the discovery → brainstorm → spec → plan chain. Preload via SessionStart hook so the agent matches user intent without requiring slash commands.
+description: Use when starting any conversation about Vulca visual workflows - establishes auto-invoke discipline for the discovery -> brainstorm -> spec -> plan -> evaluate chain. Preload via SessionStart hook so the agent matches user intent without requiring slash commands.
 ---
 
 <SUBAGENT-STOP>
@@ -28,6 +28,7 @@ If the user says "skip the brainstorm, just generate" — that's an explicit ins
 | explore fuzzy visual direction, taste, culture tendency, "抽卡", "方向探索", "审美分析", "文化倾向分析"; no discovery artifacts yet | `visual-discovery` |
 | define / scope / brainstorm a 2D visual project (poster / illustration / packaging / brand / editorial / photo brief / hero art); no proposal.md yet | `visual-brainstorm` |
 | derive technical decisions (provider, prompt, L1-L5 weights, thresholds, cost) from an existing `proposal.md` with `status: ready` | `visual-spec` |
+| evaluate an existing image against a tradition/brief, ask for L1-L5 scoring, cultural critique, "评价这张图", "文化评分"; image already exists | `evaluate` |
 | review the derived plan.md AND execute the real generate+evaluate loop for an existing `design.md` with `status: resolved` | `visual-plan` |
 | decompose a given image into semantic layers | `decompose` |
 
@@ -72,4 +73,5 @@ Then follow the skill's body exactly.
 - `.claude/skills/visual-brainstorm/SKILL.md`
 - `.claude/skills/visual-spec/SKILL.md`
 - `.claude/skills/visual-plan/SKILL.md`
+- `.claude/skills/evaluate/SKILL.md`
 - Sibling pattern: `superpowers:using-superpowers` (Superpowers' meta-skill this one is modeled on).

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ fuzzy intent
 | Specify | `proposal.md`, `design.md`, `plan.md` | Current |
 | Generate | Provider-routed image calls across OpenAI, Gemini, ComfyUI, mock | Current |
 | Edit | Semantic layers, masks, redraw, inpaint, composite, paste-back | Current + v0.22 hardening |
-| Evaluate | L1-L5 cultural and visual scoring | Tool current, skill next |
+| Evaluate | L1-L5 cultural and visual scoring | Current |
 | Archive | Prompts, masks, layers, evaluations, errors, user overrides | Current |
 
 > *Concrete demo below: Michelangelo's *Creation of Adam* → 5 semantic layers via `/decompose` (background · adam · god_and_angels · red_cloak · green_ground), decomposed locally on Apple Silicon (ComfyUI + Ollama) with zero cloud API calls. SDK surface: MCP tools plus agent skills, validated by the test suite.*
@@ -128,7 +128,7 @@ Practical consequences of this framing:
 |---|---|:---:|---|
 | **Decompose** | Extract 10–20 semantic layers from any image with real transparency. | ✅ `/decompose` | `layers_split` (orchestrated), `layers_list` |
 | **Edit** | Redraw one region or one layer without touching the rest. Composite back. | Roadmap | `inpaint_artwork`, `layers_edit`, `layers_redraw`, `layers_transform`, `layers_composite`, `layers_export`, `layers_evaluate` |
-| **Evaluate** | Judge a visual against L1–L5 cultural criteria over 13 traditions with citable rationale. | Roadmap | `evaluate_artwork`, `list_traditions`, `get_tradition_guide`, `search_traditions` |
+| **Evaluate** | Judge a visual against L1–L5 cultural criteria over 13 traditions with citable rationale. | ✅ `/evaluate` | `evaluate_artwork`, `list_traditions`, `get_tradition_guide`, `search_traditions` |
 | **Create** | Generate a new image from intent + tradition guidance, optionally in structured layers. | — | `create_artwork`, `generate_image` |
 | **Discovery / Brief / Studio** | Turn fuzzy intent into direction cards, then a reviewable proposal.md; mock sketch records by default, real provider sketch only after explicit opt-in. | ✅ `/visual-discovery`, ✅ `/visual-brainstorm` | `brief_parse`, `generate_concepts(provider="mock")`, `compose_prompt_from_design` |
 | **Admin** | Expose intermediate artifacts, unload models, archive sessions. | — | `view_image`, `unload_models`, `archive_session`, `sync_data` |
@@ -141,8 +141,8 @@ User intent ─▶ Claude Code (planning) ─▶ Vulca MCP tools ─▶ Image ar
 
 ### Roadmap — no promises, just honest order
 
-- **Next skill:** `/evaluate` — reactivates the EMNLP anchor for agent-driven cultural scoring
-- **Then:** `/inpaint` (region-level edit), `/layered-create` (structured generation)
+- **Next skill:** `/inpaint` (region-level edit), once v0.22 redraw routes are hardened
+- **Then:** `/layered-create` (structured generation)
 - **Beyond:** community-driven — file an issue with your workflow
 
 See [docs/agent-native-workflow.md](docs/agent-native-workflow.md) for the deeper walkthrough.
@@ -152,7 +152,7 @@ See [docs/agent-native-workflow.md](docs/agent-native-workflow.md) for the deepe
 <details>
 <summary><strong>Evaluate — three modes (L1–L5 cultural scoring)</strong></summary>
 
-Beyond decomposition, Vulca evaluates any image against a cultural tradition across 5 dimensions (L1 Visual Perception, L2 Technical Execution, L3 Cultural Context, L4 Critical Interpretation, L5 Philosophical Aesthetics) in three modes. The MCP tool is `evaluate_artwork`; the CLI is `vulca evaluate`. No agent skill yet — **`/evaluate` is next on the roadmap**.
+Beyond decomposition, Vulca evaluates any image against a cultural tradition across 5 dimensions (L1 Visual Perception, L2 Technical Execution, L3 Cultural Context, L4 Critical Interpretation, L5 Philosophical Aesthetics) in three modes. The MCP tool is `evaluate_artwork`; the CLI is `vulca evaluate`. The `/evaluate` skill wraps `evaluate_artwork` for agent-led critique and next-action guidance.
 
 ### Strict (binary cultural judgment)
 
@@ -415,7 +415,7 @@ $ vulca evolution chinese_xieyi
   Sessions: 71
 ```
 
-From an agent: the `evaluate_artwork` MCP tool returns evolved weights alongside scores; no separate skill needed.
+From an agent: `/evaluate` calls the `evaluate_artwork` MCP tool and returns evolved weights alongside scores.
 
 </details>
 

--- a/docs/product/roadmap.md
+++ b/docs/product/roadmap.md
@@ -10,14 +10,13 @@ Vulca is an agent-native visual control layer. The product turns fuzzy visual in
 - `/decompose`: semantic layer extraction into transparent PNG artifacts.
 - `/visual-discovery`: fuzzy intent -> taste profile -> direction cards -> discovery artifacts.
 - `/visual-brainstorm`, `/visual-spec`, `/visual-plan`: proposal/design/plan workflow for controlled generation.
+- `/evaluate`: user-facing evaluation skill over existing `evaluate_artwork`.
 - Provider registry: `mock`, `gemini`, `nb2`, `openai`, `comfyui`.
 - MCP tools for image generation, image viewing, evaluation, inpainting, layers, redraw, compositing, paste-back, and Tool Protocol analysis.
 - 13 cultural traditions and L1-L5 evaluation framework.
 
 ## Next
 
-- README repositioning around the full Discover -> Spec -> Generate -> Edit -> Evaluate workflow.
-- `/evaluate` skill packaging on top of existing `evaluate_artwork`.
 - Provider capability matrix for public docs.
 - Cultural-term efficacy benchmark.
 

--- a/docs/superpowers/plans/2026-04-30-evaluate-skill.md
+++ b/docs/superpowers/plans/2026-04-30-evaluate-skill.md
@@ -1,0 +1,381 @@
+# Evaluate Skill Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship `/evaluate` as a minimal user-facing skill over existing `evaluate_artwork`, closing the Discover -> Spec -> Generate/Edit -> Evaluate loop.
+
+**Architecture:** This is a skill/docs/test packaging change. It adds `.agents` and `.claude` skill files, updates the Vulca skill router, updates README/product roadmap wording, and adds contract tests. It does not change runtime scoring code, provider code, redraw code, or evaluation algorithms.
+
+**Tech Stack:** Markdown skills, pytest doc/skill contract tests, existing MCP `evaluate_artwork`, existing `view_image` and `get_tradition_guide`.
+
+---
+
+## Task 1: Add Evaluate Skill Contract Tests
+
+**Files:**
+- Create: `tests/test_evaluate_skill_contract.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `tests/test_evaluate_skill_contract.py` with:
+
+```python
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+AGENTS_SKILL = ROOT / ".agents" / "skills" / "evaluate" / "SKILL.md"
+CLAUDE_SKILL = ROOT / ".claude" / "skills" / "evaluate" / "SKILL.md"
+AGENTS_ROUTER = ROOT / ".agents" / "skills" / "using-vulca-skills" / "SKILL.md"
+CLAUDE_ROUTER = ROOT / ".claude" / "skills" / "using-vulca-skills" / "SKILL.md"
+
+
+def test_evaluate_skill_exists_and_wraps_existing_tool():
+    body = AGENTS_SKILL.read_text(encoding="utf-8")
+
+    assert "name: evaluate" in body
+    assert "evaluate_artwork" in body
+    assert "view_image" in body
+    assert "get_tradition_guide" in body
+    assert "L1-L5" in body
+    assert "evaluation.md" in body
+    assert "evaluation.json" in body
+
+
+def test_evaluate_skill_bans_generation_and_layer_tools():
+    body = AGENTS_SKILL.read_text(encoding="utf-8")
+
+    assert "`generate_image`" in body
+    assert "`create_artwork`" in body
+    assert "`generate_concepts`" in body
+    assert "`inpaint_artwork`" in body
+    assert "`layers_*`" in body
+    assert "must not execute pixel edits" in body.lower()
+
+
+def test_router_invokes_evaluate_for_scoring_requests():
+    body = AGENTS_ROUTER.read_text(encoding="utf-8")
+
+    assert "evaluate an existing image" in body
+    assert "`evaluate`" in body
+    assert "L1-L5" in body
+    assert "文化评分" in body
+
+
+def test_claude_mirror_matches_evaluate_routing():
+    skill = CLAUDE_SKILL.read_text(encoding="utf-8")
+    router = CLAUDE_ROUTER.read_text(encoding="utf-8")
+
+    assert "name: evaluate" in skill
+    assert "evaluate_artwork" in skill
+    assert "evaluation.md" in skill
+    assert "evaluate an existing image" in router
+```
+
+- [ ] **Step 2: Run tests and confirm failure**
+
+Run:
+
+```bash
+PYTHONPATH=src pytest tests/test_evaluate_skill_contract.py -q
+```
+
+Expected: failure because the evaluate skill files do not exist.
+
+---
+
+## Task 2: Add `/evaluate` Skill
+
+**Files:**
+- Create: `.agents/skills/evaluate/SKILL.md`
+- Create: `.claude/skills/evaluate/SKILL.md`
+
+- [ ] **Step 1: Create the skill body**
+
+Create `.agents/skills/evaluate/SKILL.md` with:
+
+```markdown
+---
+name: evaluate
+description: Evaluate an existing visual artifact against a tradition, intent, and L1-L5 cultural/visual rubric.
+---
+
+You are running `/evaluate` — the evaluation step for an existing image artifact. Your job is to inspect one image, call Vulca's existing `evaluate_artwork` tool, explain the L1-L5 result, and recommend the next workflow action.
+
+## Triggers
+
+- Slash command: `/evaluate <image_path>` or `/evaluate <slug>`
+- Chinese aliases: `评价这张图`, `文化评分`, `L1-L5 评分`, `帮我判断这张图`
+- Intent auto-match: the user asks whether an image fits a tradition, brief, culture, or visual direction; asks for cultural critique; asks for L1-L5 scoring; or asks what to improve after generation.
+
+## Scope
+
+Evaluate one existing image. Do not generate, edit, redraw, decompose, or composite images.
+
+## Inputs
+
+- Required: `image_path` or `slug`.
+- Optional: `tradition`, `intent`, `mode`, `mock`, `vlm_model`, `write_artifacts`.
+- `mode`: `strict`, `reference`, or `rubric_only`.
+- `mock`: only for no-cost shape checks and tests. Never present mock scores as real quality evidence.
+
+## Path Resolution
+
+If the user provides a file path, verify it exists before calling any tool.
+
+If the user provides a slug, search in this order:
+
+1. `docs/visual-specs/<slug>/iters/**/gen_*`
+2. `docs/visual-specs/<slug>/iters/**/*.{png,jpg,jpeg,webp}`
+3. `docs/visual-specs/<slug>/source.{png,jpg,jpeg,webp}`
+
+If more than one image is found, ask the user which image to evaluate.
+
+## Allowed Tools
+
+- `view_image`
+- `get_tradition_guide`
+- `evaluate_artwork`
+- Read/write project docs
+
+## Forbidden Tools
+
+- `generate_image`
+- `create_artwork`
+- `generate_concepts`
+- `inpaint_artwork`
+- `layers_*`
+
+If the evaluation recommends an edit, explain the next action. You must not execute pixel edits from this skill.
+
+## Workflow
+
+1. Resolve and verify the image path.
+2. If a tradition is provided, call `get_tradition_guide(tradition)` and use it to explain L1-L5 context.
+3. Call `view_image(image_path)` when visual grounding is useful.
+4. Call `evaluate_artwork(image_path, tradition=<tradition>, intent=<intent>, mode=<mode>, mock=<mock>, vlm_model=<vlm_model>)`.
+5. Extract `score`, `tradition`, `dimensions`, `rationales`, `recommendations`, `risk_flags`, and `risk_level`.
+6. If all L1-L5 scores are zero or missing, mark the result as suspect and recommend rerunning with a real VLM or checking credentials.
+7. Explain strongest dimensions, weakest dimensions, and concrete next action.
+8. When a slug is known or `write_artifacts=true`, write:
+   - `docs/visual-specs/<slug>/evaluation.md`
+   - `docs/visual-specs/<slug>/evaluation.json`
+
+## User-Facing Response
+
+Include:
+
+- image path
+- tradition and mode
+- overall score
+- L1-L5 summary
+- strongest dimensions
+- weakest dimensions
+- recommendations
+- risk flags
+- next action
+
+Next action must be one of:
+
+- `accept`
+- `revise prompt`
+- `rerun /visual-plan`
+- `redraw target after v0.22 route is available`
+- `run /visual-discovery`
+
+## Artifact Contract
+
+`evaluation.md`:
+
+```markdown
+# Evaluation: <slug or image stem>
+
+## Status
+evaluated
+
+## Image
+<path>
+
+## Tradition
+<tradition>
+
+## Mode
+<mode>
+
+## Overall Score
+<score or unavailable>
+
+## L1-L5
+<table>
+
+## Recommendations
+<bullets>
+
+## Risk Flags
+<bullets or none>
+
+## Next Action
+<decision>
+```
+
+`evaluation.json`:
+
+```json
+{
+  "schema_version": "0.1",
+  "image_path": "...",
+  "tradition": "...",
+  "mode": "...",
+  "intent": "...",
+  "evaluate_artwork": {}
+}
+```
+```
+
+Copy the same file to `.claude/skills/evaluate/SKILL.md`.
+
+- [ ] **Step 2: Run tests**
+
+Run:
+
+```bash
+PYTHONPATH=src pytest tests/test_evaluate_skill_contract.py -q
+```
+
+Expected: router tests still fail until Task 3.
+
+---
+
+## Task 3: Route `/evaluate`
+
+**Files:**
+- Modify: `.agents/skills/using-vulca-skills/SKILL.md`
+- Modify: `.claude/skills/using-vulca-skills/SKILL.md`
+
+- [ ] **Step 1: Update router frontmatter description**
+
+Change description to include:
+
+```text
+discovery -> brainstorm -> spec -> plan -> evaluate chain
+```
+
+- [ ] **Step 2: Add route row**
+
+Add this row before `/visual-plan`:
+
+```markdown
+| evaluate an existing image against a tradition/brief, ask for L1-L5 scoring, cultural critique, "评价这张图", "文化评分"; image already exists | `evaluate` |
+```
+
+- [ ] **Step 3: Add reference**
+
+Add `.agents/skills/evaluate/SKILL.md` and `.claude/skills/evaluate/SKILL.md` to each router reference list respectively.
+
+- [ ] **Step 4: Run tests**
+
+Run:
+
+```bash
+PYTHONPATH=src pytest tests/test_evaluate_skill_contract.py tests/test_visual_discovery_skill_contract.py -q
+```
+
+Expected: pass.
+
+---
+
+## Task 4: Update README and Product Roadmap
+
+**Files:**
+- Modify: `README.md`
+- Modify: `docs/product/roadmap.md`
+- Modify: `tests/test_visual_discovery_docs_truth.py`
+
+- [ ] **Step 1: Add doc truth assertions**
+
+Extend `tests/test_visual_discovery_docs_truth.py` with:
+
+```python
+def test_readme_and_roadmap_mark_evaluate_skill_current():
+    readme = (ROOT / "README.md").read_text(encoding="utf-8")
+    roadmap = (ROOT / "docs" / "product" / "roadmap.md").read_text(
+        encoding="utf-8"
+    )
+
+    assert "✅ `/evaluate`" in readme
+    assert "`/evaluate`: user-facing evaluation skill" in roadmap
+    assert "/evaluate` skill packaging" not in roadmap
+```
+
+- [ ] **Step 2: Run tests and confirm failure**
+
+Run:
+
+```bash
+PYTHONPATH=src pytest tests/test_visual_discovery_docs_truth.py -q
+```
+
+Expected: failure until README/roadmap are updated.
+
+- [ ] **Step 3: Update README**
+
+In README:
+
+- Change Evaluate row in "What Vulca takes off your agent's hands" from Roadmap to `✅ /evaluate`.
+- In the Evaluate details section, replace "No agent skill yet — `/evaluate` is next on the roadmap" with "The `/evaluate` skill wraps `evaluate_artwork` for agent-led critique and next-action guidance."
+- In the top capability matrix, change Evaluate status from "Tool current, skill next" to "Current".
+
+- [ ] **Step 4: Update roadmap**
+
+In `docs/product/roadmap.md`:
+
+- Add current bullet: `` `/evaluate`: user-facing evaluation skill over existing `evaluate_artwork`. ``
+- Remove the "Next" bullet for `/evaluate` skill packaging.
+
+- [ ] **Step 5: Run docs tests**
+
+Run:
+
+```bash
+PYTHONPATH=src pytest tests/test_visual_discovery_docs_truth.py -q
+```
+
+Expected: pass.
+
+---
+
+## Task 5: Final Verification and Commit
+
+**Files:**
+- All above.
+
+- [ ] **Step 1: Run focused tests**
+
+Run:
+
+```bash
+PYTHONPATH=src pytest tests/test_evaluate_skill_contract.py tests/test_visual_discovery_skill_contract.py tests/test_visual_discovery_docs_truth.py tests/test_evaluate.py tests/test_mcp_v2.py tests/test_mcp_server.py -q
+```
+
+Expected: pass.
+
+- [ ] **Step 2: Scan for unfinished markers**
+
+Run:
+
+```bash
+grep -RInE "TB[D]|TO[D]O|lo[r]em|coming soo[n]" .agents/skills/evaluate .claude/skills/evaluate docs/superpowers/specs/2026-04-30-evaluate-skill-design.md docs/superpowers/plans/2026-04-30-evaluate-skill.md README.md docs/product/roadmap.md
+```
+
+Expected: no matches.
+
+- [ ] **Step 3: Commit**
+
+Run:
+
+```bash
+git add .agents/skills/evaluate/SKILL.md .claude/skills/evaluate/SKILL.md .agents/skills/using-vulca-skills/SKILL.md .claude/skills/using-vulca-skills/SKILL.md README.md docs/product/roadmap.md docs/superpowers/specs/2026-04-30-evaluate-skill-design.md docs/superpowers/plans/2026-04-30-evaluate-skill.md tests/test_evaluate_skill_contract.py tests/test_visual_discovery_docs_truth.py
+git commit -m "feat: add evaluate skill"
+```

--- a/docs/superpowers/specs/2026-04-30-evaluate-skill-design.md
+++ b/docs/superpowers/specs/2026-04-30-evaluate-skill-design.md
@@ -1,0 +1,214 @@
+# `/evaluate` Skill Design Spec
+
+**Date:** 2026-04-30
+**Status:** Approved minimal v1 design
+**Depends on:** `codex/product-positioning-plan`
+**Scope:** Agent skill packaging for existing `evaluate_artwork`; no runtime scoring changes
+
+`/evaluate` closes the first product loop after `/visual-discovery` and `/visual-plan`: a user can score an existing image, understand L1-L5 strengths and failures, and choose the next action. The skill exposes the existing `evaluate_artwork` MCP tool as a disciplined agent workflow rather than adding a new scoring implementation.
+
+---
+
+## 1. Product Role
+
+`/evaluate` is the first user-facing evaluation skill. It completes this loop:
+
+```text
+Discover -> Spec -> Generate/Edit -> Evaluate -> Iterate
+```
+
+It should be positioned as:
+
+```text
+Evaluate a finished or intermediate visual artifact against a tradition, intent,
+and L1-L5 cultural/visual rubric.
+```
+
+The skill turns numeric scoring into product behavior: accept, revise prompt, redraw a target, or rerun a plan.
+
+---
+
+## 2. Scope
+
+### In Scope
+
+- Evaluate one existing image path.
+- Support `tradition`, `intent`, `mode`, `mock`, and `vlm_model` options.
+- Call `view_image` before scoring when image grounding is useful.
+- Call `get_tradition_guide` when a tradition is supplied.
+- Call `evaluate_artwork`.
+- Summarize score, L1-L5 dimensions, rationales, recommendations, risk flags, and next action.
+- Optionally write an evaluation artifact beside a visual project:
+  - `docs/visual-specs/<slug>/evaluation.md`
+  - `docs/visual-specs/<slug>/evaluation.json`
+
+### Out of Scope
+
+- Changing `evaluate_artwork` scoring behavior.
+- Running generation.
+- Running layer tools, redraw, inpaint, or composite.
+- Running cultural-term efficacy benchmarks.
+- Comparing multiple candidate images in v1.
+- Updating `plan.md` or `design.md`.
+
+---
+
+## 3. Triggering
+
+Explicit:
+
+- `/evaluate <image_path>`
+- `/evaluate <slug>`
+
+Chinese aliases:
+
+- `评价这张图`
+- `文化评分`
+- `L1-L5 评分`
+- `帮我判断这张图`
+
+Intent auto-match:
+
+- user asks whether an image fits a tradition/brief;
+- user asks for L1-L5 score;
+- user asks for cultural critique of a generated image;
+- user asks what to improve after generation.
+
+If the user asks to run a generation loop, route to `/visual-plan`, not `/evaluate`.
+
+---
+
+## 4. Inputs
+
+Required:
+
+- `image_path`, or a `slug` that can resolve to a recent image artifact.
+
+Optional:
+
+- `tradition`: default auto-detect / `default`.
+- `intent`: user's brief or desired expression.
+- `mode`: `strict`, `reference`, or `rubric_only`.
+- `mock`: explicit no-cost scoring mode for tests/demos.
+- `vlm_model`: override VLM model.
+- `write_artifacts`: default true when slug is known, false for ad hoc image paths.
+
+Path rule:
+
+- Reject missing image paths before calling `evaluate_artwork`.
+- If slug is provided, search in this order:
+  - `docs/visual-specs/<slug>/iters/**/gen_*`
+  - `docs/visual-specs/<slug>/iters/**/*.{png,jpg,jpeg,webp}`
+  - `docs/visual-specs/<slug>/source.{png,jpg,jpeg,webp}`
+
+---
+
+## 5. Tool Policy
+
+Allowed:
+
+- `view_image`
+- `get_tradition_guide`
+- `evaluate_artwork`
+- read/write project docs
+
+Forbidden:
+
+- `generate_image`
+- `create_artwork`
+- `generate_concepts`
+- `inpaint_artwork`
+- any `layers_*` tool
+- modifying `design.md` or `plan.md`
+
+If evaluation recommends an edit, the skill should produce next-action guidance only. It must not execute pixel edits.
+
+---
+
+## 6. Output Contract
+
+The user-facing response must include:
+
+- image path;
+- tradition and mode;
+- overall score if present;
+- L1-L5 summary;
+- strongest dimensions;
+- weakest dimensions;
+- recommendations;
+- risk flags if any;
+- next action:
+  - `accept`
+  - `revise prompt`
+  - `rerun /visual-plan`
+  - `redraw target after v0.22 route is available`
+  - `run /visual-discovery` if the brief is unclear
+
+Artifact markdown should include:
+
+```markdown
+# Evaluation: <slug or image stem>
+
+## Status
+evaluated
+
+## Image
+<path>
+
+## Tradition
+<tradition>
+
+## Mode
+<mode>
+
+## Overall Score
+<score or unavailable>
+
+## L1-L5
+<table>
+
+## Recommendations
+<bullets>
+
+## Risk Flags
+<bullets or none>
+
+## Next Action
+<decision>
+```
+
+JSON artifact should preserve the raw `evaluate_artwork` return plus metadata:
+
+```json
+{
+  "schema_version": "0.1",
+  "image_path": "...",
+  "tradition": "...",
+  "mode": "...",
+  "intent": "...",
+  "evaluate_artwork": {}
+}
+```
+
+---
+
+## 7. Error Handling
+
+- Missing image path: stop and ask for a path or slug.
+- Image file does not exist: stop before tool call and show exact path checked.
+- Unknown tradition: call `list_traditions` or ask the user to choose a supported tradition.
+- `evaluate_artwork` returns error: show the error and recommend `mock=True` only for no-cost shape checks.
+- All-zero scores: mark result as suspect and recommend rerunning with a real VLM or checking provider credentials.
+
+---
+
+## 8. Acceptance Criteria
+
+- `.agents/skills/evaluate/SKILL.md` exists.
+- `.claude/skills/evaluate/SKILL.md` mirror exists.
+- `using-vulca-skills` routes evaluation requests to `evaluate`.
+- Skill bans generation and layer tools.
+- README says `/evaluate` is current, not next.
+- Product roadmap lists `/evaluate` as current.
+- Tests verify skill contract and router mirror.
+- Existing `evaluate_artwork` tests still pass.

--- a/tests/test_evaluate_skill_contract.py
+++ b/tests/test_evaluate_skill_contract.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+AGENTS_SKILL = ROOT / ".agents" / "skills" / "evaluate" / "SKILL.md"
+CLAUDE_SKILL = ROOT / ".claude" / "skills" / "evaluate" / "SKILL.md"
+AGENTS_ROUTER = ROOT / ".agents" / "skills" / "using-vulca-skills" / "SKILL.md"
+CLAUDE_ROUTER = ROOT / ".claude" / "skills" / "using-vulca-skills" / "SKILL.md"
+
+
+def test_evaluate_skill_exists_and_wraps_existing_tool():
+    body = AGENTS_SKILL.read_text(encoding="utf-8")
+
+    assert "name: evaluate" in body
+    assert "evaluate_artwork" in body
+    assert "view_image" in body
+    assert "get_tradition_guide" in body
+    assert "L1-L5" in body
+    assert "evaluation.md" in body
+    assert "evaluation.json" in body
+
+
+def test_evaluate_skill_bans_generation_and_layer_tools():
+    body = AGENTS_SKILL.read_text(encoding="utf-8")
+
+    assert "`generate_image`" in body
+    assert "`create_artwork`" in body
+    assert "`generate_concepts`" in body
+    assert "`inpaint_artwork`" in body
+    assert "`layers_*`" in body
+    assert "must not execute pixel edits" in body.lower()
+
+
+def test_router_invokes_evaluate_for_scoring_requests():
+    body = AGENTS_ROUTER.read_text(encoding="utf-8")
+
+    assert "evaluate an existing image" in body
+    assert "`evaluate`" in body
+    assert "L1-L5" in body
+    assert "文化评分" in body
+
+
+def test_claude_mirror_matches_evaluate_routing():
+    skill = CLAUDE_SKILL.read_text(encoding="utf-8")
+    router = CLAUDE_ROUTER.read_text(encoding="utf-8")
+
+    assert "name: evaluate" in skill
+    assert "evaluate_artwork" in skill
+    assert "evaluation.md" in skill
+    assert "evaluate an existing image" in router

--- a/tests/test_visual_discovery_docs_truth.py
+++ b/tests/test_visual_discovery_docs_truth.py
@@ -30,6 +30,19 @@ def test_readme_mentions_visual_discovery_and_mock_boundary():
     assert "real provider sketch" in readme.lower()
 
 
+def test_readme_and_roadmap_mark_evaluate_skill_current():
+    readme = (ROOT / "README.md").read_text(encoding="utf-8")
+    roadmap = (ROOT / "docs" / "product" / "roadmap.md").read_text(
+        encoding="utf-8"
+    )
+
+    assert "✅ `/evaluate`" in readme
+    assert "`/evaluate`: user-facing evaluation skill" in roadmap
+    assert "/evaluate` skill packaging" not in roadmap
+    assert "no separate skill needed" not in readme
+    assert "no agent skill yet" not in readme.lower()
+
+
 def test_readme_leads_with_full_visual_workflow():
     readme = (ROOT / "README.md").read_text(encoding="utf-8")
     first_screen = readme[:2500].lower()


### PR DESCRIPTION
Summary: Adds /evaluate skill wrappers for .agents and .claude over existing evaluate_artwork; routes evaluation intent through using-vulca-skills; moves /evaluate docs from roadmap to current and adds contract/truth tests. Test plan: PYTHONPATH=src pytest tests/test_evaluate_skill_contract.py tests/test_visual_discovery_skill_contract.py tests/test_visual_discovery_docs_truth.py tests/test_evaluate.py tests/test_mcp_v2.py tests/test_mcp_server.py -q; git diff --check.