### PR TITLE
[codex] Ignore local artifact outputs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,11 @@ env/
 # Phase 0 Task 7 — ignore large model weights and generated showcase/demo assets
 FastSAM-s.pt
 *.pt
+*.pth
+*.ckpt
+*.safetensors
+*.onnx
+/mobileclip_blt.ts
 .playwright-mcp/
 assets/showcase/*
 !assets/showcase/originals/
@@ -49,3 +54,13 @@ assets/showcase/*
 tmp-shipgate/
 tmp-shipgate-*/
 docs/tool-audit-logs/
+
+# Local browser/social publishing screenshots and transient logs
+/error.log
+/bieber-search-*.jpeg
+/devto-draft-saved.png
+/hn-submit-*.png
+/x-compose-ready.png
+/x-posted-verify*.png
+/xhs-*.png
+/yt-*.jpeg


### PR DESCRIPTION
## Summary

- Adds ignore rules for large local model artifacts such as `.pth`, `.ckpt`, `.safetensors`, and `.onnx`.
- Ignores the root-level `mobileclip_blt.ts` artifact without globally ignoring TypeScript source files.
- Ignores local browser/social publishing screenshots and transient root `error.log` files.

## Validation

- `git check-ignore -v rf-detr-base.pth mobileclip_blt.ts error.log bieber-search-1.jpeg devto-draft-saved.png hn-submit-final.png x-compose-ready.png x-posted-verify2.png xhs-login-page.png yt-results.jpeg`
- `git ls-files '*.ts' '*.pth' '*.onnx' '*.ckpt' '*.safetensors'` returned no tracked files, so these new rules do not hide currently versioned files.

## Notes

This PR only updates `.gitignore`; it does not delete local artifacts or change generated demo/spec directories.
