### PR TITLE
[codex] add cultural term efficacy harness

### DIFF
--- a/docs/product/experiments/cultural-term-efficacy.md
+++ b/docs/product/experiments/cultural-term-efficacy.md
@@ -24,6 +24,16 @@ Do cultural and taste terms improve generated visual outputs, or do concrete vis
 
 `mock` may validate artifact structure but must not be used for quality conclusions.
 
+## Harness
+
+Run the no-cost dry-run harness with:
+
+```bash
+PYTHONPATH=src python3 scripts/visual_discovery_benchmark.py --date 2026-04-30
+```
+
+The harness writes prompts, manifests, empty result records, and summaries. It does not call OpenAI, Gemini, ComfyUI, or `mock` for quality evidence. Real provider execution is a future explicit opt-in path and is disabled in this version.
+
 ## Projects
 
 Run at least three domains:

--- a/docs/product/roadmap.md
+++ b/docs/product/roadmap.md
@@ -12,12 +12,12 @@ Vulca is an agent-native visual control layer. The product turns fuzzy visual in
 - `/visual-brainstorm`, `/visual-spec`, `/visual-plan`: proposal/design/plan workflow for controlled generation.
 - `/evaluate`: user-facing evaluation skill over existing `evaluate_artwork`.
 - Provider registry: `mock`, `gemini`, `nb2`, `openai`, `comfyui`.
+- `docs/product/provider-capabilities.md`: provider/platform capability matrix.
 - MCP tools for image generation, image viewing, evaluation, inpainting, layers, redraw, compositing, paste-back, and Tool Protocol analysis.
 - 13 cultural traditions and L1-L5 evaluation framework.
 
 ## Next
 
-- Provider capability matrix for public docs.
 - Cultural-term efficacy benchmark.
 
 ## In Parallel

--- a/docs/superpowers/plans/2026-04-30-cultural-term-efficacy-harness.md
+++ b/docs/superpowers/plans/2026-04-30-cultural-term-efficacy-harness.md
@@ -582,7 +582,7 @@ In `docs/product/experiments/cultural-term-efficacy.md`, add this section after 
 Run the no-cost dry-run harness with:
 
 ```bash
-PYTHONPATH=src python scripts/visual_discovery_benchmark.py --date 2026-04-30
+PYTHONPATH=src python3 scripts/visual_discovery_benchmark.py --date 2026-04-30
 ```
 
 The harness writes prompts, manifests, empty result records, and summaries. It does not call OpenAI, Gemini, ComfyUI, or `mock` for quality evidence. Real provider execution is a future explicit opt-in path and is disabled in this version.
@@ -618,7 +618,7 @@ Expected: pass.
 Run:
 
 ```bash
-PYTHONPATH=src python scripts/visual_discovery_benchmark.py --output-root /private/tmp/vulca-cultural-term-efficacy --date 2026-04-30
+PYTHONPATH=src python3 scripts/visual_discovery_benchmark.py --output-root /private/tmp/vulca-cultural-term-efficacy --date 2026-04-30
 ```
 
 Expected: command exits 0 and writes three result directories under `/private/tmp/vulca-cultural-term-efficacy`.

--- a/docs/superpowers/plans/2026-04-30-cultural-term-efficacy-harness.md
+++ b/docs/superpowers/plans/2026-04-30-cultural-term-efficacy-harness.md
@@ -1,0 +1,653 @@
+# Cultural-Term Efficacy Harness Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a no-cost dry-run harness for the cultural-term efficacy experiment so Vulca can test whether culture terms, visual operations, avoid lists, and evaluation criteria actually improve model outputs.
+
+**Architecture:** Extend the existing `scripts/visual_discovery_benchmark.py` into a deterministic experiment artifact writer. The harness produces A/B/C/D prompt conditions, built-in project fixtures, manifest/results skeletons, and product docs, while keeping real providers disabled by default.
+
+**Tech Stack:** Python standard library, existing `vulca.discovery` dataclasses/functions, pytest, Markdown product docs.
+
+---
+
+## File Map
+
+- Modify `scripts/visual_discovery_benchmark.py`: experiment fixtures, A-D condition builder, dry-run artifact writer, fail-closed real-provider stub, CLI.
+- Modify `tests/test_visual_discovery_benchmark.py`: TDD contract for fixtures, conditions, artifact skeleton, and real-provider safety.
+- Modify `tests/test_visual_discovery_docs_truth.py`: roadmap consistency and public-claim guardrails.
+- Modify `docs/product/roadmap.md`: move provider capability matrix into Current.
+- Modify `docs/product/experiments/cultural-term-efficacy.md`: document the dry-run harness and explicit opt-in boundary.
+
+## Task 1: Add Roadmap Consistency Tests
+
+**Files:**
+- Modify: `tests/test_visual_discovery_docs_truth.py`
+
+- [ ] **Step 1: Write failing docs truth test**
+
+Append this test after `test_readme_and_roadmap_mark_evaluate_skill_current`:
+
+```python
+def test_roadmap_marks_provider_matrix_current():
+    roadmap = (ROOT / "docs" / "product" / "roadmap.md").read_text(
+        encoding="utf-8"
+    )
+    provider_matrix = (
+        ROOT / "docs" / "product" / "provider-capabilities.md"
+    ).read_text(encoding="utf-8")
+
+    assert "Vulca Provider and Platform Capability Matrix" in provider_matrix
+    assert (
+        "`docs/product/provider-capabilities.md`: provider/platform capability matrix"
+        in roadmap
+    )
+    assert "Provider capability matrix for public docs" not in roadmap
+```
+
+- [ ] **Step 2: Verify RED**
+
+Run:
+
+```bash
+PYTHONPATH=src pytest tests/test_visual_discovery_docs_truth.py -q
+```
+
+Expected: one failure because `docs/product/roadmap.md` still lists the provider matrix under Next instead of Current.
+
+## Task 2: Add Benchmark Harness Contract Tests
+
+**Files:**
+- Modify: `tests/test_visual_discovery_benchmark.py`
+
+- [ ] **Step 1: Replace benchmark tests with the A-D harness contract**
+
+Replace `tests/test_visual_discovery_benchmark.py` with:
+
+```python
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+def test_experiment_projects_match_protocol_domains():
+    from scripts.visual_discovery_benchmark import build_experiment_projects
+
+    projects = build_experiment_projects()
+
+    assert [project.slug for project in projects] == [
+        "premium-tea-packaging",
+        "spiritual-editorial-poster",
+        "cultural-material-campaign",
+    ]
+    assert "xieyi restraint" in projects[0].prompt
+    assert "spiritual but non-religious" in projects[1].prompt
+    assert "material references" in projects[2].prompt
+
+
+def test_build_conditions_a_through_d():
+    from scripts.visual_discovery_benchmark import (
+        build_conditions,
+        build_experiment_projects,
+        select_direction_card,
+    )
+
+    project = build_experiment_projects()[0]
+    card = select_direction_card(project)
+
+    conditions = build_conditions(project.prompt, card)
+
+    assert [condition["id"] for condition in conditions] == ["A", "B", "C", "D"]
+    assert conditions[0]["label"] == "User prompt only"
+    assert conditions[0]["source_card_id"] == ""
+    assert "cultural terms" in conditions[1]["label"].lower()
+    assert card.culture_terms[0] in conditions[1]["prompt"]
+    assert "Visual operations:" in conditions[2]["prompt"]
+    assert conditions[3]["label"] == "Full direction-card prompt"
+    assert conditions[3]["negative_prompt"]
+    assert conditions[3]["evaluation_focus"]["L1"]
+    assert conditions[3]["source_card_id"] == card.id
+
+
+def test_write_experiment_dry_run_artifacts(tmp_path):
+    from scripts.visual_discovery_benchmark import write_experiment_dry_run
+
+    result = write_experiment_dry_run(
+        output_root=tmp_path,
+        slug="premium-tea-packaging",
+        date="2026-04-30",
+    )
+
+    out_dir = Path(result["output_dir"])
+    assert out_dir == tmp_path / "2026-04-30-premium-tea-packaging"
+    for condition_id in ["A", "B", "C", "D"]:
+        assert (out_dir / "prompts" / f"{condition_id}.txt").exists()
+    assert (out_dir / "images" / "README.md").exists()
+    assert (out_dir / "evaluations" / "README.md").exists()
+
+    manifest = json.loads((out_dir / "manifest.json").read_text(encoding="utf-8"))
+    assert manifest["schema_version"] == "0.1"
+    assert manifest["experiment"] == "cultural-term-efficacy"
+    assert manifest["mode"] == "dry_run"
+    assert manifest["provider_execution"] == "disabled"
+    assert manifest["project"]["slug"] == "premium-tea-packaging"
+    assert [condition["id"] for condition in manifest["conditions"]] == [
+        "A",
+        "B",
+        "C",
+        "D",
+    ]
+    assert {provider["execution"] for provider in manifest["providers"]} == {
+        "not_run"
+    }
+
+    human_ranking = json.loads(
+        (out_dir / "human_ranking.json").read_text(encoding="utf-8")
+    )
+    provider_costs = json.loads(
+        (out_dir / "provider_costs.json").read_text(encoding="utf-8")
+    )
+    assert human_ranking["status"] == "not_collected"
+    assert provider_costs["status"] == "not_collected"
+    assert "No image quality conclusion" in (
+        out_dir / "summary.md"
+    ).read_text(encoding="utf-8")
+
+
+def test_real_provider_execution_fails_closed():
+    from scripts.visual_discovery_benchmark import run_real_provider_experiment
+
+    with pytest.raises(RuntimeError, match="explicit opt-in"):
+        run_real_provider_experiment(real_provider=False)
+```
+
+- [ ] **Step 2: Verify RED**
+
+Run:
+
+```bash
+PYTHONPATH=src pytest tests/test_visual_discovery_benchmark.py -q
+```
+
+Expected: failures because the script still emits A-F conditions and lacks the project fixtures, dry-run artifact writer, and fail-closed real-provider function.
+
+## Task 3: Implement the Dry-Run Harness
+
+**Files:**
+- Modify: `scripts/visual_discovery_benchmark.py`
+
+- [ ] **Step 1: Replace the benchmark script implementation**
+
+Replace `scripts/visual_discovery_benchmark.py` with:
+
+```python
+"""Dry-run harness for the cultural-term efficacy experiment."""
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import dataclass
+from datetime import date as date_type
+from pathlib import Path
+from typing import Any
+
+from vulca.discovery.cards import generate_direction_cards
+from vulca.discovery.profile import infer_taste_profile
+from vulca.discovery.prompting import compose_prompt_from_direction_card
+from vulca.discovery.types import DirectionCard
+
+
+PROVIDERS = [
+    {
+        "label": "OpenAI GPT Image",
+        "provider": "openai",
+        "model": "gpt-image-2",
+    },
+    {
+        "label": "Gemini image",
+        "provider": "gemini",
+        "model": "gemini-3.1-flash-image-preview",
+    },
+    {"label": "ComfyUI", "provider": "comfyui", "model": ""},
+]
+
+
+@dataclass(frozen=True)
+class ExperimentProject:
+    slug: str
+    prompt: str
+    domain: str
+    tradition_terms: tuple[str, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "slug": self.slug,
+            "prompt": self.prompt,
+            "domain": self.domain,
+            "tradition_terms": list(self.tradition_terms),
+        }
+
+
+def build_experiment_projects() -> list[ExperimentProject]:
+    return [
+        ExperimentProject(
+            slug="premium-tea-packaging",
+            prompt="premium tea packaging with xieyi restraint",
+            domain="packaging",
+            tradition_terms=("chinese_xieyi", "liu bai", "ink restraint"),
+        ),
+        ExperimentProject(
+            slug="spiritual-editorial-poster",
+            prompt="editorial poster with spiritual but non-religious atmosphere",
+            domain="editorial poster",
+            tradition_terms=("sacred atmosphere", "quiet symbolism", "restraint"),
+        ),
+        ExperimentProject(
+            slug="cultural-material-campaign",
+            prompt=(
+                "product campaign visual with culturally specific material "
+                "references"
+            ),
+            domain="campaign visual",
+            tradition_terms=("material culture", "specific craft", "local texture"),
+        ),
+    ]
+
+
+def get_experiment_project(slug: str) -> ExperimentProject:
+    for project in build_experiment_projects():
+        if project.slug == slug:
+            return project
+    known = ", ".join(project.slug for project in build_experiment_projects())
+    raise ValueError(f"unknown project slug: {slug!r}; expected one of: {known}")
+
+
+def select_direction_card(project: ExperimentProject) -> DirectionCard:
+    profile = infer_taste_profile(
+        slug=project.slug,
+        intent=f"{project.prompt}; {'; '.join(project.tradition_terms)}",
+    )
+    return generate_direction_cards(profile, count=3)[0]
+
+
+def _visual_ops_text(card: DirectionCard) -> str:
+    ops = card.visual_ops
+    return "; ".join(
+        part
+        for part in [
+            ops.composition,
+            ops.color,
+            ops.texture,
+            ops.lighting,
+            ops.camera,
+            ops.typography,
+            ops.symbol_strategy,
+        ]
+        if part
+    )
+
+
+def build_conditions(base_prompt: str, card: DirectionCard) -> list[dict[str, Any]]:
+    raw_terms = ", ".join(card.culture_terms)
+    visual_ops = _visual_ops_text(card)
+    compiled = compose_prompt_from_direction_card(card, target="final")
+    return [
+        {
+            "id": "A",
+            "label": "User prompt only",
+            "prompt": base_prompt,
+            "negative_prompt": "",
+            "source_card_id": "",
+            "culture_terms": [],
+            "evaluation_focus": {},
+        },
+        {
+            "id": "B",
+            "label": "User prompt + cultural terms",
+            "prompt": f"{base_prompt}. Cultural terms: {raw_terms}",
+            "negative_prompt": "",
+            "source_card_id": card.id,
+            "culture_terms": list(card.culture_terms),
+            "evaluation_focus": {},
+        },
+        {
+            "id": "C",
+            "label": "User prompt + cultural terms + visual operations",
+            "prompt": (
+                f"{base_prompt}. Cultural terms: {raw_terms}. "
+                f"Visual operations: {visual_ops}"
+            ),
+            "negative_prompt": "",
+            "source_card_id": card.id,
+            "culture_terms": list(card.culture_terms),
+            "evaluation_focus": {},
+        },
+        {
+            "id": "D",
+            "label": "Full direction-card prompt",
+            "prompt": compiled.prompt,
+            "negative_prompt": compiled.negative_prompt,
+            "source_card_id": card.id,
+            "culture_terms": list(card.culture_terms),
+            "evaluation_focus": card.evaluation_focus.to_dict(),
+        },
+    ]
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.write_text(
+        json.dumps(payload, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _provider_records() -> list[dict[str, str]]:
+    return [
+        {
+            "label": provider["label"],
+            "provider": provider["provider"],
+            "model": provider["model"],
+            "execution": "not_run",
+        }
+        for provider in PROVIDERS
+    ]
+
+
+def write_experiment_dry_run(
+    *,
+    output_root: str | Path,
+    slug: str,
+    date: str | None = None,
+) -> dict[str, str]:
+    project = get_experiment_project(slug)
+    card = select_direction_card(project)
+    conditions = build_conditions(project.prompt, card)
+    run_date = date or date_type.today().isoformat()
+    out_dir = Path(output_root) / f"{run_date}-{project.slug}"
+    prompts_dir = out_dir / "prompts"
+    images_dir = out_dir / "images"
+    evaluations_dir = out_dir / "evaluations"
+    prompts_dir.mkdir(parents=True, exist_ok=True)
+    images_dir.mkdir(parents=True, exist_ok=True)
+    evaluations_dir.mkdir(parents=True, exist_ok=True)
+
+    for condition in conditions:
+        prompt_text = condition["prompt"]
+        if condition["negative_prompt"]:
+            prompt_text += f"\n\nNegative prompt:\n{condition['negative_prompt']}"
+        if condition["evaluation_focus"]:
+            prompt_text += "\n\nEvaluation focus:\n" + json.dumps(
+                condition["evaluation_focus"],
+                ensure_ascii=False,
+                indent=2,
+            )
+        (prompts_dir / f"{condition['id']}.txt").write_text(
+            prompt_text + "\n",
+            encoding="utf-8",
+        )
+
+    images_readme = (
+        "# Images\n\n"
+        "Dry run only. Real provider images are not generated by this harness.\n"
+    )
+    evaluations_readme = (
+        "# Evaluations\n\n"
+        "Dry run only. Run `/evaluate` after real images exist.\n"
+    )
+    (images_dir / "README.md").write_text(images_readme, encoding="utf-8")
+    (evaluations_dir / "README.md").write_text(
+        evaluations_readme,
+        encoding="utf-8",
+    )
+
+    _write_json(
+        out_dir / "human_ranking.json",
+        {
+            "schema_version": "0.1",
+            "status": "not_collected",
+            "rankings": [],
+        },
+    )
+    _write_json(
+        out_dir / "provider_costs.json",
+        {
+            "schema_version": "0.1",
+            "status": "not_collected",
+            "providers": [],
+            "total_usd": 0,
+        },
+    )
+
+    manifest_conditions = [
+        {
+            "id": condition["id"],
+            "label": condition["label"],
+            "prompt_path": f"prompts/{condition['id']}.txt",
+            "source_card_id": condition["source_card_id"],
+        }
+        for condition in conditions
+    ]
+    manifest = {
+        "schema_version": "0.1",
+        "experiment": "cultural-term-efficacy",
+        "mode": "dry_run",
+        "provider_execution": "disabled",
+        "project": project.to_dict(),
+        "selected_card_id": card.id,
+        "conditions": manifest_conditions,
+        "providers": _provider_records(),
+    }
+    _write_json(out_dir / "manifest.json", manifest)
+
+    summary = f"""# Cultural-Term Efficacy Dry Run: {project.slug}
+
+## Status
+dry_run
+
+## Provider Execution
+disabled
+
+## Project
+{project.prompt}
+
+## Conditions
+{chr(10).join(f"- {item['id']}: {item['label']}" for item in conditions)}
+
+## Decision Boundary
+No image quality conclusion can be drawn from this dry run. It validates prompts,
+metadata, and result structure only.
+"""
+    (out_dir / "summary.md").write_text(summary, encoding="utf-8")
+
+    return {
+        "output_dir": str(out_dir),
+        "manifest_json": str(out_dir / "manifest.json"),
+        "summary_md": str(out_dir / "summary.md"),
+    }
+
+
+def run_real_provider_experiment(*, real_provider: bool = False) -> None:
+    if not real_provider:
+        raise RuntimeError(
+            "Real provider execution requires explicit opt-in and is disabled "
+            "for the dry-run harness."
+        )
+    raise NotImplementedError(
+        "Real provider execution is intentionally not implemented in this "
+        "harness version."
+    )
+
+
+def write_dry_run_report(path: str | Path) -> str:
+    provider_lines = "\n".join(
+        f"- {item['label']}: provider={item['provider']} "
+        f"model={item['model'] or 'default'}"
+        for item in PROVIDERS
+    )
+    report = f"""# Cultural-Term Efficacy Harness Dry Run
+
+## Providers
+{provider_lines}
+
+## Conditions
+- A: user prompt only
+- B: user prompt + cultural terms
+- C: user prompt + cultural terms + visual operations
+- D: full direction-card prompt with avoid list and evaluation focus
+
+No image quality conclusion can be drawn from this dry run.
+"""
+    p = Path(path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(report, encoding="utf-8")
+    return report
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Write cultural-term efficacy dry-run artifacts."
+    )
+    parser.add_argument("--slug", default="all")
+    parser.add_argument(
+        "--output-root",
+        default="docs/product/experiments/results",
+    )
+    parser.add_argument("--date", default=date_type.today().isoformat())
+    parser.add_argument("--real-provider", action="store_true")
+    args = parser.parse_args(argv)
+
+    if args.real_provider:
+        run_real_provider_experiment(real_provider=True)
+
+    projects = build_experiment_projects()
+    slugs = [project.slug for project in projects] if args.slug == "all" else [args.slug]
+    for slug in slugs:
+        write_experiment_dry_run(
+            output_root=args.output_root,
+            slug=slug,
+            date=args.date,
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+```
+
+- [ ] **Step 2: Verify benchmark tests pass**
+
+Run:
+
+```bash
+PYTHONPATH=src pytest tests/test_visual_discovery_benchmark.py -q
+```
+
+Expected: pass.
+
+## Task 4: Update Product Docs
+
+**Files:**
+- Modify: `docs/product/roadmap.md`
+- Modify: `docs/product/experiments/cultural-term-efficacy.md`
+
+- [ ] **Step 1: Update roadmap**
+
+In `docs/product/roadmap.md`, under `## Current`, add:
+
+```markdown
+- `docs/product/provider-capabilities.md`: provider/platform capability matrix.
+```
+
+Under `## Next`, remove:
+
+```markdown
+- Provider capability matrix for public docs.
+```
+
+- [ ] **Step 2: Update cultural-term efficacy docs**
+
+In `docs/product/experiments/cultural-term-efficacy.md`, add this section after `## Providers`:
+
+```markdown
+## Harness
+
+Run the no-cost dry-run harness with:
+
+```bash
+PYTHONPATH=src python scripts/visual_discovery_benchmark.py --date 2026-04-30
+```
+
+The harness writes prompts, manifests, empty result records, and summaries. It does not call OpenAI, Gemini, ComfyUI, or `mock` for quality evidence. Real provider execution is a future explicit opt-in path and is disabled in this version.
+```
+
+- [ ] **Step 3: Verify docs truth tests pass**
+
+Run:
+
+```bash
+PYTHONPATH=src pytest tests/test_visual_discovery_docs_truth.py -q
+```
+
+Expected: pass.
+
+## Task 5: Final Verification and Commit
+
+**Files:**
+- All files above.
+
+- [ ] **Step 1: Run focused tests**
+
+Run:
+
+```bash
+PYTHONPATH=src pytest tests/test_visual_discovery_benchmark.py tests/test_visual_discovery_docs_truth.py tests/test_visual_discovery_prompting.py tests/test_visual_discovery_artifacts.py -q
+```
+
+Expected: pass.
+
+- [ ] **Step 2: Run dry-run CLI into a temporary directory**
+
+Run:
+
+```bash
+PYTHONPATH=src python scripts/visual_discovery_benchmark.py --output-root /private/tmp/vulca-cultural-term-efficacy --date 2026-04-30
+```
+
+Expected: command exits 0 and writes three result directories under `/private/tmp/vulca-cultural-term-efficacy`.
+
+- [ ] **Step 3: Scan for unfinished markers**
+
+Run:
+
+```bash
+grep -RInE "TB[D]|TO[D]O|lo[r]em|coming soo[n]" scripts/visual_discovery_benchmark.py tests/test_visual_discovery_benchmark.py docs/product/roadmap.md docs/product/experiments/cultural-term-efficacy.md docs/superpowers/specs/2026-04-30-cultural-term-efficacy-harness-design.md docs/superpowers/plans/2026-04-30-cultural-term-efficacy-harness.md
+```
+
+Expected: no matches.
+
+- [ ] **Step 4: Check whitespace**
+
+Run:
+
+```bash
+git diff --check
+```
+
+Expected: no output.
+
+- [ ] **Step 5: Commit implementation**
+
+Run:
+
+```bash
+git add scripts/visual_discovery_benchmark.py tests/test_visual_discovery_benchmark.py tests/test_visual_discovery_docs_truth.py docs/product/roadmap.md docs/product/experiments/cultural-term-efficacy.md docs/superpowers/plans/2026-04-30-cultural-term-efficacy-harness.md
+git commit -m "feat: add cultural term efficacy harness"
+```

--- a/docs/superpowers/specs/2026-04-30-cultural-term-efficacy-harness-design.md
+++ b/docs/superpowers/specs/2026-04-30-cultural-term-efficacy-harness-design.md
@@ -1,0 +1,137 @@
+# Cultural-Term Efficacy Harness Design
+
+## Status
+
+approved_for_planning
+
+## Context
+
+Vulca now positions itself as an agent-native visual control layer, not a foundation image model. The current roadmap names two product evidence gaps: provider/platform capability clarity and a cultural-term efficacy benchmark. The provider capability matrix already exists as `docs/product/provider-capabilities.md`, so this work should first make the roadmap consistent, then turn `docs/product/experiments/cultural-term-efficacy.md` from protocol-only into a repeatable dry-run harness.
+
+The product question is specific: do cultural and taste terms directly improve generated outputs, or does Vulca create value by translating cultural analysis into concrete visual operations, avoid lists, and evaluation criteria? The harness must support that decision without making unproven quality claims.
+
+## Goals
+
+- Provide a default no-cost experiment harness for the cultural-term efficacy protocol.
+- Generate deterministic A/B/C/D prompt conditions for the three project domains in the protocol.
+- Write the expected result directory skeleton under `docs/product/experiments/results/<date>-<slug>/`.
+- Keep real provider generation behind an explicit opt-in flag.
+- Prevent public docs from claiming that cultural terms are proven or guaranteed to improve outputs.
+- Move the provider capability matrix out of roadmap "Next" because it already exists.
+
+## Non-Goals
+
+- Do not call OpenAI, Gemini, ComfyUI, or any other real image provider by default.
+- Do not run image generation, evaluation, or human ranking in this first harness.
+- Do not change provider APIs, MCP tools, `/visual-discovery`, `/visual-plan`, `/evaluate`, redraw, layers, or v0.22 mask refinement.
+- Do not market `/inpaint` or `/redraw-layer` as polished user-facing skills.
+
+## Recommended Approach
+
+Extend the existing `scripts/visual_discovery_benchmark.py` into a product experiment harness. This is intentionally conservative: the script already imports the visual discovery prompt machinery and has tests. The first version should make the experiment reproducible and artifact-backed without introducing a new runtime package or provider execution path.
+
+The script will expose library functions that tests can call directly and keep its command-line behavior as a dry-run artifact writer. Later, if the experiment needs real provider execution, a separate follow-up can add an explicit `--real-provider` path after credentials, costs, output normalization, and evaluation policy are settled.
+
+## Experiment Conditions
+
+The harness uses the protocol's four conditions:
+
+| ID | Meaning | Prompt contents |
+|---|---|---|
+| A | User prompt only | The project's raw user prompt. |
+| B | User prompt + cultural terms | Raw prompt plus the selected card's `culture_terms`. |
+| C | User prompt + cultural terms + visual operations | Raw prompt plus `culture_terms` and concrete `visual_ops`. |
+| D | Full direction-card prompt | `compose_prompt_from_direction_card(..., target="final")`, plus avoid list and L1-L5 evaluation focus metadata. |
+
+This deliberately removes the older E/F conditions from `scripts/visual_discovery_benchmark.py`; those were useful scaffolding, but they no longer match the public protocol.
+
+## Project Fixtures
+
+The harness defines exactly three built-in projects:
+
+- `premium-tea-packaging`: premium tea packaging with xieyi restraint.
+- `spiritual-editorial-poster`: editorial poster with spiritual but non-religious atmosphere.
+- `cultural-material-campaign`: product campaign visual with culturally specific material references.
+
+Each fixture includes a slug, user prompt, expected domain, seed tradition hints, and enough input text for `infer_taste_profile()` and `generate_direction_cards()` to create a deterministic selected card.
+
+## Artifact Contract
+
+For each dry run, the harness writes:
+
+```text
+docs/product/experiments/results/<date>-<slug>/
+  prompts/
+    A.txt
+    B.txt
+    C.txt
+    D.txt
+  images/
+    README.md
+  evaluations/
+    README.md
+  human_ranking.json
+  provider_costs.json
+  summary.md
+  manifest.json
+```
+
+`manifest.json` contains:
+
+```json
+{
+  "schema_version": "0.1",
+  "experiment": "cultural-term-efficacy",
+  "mode": "dry_run",
+  "provider_execution": "disabled",
+  "project": {
+    "slug": "premium-tea-packaging",
+    "prompt": "..."
+  },
+  "conditions": [
+    {
+      "id": "A",
+      "label": "User prompt only",
+      "prompt_path": "prompts/A.txt",
+      "source_card_id": ""
+    }
+  ],
+  "providers": [
+    {
+      "provider": "openai",
+      "model": "gpt-image-2",
+      "execution": "not_run"
+    }
+  ]
+}
+```
+
+`human_ranking.json` and `provider_costs.json` are placeholders only in the data sense: they are valid empty result records with `"status": "not_collected"` and must not contain prose placeholders.
+
+## Safety and Product Claims
+
+- `mock` may be used only to validate artifact structure.
+- Dry-run artifacts must say that provider execution is disabled.
+- Summary text must not claim that any condition improves image quality.
+- Public docs must continue to avoid phrases such as "culture terms guarantee", "cultural terms guarantee", "always improves generation", and "proves cultural prompting".
+- Real providers require a future explicit opt-in interface. The first harness should fail closed if asked to run real providers.
+
+## Files
+
+- Modify `scripts/visual_discovery_benchmark.py` to define fixtures, A-D conditions, artifact writers, and a dry-run CLI.
+- Modify `tests/test_visual_discovery_benchmark.py` to expect A-D only and validate dry-run outputs.
+- Modify `tests/test_visual_discovery_docs_truth.py` to lock the roadmap consistency and safety claims.
+- Modify `docs/product/roadmap.md` to move the provider capability matrix into Current.
+- Modify `docs/product/experiments/cultural-term-efficacy.md` to point readers at the dry-run harness and clarify explicit opt-in for real provider runs.
+
+## Testing
+
+- Focused benchmark tests verify prompt conditions, project fixtures, artifact tree, manifest schema, and dry-run safety.
+- Docs truth tests verify roadmap consistency and public-claim boundaries.
+- Existing visual discovery prompt/artifact tests remain in scope because the harness reuses direction-card generation and prompt composition.
+
+## Open Decisions Deferred
+
+- The scoring methodology for human rankings is deferred until there are real generated images.
+- Provider-specific generation adapters are deferred until costs, credentials, and output normalization are agreed.
+- `/evaluate` integration is deferred until the harness has real image artifacts.

--- a/scripts/visual_discovery_benchmark.py
+++ b/scripts/visual_discovery_benchmark.py
@@ -1,20 +1,30 @@
-"""Benchmark scaffolding for visual-discovery prompt guidance."""
+"""Dry-run harness for the cultural-term efficacy experiment."""
 from __future__ import annotations
 
+import argparse
+import json
+import os
+from dataclasses import dataclass
+from datetime import date as date_type
 from pathlib import Path
+from typing import Any
 
+os.environ.setdefault("LITELLM_LOCAL_MODEL_COST_MAP", "true")
+
+from vulca.discovery.cards import generate_direction_cards
+from vulca.discovery.profile import infer_taste_profile
 from vulca.discovery.prompting import compose_prompt_from_direction_card
 from vulca.discovery.types import DirectionCard
 
 
 PROVIDERS = [
     {
-        "label": "OpenAI GPT Image 2",
+        "label": "OpenAI GPT Image",
         "provider": "openai",
         "model": "gpt-image-2",
     },
     {
-        "label": "Gemini / Nano Banana",
+        "label": "Gemini image",
         "provider": "gemini",
         "model": "gemini-3.1-flash-image-preview",
     },
@@ -22,65 +32,270 @@ PROVIDERS = [
 ]
 
 
-def build_conditions(base_prompt: str, card: DirectionCard) -> list[dict[str, str]]:
+@dataclass(frozen=True)
+class ExperimentProject:
+    slug: str
+    prompt: str
+    domain: str
+    tradition_terms: tuple[str, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "slug": self.slug,
+            "prompt": self.prompt,
+            "domain": self.domain,
+            "tradition_terms": list(self.tradition_terms),
+        }
+
+
+def build_experiment_projects() -> list[ExperimentProject]:
+    return [
+        ExperimentProject(
+            slug="premium-tea-packaging",
+            prompt="premium tea packaging with xieyi restraint",
+            domain="packaging",
+            tradition_terms=("chinese_xieyi", "liu bai", "ink restraint"),
+        ),
+        ExperimentProject(
+            slug="spiritual-editorial-poster",
+            prompt="editorial poster with spiritual but non-religious atmosphere",
+            domain="editorial poster",
+            tradition_terms=("sacred atmosphere", "quiet symbolism", "restraint"),
+        ),
+        ExperimentProject(
+            slug="cultural-material-campaign",
+            prompt=(
+                "product campaign visual with culturally specific material "
+                "references"
+            ),
+            domain="campaign visual",
+            tradition_terms=("material culture", "specific craft", "local texture"),
+        ),
+    ]
+
+
+def get_experiment_project(slug: str) -> ExperimentProject:
+    for project in build_experiment_projects():
+        if project.slug == slug:
+            return project
+    known = ", ".join(project.slug for project in build_experiment_projects())
+    raise ValueError(f"unknown project slug: {slug!r}; expected one of: {known}")
+
+
+def select_direction_card(project: ExperimentProject) -> DirectionCard:
+    profile = infer_taste_profile(
+        slug=project.slug,
+        intent=f"{project.prompt}; {'; '.join(project.tradition_terms)}",
+    )
+    return generate_direction_cards(profile, count=3)[0]
+
+
+def _visual_ops_text(card: DirectionCard) -> str:
     ops = card.visual_ops
-    compiled = compose_prompt_from_direction_card(card, target="final")
-    raw_terms = ", ".join(card.culture_terms)
-    visual_ops = "; ".join(
+    return "; ".join(
         part
         for part in [
             ops.composition,
             ops.color,
             ops.texture,
+            ops.lighting,
+            ops.camera,
+            ops.typography,
             ops.symbol_strategy,
         ]
         if part
     )
+
+
+def build_conditions(base_prompt: str, card: DirectionCard) -> list[dict[str, Any]]:
+    raw_terms = ", ".join(card.culture_terms)
+    visual_ops = _visual_ops_text(card)
+    compiled = compose_prompt_from_direction_card(card, target="final")
     return [
         {
             "id": "A",
-            "label": "Baseline user prompt",
+            "label": "User prompt only",
             "prompt": base_prompt,
+            "negative_prompt": "",
             "source_card_id": "",
+            "culture_terms": [],
+            "evaluation_focus": {},
         },
         {
             "id": "B",
-            "label": "Baseline + raw cultural terms",
-            "prompt": f"{base_prompt}. Raw cultural terms: {raw_terms}",
+            "label": "User prompt + cultural terms",
+            "prompt": f"{base_prompt}. Cultural terms: {raw_terms}",
+            "negative_prompt": "",
             "source_card_id": card.id,
+            "culture_terms": list(card.culture_terms),
+            "evaluation_focus": {},
         },
         {
             "id": "C",
-            "label": "Baseline + visual operations",
-            "prompt": f"{base_prompt}. Visual operations: {visual_ops}",
+            "label": "User prompt + cultural terms + visual operations",
+            "prompt": (
+                f"{base_prompt}. Cultural terms: {raw_terms}. "
+                f"Visual operations: {visual_ops}"
+            ),
+            "negative_prompt": "",
             "source_card_id": card.id,
+            "culture_terms": list(card.culture_terms),
+            "evaluation_focus": {},
         },
         {
             "id": "D",
-            "label": "Raw terms + visual operations",
-            "prompt": (
-                f"{base_prompt}. Terms: {raw_terms}. "
-                f"Visual operations: {visual_ops}"
-            ),
-            "source_card_id": card.id,
-        },
-        {
-            "id": "E",
-            "label": "Raw terms + visual operations + references",
-            "prompt": (
-                f"{base_prompt}. Terms: {raw_terms}. "
-                f"Visual operations: {visual_ops}. "
-                "Use provided references when available."
-            ),
-            "source_card_id": card.id,
-        },
-        {
-            "id": "F",
-            "label": "Visual-discovery card compiled prompt",
+            "label": "Full direction-card prompt",
             "prompt": compiled.prompt,
+            "negative_prompt": compiled.negative_prompt,
             "source_card_id": card.id,
+            "culture_terms": list(card.culture_terms),
+            "evaluation_focus": card.evaluation_focus.to_dict(),
         },
     ]
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.write_text(
+        json.dumps(payload, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _provider_records() -> list[dict[str, str]]:
+    return [
+        {
+            "label": provider["label"],
+            "provider": provider["provider"],
+            "model": provider["model"],
+            "execution": "not_run",
+        }
+        for provider in PROVIDERS
+    ]
+
+
+def write_experiment_dry_run(
+    *,
+    output_root: str | Path,
+    slug: str,
+    date: str | None = None,
+) -> dict[str, str]:
+    project = get_experiment_project(slug)
+    card = select_direction_card(project)
+    conditions = build_conditions(project.prompt, card)
+    run_date = date or date_type.today().isoformat()
+    out_dir = Path(output_root) / f"{run_date}-{project.slug}"
+    prompts_dir = out_dir / "prompts"
+    images_dir = out_dir / "images"
+    evaluations_dir = out_dir / "evaluations"
+    prompts_dir.mkdir(parents=True, exist_ok=True)
+    images_dir.mkdir(parents=True, exist_ok=True)
+    evaluations_dir.mkdir(parents=True, exist_ok=True)
+
+    for condition in conditions:
+        prompt_text = condition["prompt"]
+        if condition["negative_prompt"]:
+            prompt_text += f"\n\nNegative prompt:\n{condition['negative_prompt']}"
+        if condition["evaluation_focus"]:
+            prompt_text += "\n\nEvaluation focus:\n" + json.dumps(
+                condition["evaluation_focus"],
+                ensure_ascii=False,
+                indent=2,
+            )
+        (prompts_dir / f"{condition['id']}.txt").write_text(
+            prompt_text + "\n",
+            encoding="utf-8",
+        )
+
+    images_readme = (
+        "# Images\n\n"
+        "Dry run only. Real provider images are not generated by this harness.\n"
+    )
+    evaluations_readme = (
+        "# Evaluations\n\n"
+        "Dry run only. Run `/evaluate` after real images exist.\n"
+    )
+    (images_dir / "README.md").write_text(images_readme, encoding="utf-8")
+    (evaluations_dir / "README.md").write_text(
+        evaluations_readme,
+        encoding="utf-8",
+    )
+
+    _write_json(
+        out_dir / "human_ranking.json",
+        {
+            "schema_version": "0.1",
+            "status": "not_collected",
+            "rankings": [],
+        },
+    )
+    _write_json(
+        out_dir / "provider_costs.json",
+        {
+            "schema_version": "0.1",
+            "status": "not_collected",
+            "providers": [],
+            "total_usd": 0,
+        },
+    )
+
+    manifest_conditions = [
+        {
+            "id": condition["id"],
+            "label": condition["label"],
+            "prompt_path": f"prompts/{condition['id']}.txt",
+            "source_card_id": condition["source_card_id"],
+        }
+        for condition in conditions
+    ]
+    manifest = {
+        "schema_version": "0.1",
+        "experiment": "cultural-term-efficacy",
+        "mode": "dry_run",
+        "provider_execution": "disabled",
+        "project": project.to_dict(),
+        "selected_card_id": card.id,
+        "conditions": manifest_conditions,
+        "providers": _provider_records(),
+    }
+    _write_json(out_dir / "manifest.json", manifest)
+
+    summary = f"""# Cultural-Term Efficacy Dry Run: {project.slug}
+
+## Status
+dry_run
+
+## Provider Execution
+disabled
+
+## Project
+{project.prompt}
+
+## Conditions
+{chr(10).join(f"- {item['id']}: {item['label']}" for item in conditions)}
+
+## Decision Boundary
+No image quality conclusion can be drawn from this dry run. It validates prompts,
+metadata, and result structure only.
+"""
+    (out_dir / "summary.md").write_text(summary, encoding="utf-8")
+
+    return {
+        "output_dir": str(out_dir),
+        "manifest_json": str(out_dir / "manifest.json"),
+        "summary_md": str(out_dir / "summary.md"),
+    }
+
+
+def run_real_provider_experiment(*, real_provider: bool = False) -> None:
+    if not real_provider:
+        raise RuntimeError(
+            "Real provider execution requires explicit opt-in and is disabled "
+            "for the dry-run harness."
+        )
+    raise NotImplementedError(
+        "Real provider execution is intentionally not implemented in this "
+        "harness version."
+    )
 
 
 def write_dry_run_report(path: str | Path) -> str:
@@ -89,18 +304,18 @@ def write_dry_run_report(path: str | Path) -> str:
         f"model={item['model'] or 'default'}"
         for item in PROVIDERS
     )
-    report = f"""# Visual Discovery Benchmark Dry Run
+    report = f"""# Cultural-Term Efficacy Harness Dry Run
 
 ## Providers
 {provider_lines}
 
 ## Conditions
-- A: baseline user prompt
-- B: baseline + raw cultural/aesthetic terms
-- C: baseline + visual operations only
-- D: raw terms + visual operations
-- E: raw terms + visual operations + reference images
-- F: visual-discovery card compiled prompt
+- A: user prompt only
+- B: user prompt + cultural terms
+- C: user prompt + cultural terms + visual operations
+- D: full direction-card prompt with avoid list and evaluation focus
+
+No image quality conclusion can be drawn from this dry run.
 """
     p = Path(path)
     p.parent.mkdir(parents=True, exist_ok=True)
@@ -108,5 +323,32 @@ def write_dry_run_report(path: str | Path) -> str:
     return report
 
 
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Write cultural-term efficacy dry-run artifacts."
+    )
+    parser.add_argument("--slug", default="all")
+    parser.add_argument(
+        "--output-root",
+        default="docs/product/experiments/results",
+    )
+    parser.add_argument("--date", default=date_type.today().isoformat())
+    parser.add_argument("--real-provider", action="store_true")
+    args = parser.parse_args(argv)
+
+    if args.real_provider:
+        run_real_provider_experiment(real_provider=True)
+
+    projects = build_experiment_projects()
+    slugs = [project.slug for project in projects] if args.slug == "all" else [args.slug]
+    for slug in slugs:
+        write_experiment_dry_run(
+            output_root=args.output_root,
+            slug=slug,
+            date=args.date,
+        )
+    return 0
+
+
 if __name__ == "__main__":
-    write_dry_run_report("docs/visual-discovery-benchmark-dry-run.md")
+    raise SystemExit(main())

--- a/tests/test_visual_discovery_benchmark.py
+++ b/tests/test_visual_discovery_benchmark.py
@@ -1,7 +1,12 @@
 from __future__ import annotations
 
+import json
+import importlib
+import os
 import sys
 from pathlib import Path
+
+import pytest
 
 
 ROOT = Path(__file__).resolve().parent.parent
@@ -9,37 +14,101 @@ if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
 
-def test_build_conditions_a_through_f():
-    from scripts.visual_discovery_benchmark import build_conditions
-    from vulca.discovery.cards import generate_direction_cards
-    from vulca.discovery.profile import infer_taste_profile
+def test_experiment_projects_match_protocol_domains():
+    from scripts.visual_discovery_benchmark import build_experiment_projects
 
-    profile = infer_taste_profile(
-        slug="tea",
-        intent="premium tea packaging with ink atmosphere and liu bai",
+    projects = build_experiment_projects()
+
+    assert [project.slug for project in projects] == [
+        "premium-tea-packaging",
+        "spiritual-editorial-poster",
+        "cultural-material-campaign",
+    ]
+    assert "xieyi restraint" in projects[0].prompt
+    assert "spiritual but non-religious" in projects[1].prompt
+    assert "material references" in projects[2].prompt
+
+
+def test_build_conditions_a_through_d():
+    from scripts.visual_discovery_benchmark import (
+        build_conditions,
+        build_experiment_projects,
+        select_direction_card,
     )
-    card = generate_direction_cards(profile, count=1)[0]
 
-    conditions = build_conditions(profile.initial_intent, card)
+    project = build_experiment_projects()[0]
+    card = select_direction_card(project)
 
-    assert [condition["id"] for condition in conditions] == [
+    conditions = build_conditions(project.prompt, card)
+
+    assert [condition["id"] for condition in conditions] == ["A", "B", "C", "D"]
+    assert conditions[0]["label"] == "User prompt only"
+    assert conditions[0]["source_card_id"] == ""
+    assert "cultural terms" in conditions[1]["label"].lower()
+    assert card.culture_terms[0] in conditions[1]["prompt"]
+    assert "Visual operations:" in conditions[2]["prompt"]
+    assert conditions[3]["label"] == "Full direction-card prompt"
+    assert conditions[3]["negative_prompt"]
+    assert conditions[3]["evaluation_focus"]["L1"]
+    assert conditions[3]["source_card_id"] == card.id
+
+
+def test_write_experiment_dry_run_artifacts(tmp_path):
+    from scripts.visual_discovery_benchmark import write_experiment_dry_run
+
+    result = write_experiment_dry_run(
+        output_root=tmp_path,
+        slug="premium-tea-packaging",
+        date="2026-04-30",
+    )
+
+    out_dir = Path(result["output_dir"])
+    assert out_dir == tmp_path / "2026-04-30-premium-tea-packaging"
+    for condition_id in ["A", "B", "C", "D"]:
+        assert (out_dir / "prompts" / f"{condition_id}.txt").exists()
+    assert (out_dir / "images" / "README.md").exists()
+    assert (out_dir / "evaluations" / "README.md").exists()
+
+    manifest = json.loads((out_dir / "manifest.json").read_text(encoding="utf-8"))
+    assert manifest["schema_version"] == "0.1"
+    assert manifest["experiment"] == "cultural-term-efficacy"
+    assert manifest["mode"] == "dry_run"
+    assert manifest["provider_execution"] == "disabled"
+    assert manifest["project"]["slug"] == "premium-tea-packaging"
+    assert [condition["id"] for condition in manifest["conditions"]] == [
         "A",
         "B",
         "C",
         "D",
-        "E",
-        "F",
     ]
-    assert "raw cultural" in conditions[1]["label"].lower()
-    assert card.id in conditions[-1]["source_card_id"]
+    assert {provider["execution"] for provider in manifest["providers"]} == {
+        "not_run"
+    }
+
+    human_ranking = json.loads(
+        (out_dir / "human_ranking.json").read_text(encoding="utf-8")
+    )
+    provider_costs = json.loads(
+        (out_dir / "provider_costs.json").read_text(encoding="utf-8")
+    )
+    assert human_ranking["status"] == "not_collected"
+    assert provider_costs["status"] == "not_collected"
+    assert "No image quality conclusion" in (
+        out_dir / "summary.md"
+    ).read_text(encoding="utf-8")
 
 
-def test_dry_run_report_contains_provider_matrix(tmp_path):
-    from scripts.visual_discovery_benchmark import write_dry_run_report
+def test_real_provider_execution_fails_closed():
+    from scripts.visual_discovery_benchmark import run_real_provider_experiment
 
-    report = write_dry_run_report(tmp_path / "report.md")
+    with pytest.raises(RuntimeError, match="explicit opt-in"):
+        run_real_provider_experiment(real_provider=False)
 
-    assert "OpenAI GPT Image 2" in report
-    assert "Gemini / Nano Banana" in report
-    assert "ComfyUI" in report
-    assert (tmp_path / "report.md").exists()
+
+def test_harness_forces_litellm_local_cost_map(monkeypatch):
+    import scripts.visual_discovery_benchmark as benchmark
+
+    monkeypatch.delenv("LITELLM_LOCAL_MODEL_COST_MAP", raising=False)
+    importlib.reload(benchmark)
+
+    assert os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] == "true"

--- a/tests/test_visual_discovery_docs_truth.py
+++ b/tests/test_visual_discovery_docs_truth.py
@@ -43,6 +43,22 @@ def test_readme_and_roadmap_mark_evaluate_skill_current():
     assert "no agent skill yet" not in readme.lower()
 
 
+def test_roadmap_marks_provider_matrix_current():
+    roadmap = (ROOT / "docs" / "product" / "roadmap.md").read_text(
+        encoding="utf-8"
+    )
+    provider_matrix = (
+        ROOT / "docs" / "product" / "provider-capabilities.md"
+    ).read_text(encoding="utf-8")
+
+    assert "Vulca Provider and Platform Capability Matrix" in provider_matrix
+    assert (
+        "`docs/product/provider-capabilities.md`: provider/platform capability matrix"
+        in roadmap
+    )
+    assert "Provider capability matrix for public docs" not in roadmap
+
+
 def test_readme_leads_with_full_visual_workflow():
     readme = (ROOT / "README.md").read_text(encoding="utf-8")
     first_screen = readme[:2500].lower()


### PR DESCRIPTION
Summary: Adds a no-cost dry-run harness for the cultural-term efficacy experiment; generates A/B/C/D prompt conditions, built-in project fixtures, manifest/result skeletons, and fail-closed real-provider behavior; updates roadmap/docs to mark provider matrix current and document the dry-run boundary. Test plan: PYTHONPATH=src pytest tests/test_visual_discovery_benchmark.py tests/test_visual_discovery_docs_truth.py tests/test_visual_discovery_prompting.py tests/test_visual_discovery_artifacts.py -q; PYTHONPATH=src python3 scripts/visual_discovery_benchmark.py --output-root /private/tmp/vulca-cultural-term-efficacy --date 2026-04-30; git diff --check.