### PR TITLE
feat: add real brief benchmark harness

### DIFF
--- a/docs/product/experiments/cultural-term-efficacy.md
+++ b/docs/product/experiments/cultural-term-efficacy.md
@@ -85,3 +85,17 @@ docs/product/experiments/results/<date>-<slug>/
 ## Decision Rule
 
 If condition D does not outperform A/B/C on at least two of three domains for human preference and cliche avoidance, product language must shift from "culture terms guide models" to "Vulca converts culture analysis into visual operations and evaluation criteria."
+
+## Successor: Real-Brief Benchmark
+
+The cultural-term prompt signal test is useful for isolating whether cultural
+terms alone move model output, but it is weaker than real briefs as product
+evidence. Real briefs include client context, deliverables, constraints,
+timelines, risks, and approval questions, so they better test whether Vulca
+turns messy creative inputs into reviewable decision and production packages.
+
+Use `scripts/real_brief_benchmark.py` for the successor dry-run harness:
+
+```bash
+PYTHONPATH=src python3 scripts/real_brief_benchmark.py --date 2026-05-01
+```

--- a/docs/superpowers/plans/2026-05-01-real-brief-benchmark.md
+++ b/docs/superpowers/plans/2026-05-01-real-brief-benchmark.md
@@ -1,0 +1,1778 @@
+# Real Brief Benchmark Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a dry-run real-brief benchmark harness that turns public creative briefs into decision packages, production packages, A/B/C/D workflow conditions, workflow handoff artifacts, and a local review surface.
+
+**Architecture:** Add a focused `vulca.real_brief` package for schema, built-in fixtures, condition generation, artifact writing, and HTML review rendering. Keep `scripts/real_brief_benchmark.py` as a thin CLI wrapper. Default execution is dry-run and writes no paid-provider artifacts; real-provider flags fail closed until explicit provider execution is implemented.
+
+**Tech Stack:** Python dataclasses, `json`, `pathlib`, existing `vulca.discovery` direction cards/prompting, pytest, static HTML with localStorage.
+
+---
+
+## File Structure
+
+- Create `src/vulca/real_brief/__init__.py`: public exports for the benchmark package.
+- Create `src/vulca/real_brief/types.py`: dataclasses, slug validation, fixture validation, review dimensions.
+- Create `src/vulca/real_brief/fixtures.py`: five curated real-brief fixtures as structured data.
+- Create `src/vulca/real_brief/conditions.py`: A/B/C/D condition generation using existing discovery internals.
+- Create `src/vulca/real_brief/artifacts.py`: dry-run artifact tree writer for packages, handoff, manifest, prompts, review schema, and summary.
+- Create `src/vulca/real_brief/review_html.py`: local HTML review board renderer.
+- Create `scripts/real_brief_benchmark.py`: CLI entry point.
+- Create `tests/test_real_brief_benchmark.py`: focused test coverage for schemas, fixtures, conditions, artifact tree, HTML, CLI, and fail-closed real-provider behavior.
+- Modify `docs/product/experiments/cultural-term-efficacy.md`: add a short link from the old prompt test to the new real-brief benchmark.
+
+Implementation boundaries:
+
+- Do not change `/visual-*` skills in Phase 1.
+- Do not touch `src/vulca/layers`, redraw, mask refinement, or v0.22 branch-owned files.
+- Do not call network APIs in tests.
+- Do not write secrets, provider keys, or live endpoint strings into artifacts.
+
+---
+
+### Task 1: Real-Brief Types And Validation
+
+**Files:**
+- Create: `src/vulca/real_brief/__init__.py`
+- Create: `src/vulca/real_brief/types.py`
+- Test: `tests/test_real_brief_benchmark.py`
+
+- [ ] **Step 1: Write failing tests for slug and fixture validation**
+
+Add this to `tests/test_real_brief_benchmark.py`:
+
+```python
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+
+def test_safe_slug_accepts_fixture_style_ids():
+    from vulca.real_brief.types import safe_slug
+
+    assert safe_slug("seattle-polish-film-festival-poster") == (
+        "seattle-polish-film-festival-poster"
+    )
+    assert safe_slug("gsm-community-market-campaign") == (
+        "gsm-community-market-campaign"
+    )
+
+
+@pytest.mark.parametrize(
+    "slug",
+    ["", ".", "..", "../escape", "/abs/path", "has space", "UpperCase", "x/y"],
+)
+def test_safe_slug_rejects_unsafe_ids(slug):
+    from vulca.real_brief.types import safe_slug
+
+    with pytest.raises(ValueError, match="safe slug"):
+        safe_slug(slug)
+
+
+def test_fixture_validation_rejects_missing_required_field():
+    from vulca.real_brief.types import RealBriefFixture, SourceInfo
+
+    fixture = RealBriefFixture(
+        slug="broken-fixture",
+        title="Broken Fixture",
+        source=SourceInfo(
+            url="https://example.test/brief",
+            retrieved_on="2026-05-01",
+            usage_note="Internal benchmark only",
+        ),
+        client="",
+        context="Context exists",
+        audience=["audience"],
+        deliverables=[],
+        constraints=["constraint"],
+        budget="not specified by source",
+        timeline="source-specific deadline",
+        required_outputs=["decision_package", "production_package"],
+        ai_policy="unspecified",
+        simulation_only=True,
+        risks=["risk"],
+        avoid=["avoid"],
+        evaluation_dimensions=["brief_compliance"],
+    )
+
+    with pytest.raises(ValueError, match="client"):
+        fixture.validate()
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+PYTHONPATH=src python3 -m pytest tests/test_real_brief_benchmark.py -q
+```
+
+Expected: FAIL with `ModuleNotFoundError: No module named 'vulca.real_brief'`.
+
+- [ ] **Step 3: Implement `types.py` and package exports**
+
+Create `src/vulca/real_brief/types.py`:
+
+```python
+"""Structured real-brief benchmark data types."""
+from __future__ import annotations
+
+import re
+from dataclasses import asdict, dataclass, field
+from typing import Any
+
+
+_SAFE_SLUG_RE = re.compile(r"^[a-z0-9][a-z0-9._-]*$")
+
+AI_POLICIES = {"allowed", "prohibited_for_submission", "unspecified"}
+CONDITION_IDS = ("A", "B", "C", "D")
+REVIEW_DIMENSIONS = (
+    "brief_compliance",
+    "audience_fit",
+    "deliverable_fit",
+    "constraint_handling",
+    "cultural_taste_specificity",
+    "structural_control",
+    "editability_reusability",
+    "production_realism",
+    "risk_avoidance",
+    "decision_usefulness",
+)
+
+
+def safe_slug(slug: str) -> str:
+    if (
+        not slug
+        or slug in {".", ".."}
+        or "/" in slug
+        or "\\" in slug
+        or ".." in slug
+        or not _SAFE_SLUG_RE.match(slug)
+    ):
+        raise ValueError(
+            "safe slug required: lowercase letters, digits, '.', '_' or '-' only"
+        )
+    return slug
+
+
+@dataclass(frozen=True)
+class SourceInfo:
+    url: str
+    retrieved_on: str
+    usage_note: str = "Internal benchmark only"
+    deadline: str = ""
+
+    def to_dict(self) -> dict[str, str]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class Deliverable:
+    name: str
+    format: str
+    channel: str
+    required: bool = True
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class RealBriefFixture:
+    slug: str
+    title: str
+    source: SourceInfo
+    client: str
+    context: str
+    audience: list[str]
+    deliverables: list[Deliverable]
+    constraints: list[str]
+    budget: str
+    timeline: str
+    required_outputs: list[str]
+    ai_policy: str
+    simulation_only: bool
+    risks: list[str]
+    avoid: list[str]
+    evaluation_dimensions: list[str]
+    source_brief: str = ""
+    domain: str = "brand_visual"
+    tags: list[str] = field(default_factory=list)
+
+    def validate(self) -> None:
+        safe_slug(self.slug)
+        if not self.title.strip():
+            raise ValueError(f"{self.slug}: title is required")
+        if not self.source.url.startswith(("https://", "http://")):
+            raise ValueError(f"{self.slug}: source.url must be absolute http(s)")
+        for field_name in (
+            "client",
+            "context",
+            "budget",
+            "timeline",
+            "ai_policy",
+            "domain",
+        ):
+            if not str(getattr(self, field_name)).strip():
+                raise ValueError(f"{self.slug}: {field_name} is required")
+        if self.ai_policy not in AI_POLICIES:
+            raise ValueError(f"{self.slug}: unsupported ai_policy {self.ai_policy!r}")
+        list_fields = {
+            "audience": self.audience,
+            "deliverables": self.deliverables,
+            "constraints": self.constraints,
+            "required_outputs": self.required_outputs,
+            "risks": self.risks,
+            "avoid": self.avoid,
+            "evaluation_dimensions": self.evaluation_dimensions,
+        }
+        for field_name, value in list_fields.items():
+            if not value:
+                raise ValueError(f"{self.slug}: {field_name} must not be empty")
+        unknown_dimensions = [
+            item for item in self.evaluation_dimensions if item not in REVIEW_DIMENSIONS
+        ]
+        if unknown_dimensions:
+            joined = ", ".join(unknown_dimensions)
+            raise ValueError(f"{self.slug}: unknown evaluation dimensions: {joined}")
+
+    def to_dict(self) -> dict[str, Any]:
+        self.validate()
+        return {
+            "schema_version": "0.1",
+            "slug": self.slug,
+            "title": self.title,
+            "source": self.source.to_dict(),
+            "client": self.client,
+            "context": self.context,
+            "audience": list(self.audience),
+            "deliverables": [item.to_dict() for item in self.deliverables],
+            "constraints": list(self.constraints),
+            "budget": self.budget,
+            "timeline": self.timeline,
+            "required_outputs": list(self.required_outputs),
+            "ai_policy": self.ai_policy,
+            "simulation_only": self.simulation_only,
+            "risks": list(self.risks),
+            "avoid": list(self.avoid),
+            "evaluation_dimensions": list(self.evaluation_dimensions),
+            "source_brief": self.source_brief,
+            "domain": self.domain,
+            "tags": list(self.tags),
+        }
+```
+
+Create `src/vulca/real_brief/__init__.py`:
+
+```python
+"""Real creative brief benchmark harness."""
+from __future__ import annotations
+
+from vulca.real_brief.types import (
+    CONDITION_IDS,
+    REVIEW_DIMENSIONS,
+    Deliverable,
+    RealBriefFixture,
+    SourceInfo,
+    safe_slug,
+)
+
+__all__ = [
+    "CONDITION_IDS",
+    "REVIEW_DIMENSIONS",
+    "Deliverable",
+    "RealBriefFixture",
+    "SourceInfo",
+    "safe_slug",
+]
+```
+
+- [ ] **Step 4: Run tests to verify Task 1 passes**
+
+Run:
+
+```bash
+PYTHONPATH=src python3 -m pytest tests/test_real_brief_benchmark.py -q
+```
+
+Expected: PASS for the three Task 1 tests.
+
+- [ ] **Step 5: Commit Task 1**
+
+Run:
+
+```bash
+git add src/vulca/real_brief/__init__.py src/vulca/real_brief/types.py tests/test_real_brief_benchmark.py
+git commit -m "feat: add real brief benchmark types"
+```
+
+---
+
+### Task 2: Built-In Real Brief Fixtures
+
+**Files:**
+- Create: `src/vulca/real_brief/fixtures.py`
+- Modify: `src/vulca/real_brief/__init__.py`
+- Test: `tests/test_real_brief_benchmark.py`
+
+- [ ] **Step 1: Write failing tests for fixture inventory and source hygiene**
+
+Append:
+
+```python
+def test_builtin_fixtures_are_valid_and_ordered():
+    from vulca.real_brief.fixtures import build_real_brief_fixtures
+
+    fixtures = build_real_brief_fixtures()
+
+    assert [fixture.slug for fixture in fixtures] == [
+        "gsm-community-market-campaign",
+        "seattle-polish-film-festival-poster",
+        "model-young-package-unpacking-taboo",
+        "erie-botanical-gardens-public-art",
+        "music-video-treatment-low-budget",
+    ]
+    for fixture in fixtures:
+        fixture.validate()
+        payload = fixture.to_dict()
+        assert payload["schema_version"] == "0.1"
+        assert payload["source"]["retrieved_on"] == "2026-04-30"
+        assert payload["source"]["usage_note"] == "Internal benchmark only"
+        assert payload["simulation_only"] is True
+
+
+def test_get_real_brief_fixture_rejects_unknown_slug():
+    from vulca.real_brief.fixtures import get_real_brief_fixture
+
+    with pytest.raises(ValueError, match="unknown real brief slug"):
+        get_real_brief_fixture("missing-brief")
+
+
+def test_ai_prohibited_fixture_is_marked_for_internal_simulation_only():
+    from vulca.real_brief.fixtures import get_real_brief_fixture
+
+    imageout_like = get_real_brief_fixture("seattle-polish-film-festival-poster")
+
+    assert imageout_like.simulation_only is True
+    assert imageout_like.source.usage_note == "Internal benchmark only"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+PYTHONPATH=src python3 -m pytest tests/test_real_brief_benchmark.py -q
+```
+
+Expected: FAIL with `ModuleNotFoundError: No module named 'vulca.real_brief.fixtures'`.
+
+- [ ] **Step 3: Implement fixture inventory**
+
+Create `src/vulca/real_brief/fixtures.py` with this structure and these exact fixture slugs:
+
+```python
+"""Built-in public creative brief fixtures for the real-brief benchmark."""
+from __future__ import annotations
+
+from vulca.real_brief.types import (
+    REVIEW_DIMENSIONS,
+    Deliverable,
+    RealBriefFixture,
+    SourceInfo,
+    safe_slug,
+)
+
+
+def _dims() -> list[str]:
+    return list(REVIEW_DIMENSIONS)
+
+
+def build_real_brief_fixtures() -> list[RealBriefFixture]:
+    return [
+        RealBriefFixture(
+            slug="gsm-community-market-campaign",
+            title="Glenwood Sunday Market Campaign System",
+            source=SourceInfo(
+                url=(
+                    "https://rpba.org/wp-content/uploads/2026/02/"
+                    "Marketing-Creative-Services-for-GSM-RFP-2026.pdf"
+                ),
+                retrieved_on="2026-04-30",
+                usage_note="Internal benchmark only",
+            ),
+            client="Rogers Park Business Alliance / Glenwood Sunday Market",
+            context=(
+                "Community farmers market marketing system for a 19-week 2026 "
+                "market season."
+            ),
+            audience=[
+                "local shoppers",
+                "SNAP and matching-program participants",
+                "vendors and community partners",
+            ],
+            deliverables=[
+                Deliverable("content framework", "19-week system", "planning"),
+                Deliverable("social templates", "editable Canva templates", "social"),
+                Deliverable("banner concepts", "market signage", "print"),
+                Deliverable("sticker and tote concepts", "merchandise preview", "print"),
+            ],
+            constraints=[
+                "must use existing logo, colors, and fonts",
+                "must use real photography",
+                "must avoid illustrations and clip art",
+                "must remain Canva-editable",
+            ],
+            budget="$5,000",
+            timeline="2026 market season",
+            required_outputs=["decision_package", "production_package"],
+            ai_policy="unspecified",
+            simulation_only=True,
+            risks=[
+                "generic farmers market aesthetic",
+                "template set not reusable for 19 weeks",
+                "visual system not editable by the client",
+            ],
+            avoid=["clip art", "illustration-first campaign", "single poster only"],
+            evaluation_dimensions=_dims(),
+            source_brief=(
+                "Design a reusable community market campaign system with evergreen "
+                "templates, real-photo usage rules, social examples, and print/merch "
+                "preview assets."
+            ),
+            domain="brand_visual",
+            tags=["campaign", "community", "templates"],
+        ),
+        RealBriefFixture(
+            slug="seattle-polish-film-festival-poster",
+            title="Seattle Polish Film Festival Poster",
+            source=SourceInfo(
+                url="https://www.polishfilms.org/submit-a-poster",
+                retrieved_on="2026-04-30",
+                usage_note="Internal benchmark only",
+            ),
+            client="Seattle Polish Film Festival",
+            context="Signature poster concept for the 34th festival edition.",
+            audience=[
+                "festival attendees",
+                "Polish cinema community",
+                "Seattle arts audience",
+            ],
+            deliverables=[
+                Deliverable("poster concept", "11 x 17 in vertical", "print/digital"),
+                Deliverable("program cover adaptation", "same key art", "print"),
+            ],
+            constraints=[
+                "required festival text must be present",
+                "dates, venues, website, and producer line must be accounted for",
+                "bottom sponsor or patron logo band must remain available",
+                "print output should anticipate CMYK and 300 dpi production",
+            ],
+            budget="not specified by source",
+            timeline="source-specific contest deadline",
+            required_outputs=["decision_package", "production_package"],
+            ai_policy="unspecified",
+            simulation_only=True,
+            risks=[
+                "broken generated text",
+                "unsafe margins",
+                "generic Polish national symbolism",
+                "missing sponsor band",
+            ],
+            avoid=["illegible typography", "crowded logo area", "flag-only concept"],
+            evaluation_dimensions=_dims(),
+            source_brief=(
+                "Create layout-safe poster concept directions for a Polish film "
+                "festival, including required text strategy, margins, sponsor band, "
+                "and print-risk notes."
+            ),
+            domain="poster",
+            tags=["poster", "film", "layout"],
+        ),
+        RealBriefFixture(
+            slug="model-young-package-unpacking-taboo",
+            title="Model Young Package 2026: Unpacking Taboo",
+            source=SourceInfo(
+                url=(
+                    "https://www.modelgroup.com/language-masters/en/"
+                    "model-young-package.html"
+                ),
+                retrieved_on="2026-04-30",
+                usage_note="Internal benchmark only",
+            ),
+            client="Model Young Package",
+            context=(
+                "Paper or cardboard packaging concept around sensitive or "
+                "stigmatized topics."
+            ),
+            audience=["competition jury", "design educators", "social-impact brands"],
+            deliverables=[
+                Deliverable("packaging concept", "paper/cardboard structure", "product"),
+                Deliverable("unboxing flow", "step sequence", "prototype planning"),
+                Deliverable("structure diagram prompt", "blueprint-style view", "planning"),
+            ],
+            constraints=[
+                "must be respectful toward taboo-adjacent subject matter",
+                "must consider manufacturability",
+                "must consider sustainability and material economy",
+                "must explain function and ergonomics",
+            ],
+            budget="competition entry; production budget not specified",
+            timeline="2026 competition cycle",
+            required_outputs=["decision_package", "production_package"],
+            ai_policy="unspecified",
+            simulation_only=True,
+            risks=[
+                "sensationalizing sensitive topics",
+                "beautiful render without structural logic",
+                "unmanufacturable packaging form",
+            ],
+            avoid=["shock-value visuals", "decorative box only", "plastic-first concept"],
+            evaluation_dimensions=_dims(),
+            source_brief=(
+                "Design a paper-based packaging proposal for a taboo-adjacent "
+                "product with respectful concept, structure, unboxing sequence, "
+                "material constraints, and prototype-oriented visuals."
+            ),
+            domain="packaging",
+            tags=["packaging", "structure", "social-design"],
+        ),
+        RealBriefFixture(
+            slug="erie-botanical-gardens-public-art",
+            title="Buffalo and Erie County Botanical Gardens Public Art",
+            source=SourceInfo(
+                url=(
+                    "https://www4.erie.gov/publicart/"
+                    "2026-call-artists-buffalo-and-erie-county-botanical-gardens"
+                ),
+                retrieved_on="2026-04-30",
+                usage_note="Internal benchmark only",
+            ),
+            client="Erie County / Buffalo and Erie County Botanical Gardens",
+            context=(
+                "Site-specific public art proposal for a botanical garden setting."
+            ),
+            audience=["public art panel", "garden visitors", "local community"],
+            deliverables=[
+                Deliverable("artist proposal", "concept package", "proposal"),
+                Deliverable("site-response rationale", "written narrative", "proposal"),
+                Deliverable("installation sketch prompts", "visual thumbnails", "planning"),
+            ],
+            constraints=[
+                "must respond to site history and future",
+                "must address durability and maintenance",
+                "must include installation and engineering assumptions",
+                "must respect public access and safety",
+            ],
+            budget="up to $75,000",
+            timeline="2026 public art process",
+            required_outputs=["decision_package", "production_package"],
+            ai_policy="unspecified",
+            simulation_only=True,
+            risks=[
+                "gallery object rather than site-specific public work",
+                "missing maintenance plan",
+                "budget fantasy",
+            ],
+            avoid=["temporary-looking materials", "unanchored decorative sculpture"],
+            evaluation_dimensions=_dims(),
+            source_brief=(
+                "Create a site-specific public art proposal package with concept, "
+                "site rationale, material palette, installation assumptions, "
+                "maintenance risks, budget notes, and review thumbnails."
+            ),
+            domain="public_art",
+            tags=["public-art", "site-specific", "proposal"],
+        ),
+        RealBriefFixture(
+            slug="music-video-treatment-low-budget",
+            title="Low-Budget Music Video Treatment",
+            source=SourceInfo(
+                url="https://creative-commission.com/briefs/brief-10642",
+                retrieved_on="2026-04-30",
+                usage_note="Internal benchmark only",
+            ),
+            client="Music artist / label brief",
+            context=(
+                "Director or producer treatment for a low-budget music video, "
+                "with AI elements allowed by the brief."
+            ),
+            audience=["artist team", "label commissioner", "director shortlist panel"],
+            deliverables=[
+                Deliverable("director treatment", "written concept", "pitch"),
+                Deliverable("mood frames", "visual references", "pitch"),
+                Deliverable("scene beats", "sequence outline", "production planning"),
+            ],
+            constraints=[
+                "must fit low-budget execution",
+                "must disclose AI-use approach",
+                "must not assume expensive locations or large crew",
+                "must avoid asking for unpaid full treatment before shortlist",
+            ],
+            budget="about GBP 1,000",
+            timeline="source-specific commission window",
+            required_outputs=["decision_package", "production_package"],
+            ai_policy="allowed",
+            simulation_only=True,
+            risks=[
+                "overproduced concept",
+                "moodboard without executable scenes",
+                "unclear AI disclosure",
+            ],
+            avoid=["large crew assumptions", "expensive VFX-heavy production"],
+            evaluation_dimensions=_dims(),
+            source_brief=(
+                "Simulate a shortlisted director treatment with concept, mood "
+                "frames, scene structure, production constraints, AI-use disclosure, "
+                "and deliverables plan."
+            ),
+            domain="video_treatment",
+            tags=["video", "treatment", "low-budget"],
+        ),
+    ]
+
+
+def get_real_brief_fixture(slug: str) -> RealBriefFixture:
+    safe = safe_slug(slug)
+    for fixture in build_real_brief_fixtures():
+        if fixture.slug == safe:
+            return fixture
+    known = ", ".join(fixture.slug for fixture in build_real_brief_fixtures())
+    raise ValueError(f"unknown real brief slug: {slug!r}; expected one of: {known}")
+```
+
+Update `src/vulca/real_brief/__init__.py`:
+
+```python
+from vulca.real_brief.fixtures import (
+    build_real_brief_fixtures,
+    get_real_brief_fixture,
+)
+
+__all__ += [
+    "build_real_brief_fixtures",
+    "get_real_brief_fixture",
+]
+```
+
+- [ ] **Step 4: Run tests to verify Task 2 passes**
+
+Run:
+
+```bash
+PYTHONPATH=src python3 -m pytest tests/test_real_brief_benchmark.py -q
+```
+
+Expected: PASS for Task 1 and Task 2 tests.
+
+- [ ] **Step 5: Commit Task 2**
+
+Run:
+
+```bash
+git add src/vulca/real_brief/__init__.py src/vulca/real_brief/fixtures.py tests/test_real_brief_benchmark.py
+git commit -m "feat: add real brief benchmark fixtures"
+```
+
+---
+
+### Task 3: A/B/C/D Condition Generation
+
+**Files:**
+- Create: `src/vulca/real_brief/conditions.py`
+- Modify: `src/vulca/real_brief/__init__.py`
+- Test: `tests/test_real_brief_benchmark.py`
+
+- [ ] **Step 1: Write failing tests for condition generation**
+
+Append:
+
+```python
+def test_build_real_brief_conditions_a_through_d():
+    from vulca.real_brief.conditions import build_real_brief_conditions
+    from vulca.real_brief.fixtures import get_real_brief_fixture
+
+    fixture = get_real_brief_fixture("seattle-polish-film-festival-poster")
+    conditions = build_real_brief_conditions(fixture)
+
+    assert [condition["id"] for condition in conditions] == ["A", "B", "C", "D"]
+    assert conditions[0]["label"] == "One-shot model baseline"
+    assert "Raw real brief" in conditions[0]["purpose"]
+    assert "Required deliverables" in conditions[1]["prompt"]
+    assert "Missing questions" in conditions[2]["prompt"]
+    assert "Preview plan" in conditions[3]["prompt"]
+    assert conditions[3]["workflow_stage"] == "vulca-preview-iterate"
+
+
+def test_condition_generation_preserves_fixture_constraints():
+    from vulca.real_brief.conditions import build_real_brief_conditions
+    from vulca.real_brief.fixtures import get_real_brief_fixture
+
+    fixture = get_real_brief_fixture("gsm-community-market-campaign")
+    conditions = build_real_brief_conditions(fixture)
+    joined = "\n".join(condition["prompt"] for condition in conditions)
+
+    assert "Canva-editable" in joined
+    assert "real photography" in joined
+    assert "19-week" in joined
+    assert "clip art" in joined
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+PYTHONPATH=src python3 -m pytest tests/test_real_brief_benchmark.py -q
+```
+
+Expected: FAIL with `ModuleNotFoundError: No module named 'vulca.real_brief.conditions'`.
+
+- [ ] **Step 3: Implement condition generation**
+
+Create `src/vulca/real_brief/conditions.py`:
+
+```python
+"""A/B/C/D condition generation for real-brief benchmarks."""
+from __future__ import annotations
+
+from typing import Any
+
+from vulca.discovery.cards import generate_direction_cards
+from vulca.discovery.profile import infer_taste_profile
+from vulca.discovery.prompting import compose_prompt_from_direction_card
+from vulca.real_brief.types import CONDITION_IDS, RealBriefFixture
+
+
+def _lines(title: str, values: list[str]) -> str:
+    return f"{title}:\n" + "\n".join(f"- {item}" for item in values)
+
+
+def brief_digest(fixture: RealBriefFixture) -> str:
+    deliverables = [
+        f"{item.name} ({item.format}, {item.channel})"
+        for item in fixture.deliverables
+    ]
+    return "\n".join(
+        [
+            f"Client: {fixture.client}",
+            f"Context: {fixture.context}",
+            _lines("Audience", fixture.audience),
+            _lines("Required deliverables", deliverables),
+            _lines("Constraints", fixture.constraints),
+            f"Budget: {fixture.budget}",
+            f"Timeline: {fixture.timeline}",
+            _lines("Risks", fixture.risks),
+            _lines("Avoid", fixture.avoid),
+            f"AI policy: {fixture.ai_policy}",
+            f"Simulation only: {fixture.simulation_only}",
+        ]
+    )
+
+
+def _direction_text(fixture: RealBriefFixture) -> dict[str, Any]:
+    intent = f"{fixture.title}. {fixture.source_brief} {brief_digest(fixture)}"
+    profile = infer_taste_profile(slug=fixture.slug, intent=intent)
+    cards = generate_direction_cards(profile, count=3)
+    selected = cards[0]
+    prompt = compose_prompt_from_direction_card(selected, target="final")
+    return {
+        "profile": profile.to_dict(),
+        "cards": [card.to_dict() for card in cards],
+        "selected_card": selected.to_dict(),
+        "compiled_prompt": prompt.to_dict(),
+    }
+
+
+def build_real_brief_conditions(fixture: RealBriefFixture) -> list[dict[str, Any]]:
+    fixture.validate()
+    digest = brief_digest(fixture)
+    direction = _direction_text(fixture)
+    selected = direction["selected_card"]
+    compiled = direction["compiled_prompt"]
+    conditions = [
+        {
+            "id": "A",
+            "label": "One-shot model baseline",
+            "workflow_stage": "one-shot",
+            "purpose": "Raw real brief condensed into a single model ask.",
+            "prompt": (
+                f"Create the requested creative output for this real brief.\n\n{digest}\n\n"
+                "Return a polished concept and any visual prompt needed to generate it."
+            ),
+        },
+        {
+            "id": "B",
+            "label": "Structured brief baseline",
+            "workflow_stage": "structured-brief",
+            "purpose": "Same brief normalized into structured client, deliverable, and constraint fields.",
+            "prompt": (
+                "Create a direction from the structured brief below.\n\n"
+                f"{digest}\n\n"
+                "Success criteria:\n"
+                "- satisfy required deliverables\n"
+                "- respect every listed constraint\n"
+                "- identify the most production-relevant risk"
+            ),
+        },
+        {
+            "id": "C",
+            "label": "Vulca planning workflow",
+            "workflow_stage": "vulca-planning",
+            "purpose": "Vulca-style ambiguity detection, direction cards, visual operations, and evaluation focus.",
+            "prompt": (
+                "Build a Vulca planning package before generating final pixels.\n\n"
+                f"{digest}\n\n"
+                "Missing questions:\n"
+                "- Which stakeholder approves the final direction?\n"
+                "- Which deliverable must be most production-ready first?\n"
+                "- Which source assets already exist?\n\n"
+                f"Selected direction card: {selected['label']}\n"
+                f"Direction summary: {selected['summary']}\n"
+                f"Visual operations: {selected['visual_ops']}\n"
+                f"Evaluation focus: {selected['evaluation_focus']}"
+            ),
+        },
+        {
+            "id": "D",
+            "label": "Vulca preview-and-iterate workflow",
+            "workflow_stage": "vulca-preview-iterate",
+            "purpose": "Planning package plus preview prompts, critique pass, refined prompt, and editability notes.",
+            "prompt": (
+                "Build a Vulca preview-and-iterate package for this brief.\n\n"
+                f"{digest}\n\n"
+                "Preview plan:\n"
+                "- produce 2-3 low-cost thumbnail directions before final comp\n"
+                "- critique each direction against constraints and risks\n"
+                "- refine the strongest direction into a final comp prompt\n"
+                "- document editability, redraw, and reuse notes\n\n"
+                f"Final comp prompt: {compiled['prompt']}\n"
+                f"Negative prompt: {compiled['negative_prompt']}"
+            ),
+        },
+    ]
+    assert tuple(item["id"] for item in conditions) == CONDITION_IDS
+    return conditions
+```
+
+Update exports in `src/vulca/real_brief/__init__.py`:
+
+```python
+from vulca.real_brief.conditions import (
+    brief_digest,
+    build_real_brief_conditions,
+)
+
+__all__ += [
+    "brief_digest",
+    "build_real_brief_conditions",
+]
+```
+
+- [ ] **Step 4: Run tests to verify Task 3 passes**
+
+Run:
+
+```bash
+PYTHONPATH=src python3 -m pytest tests/test_real_brief_benchmark.py -q
+```
+
+Expected: PASS for Task 1 through Task 3 tests.
+
+- [ ] **Step 5: Commit Task 3**
+
+Run:
+
+```bash
+git add src/vulca/real_brief/__init__.py src/vulca/real_brief/conditions.py tests/test_real_brief_benchmark.py
+git commit -m "feat: generate real brief benchmark conditions"
+```
+
+---
+
+### Task 4: Dry-Run Artifact Writer
+
+**Files:**
+- Create: `src/vulca/real_brief/artifacts.py`
+- Modify: `src/vulca/real_brief/__init__.py`
+- Test: `tests/test_real_brief_benchmark.py`
+
+- [ ] **Step 1: Write failing tests for artifact tree and contracts**
+
+Append:
+
+```python
+def test_write_real_brief_dry_run_artifacts(tmp_path):
+    from vulca.real_brief.artifacts import write_real_brief_dry_run
+
+    result = write_real_brief_dry_run(
+        output_root=tmp_path,
+        slug="seattle-polish-film-festival-poster",
+        date="2026-05-01",
+        write_html_review=False,
+    )
+
+    out_dir = Path(result["output_dir"])
+    assert out_dir == tmp_path / "2026-05-01-seattle-polish-film-festival-poster"
+    for rel in [
+        "source_brief.md",
+        "structured_brief.json",
+        "decision_package.md",
+        "production_package.md",
+        "workflow_handoff.json",
+        "review_schema.json",
+        "conditions/A-one-shot.md",
+        "conditions/B-structured-brief.md",
+        "conditions/C-vulca-planning.md",
+        "conditions/D-vulca-preview-iterate.md",
+        "prompts/A.txt",
+        "prompts/B.txt",
+        "prompts/C.txt",
+        "prompts/D.txt",
+        "images/README.md",
+        "evaluations/README.md",
+        "summary.md",
+        "manifest.json",
+    ]:
+        assert (out_dir / rel).exists(), rel
+
+    handoff = json.loads((out_dir / "workflow_handoff.json").read_text())
+    assert handoff["schema_version"] == "0.1"
+    assert handoff["human_gate_required"] is True
+    assert handoff["visual_discovery_seed"]["slug"] == (
+        "seattle-polish-film-festival-poster"
+    )
+    assert handoff["visual_brainstorm_seed"]["domain"] == "poster"
+
+    review = json.loads((out_dir / "review_schema.json").read_text())
+    assert review["scale"] == {"min": 0, "max": 2, "step": 1}
+    assert "decision_usefulness" in [d["id"] for d in review["dimensions"]]
+
+    summary = (out_dir / "summary.md").read_text(encoding="utf-8")
+    assert "No image quality conclusion" in summary
+    assert "simulation_only: true" in summary
+
+
+def test_write_real_brief_dry_run_rejects_secret_like_output_root(tmp_path):
+    from vulca.real_brief.artifacts import write_real_brief_dry_run
+
+    out = tmp_path / "safe-output"
+    write_real_brief_dry_run(
+        output_root=out,
+        slug="gsm-community-market-campaign",
+        date="2026-05-01",
+        write_html_review=False,
+    )
+    generated = "\n".join(
+        path.read_text(encoding="utf-8", errors="ignore")
+        for path in out.rglob("*")
+        if path.is_file() and path.suffix in {".md", ".json", ".txt", ".html"}
+    )
+    assert "sk-" not in generated
+    assert "VULCA_REAL_PROVIDER_API_KEY" not in generated
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+PYTHONPATH=src python3 -m pytest tests/test_real_brief_benchmark.py -q
+```
+
+Expected: FAIL with `ModuleNotFoundError: No module named 'vulca.real_brief.artifacts'`.
+
+- [ ] **Step 3: Implement artifact writer**
+
+Create `src/vulca/real_brief/artifacts.py`:
+
+```python
+"""Artifact writing for real-brief benchmark dry runs."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from vulca.real_brief.conditions import build_real_brief_conditions
+from vulca.real_brief.fixtures import get_real_brief_fixture
+from vulca.real_brief.types import REVIEW_DIMENSIONS, RealBriefFixture, safe_slug
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.write_text(
+        json.dumps(payload, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _write_text(path: Path, text: str) -> None:
+    path.write_text(text.rstrip() + "\n", encoding="utf-8")
+
+
+def _review_schema() -> dict[str, Any]:
+    return {
+        "schema_version": "0.1",
+        "scale": {"min": 0, "max": 2, "step": 1},
+        "condition_ids": ["A", "B", "C", "D"],
+        "dimensions": [
+            {
+                "id": item,
+                "label": item.replace("_", " ").title(),
+                "description": f"Score {item.replace('_', ' ')} for real brief usefulness.",
+            }
+            for item in REVIEW_DIMENSIONS
+        ],
+    }
+
+
+def _source_brief_md(fixture: RealBriefFixture) -> str:
+    return f"""# Source Brief: {fixture.title}
+
+## Source
+- URL: {fixture.source.url}
+- Retrieved on: {fixture.source.retrieved_on}
+- Usage note: {fixture.source.usage_note}
+
+## Client
+{fixture.client}
+
+## Context
+{fixture.context}
+
+## Source Brief
+{fixture.source_brief}
+
+## Constraints
+{chr(10).join(f"- {item}" for item in fixture.constraints)}
+
+## Risks
+{chr(10).join(f"- {item}" for item in fixture.risks)}
+"""
+
+
+def _decision_package_md(fixture: RealBriefFixture) -> str:
+    directions = [
+        "Direction 1: compliance-first system",
+        "Direction 2: audience-empathy narrative",
+        "Direction 3: production-ready visual structure",
+    ]
+    return f"""# Decision Package: {fixture.title}
+
+## Brief Digest
+{fixture.context}
+
+## Assumptions
+- Existing brand/source assets may be incomplete at benchmark time.
+- Generated outputs are internal simulation artifacts.
+- Human approval remains required before any official `/visual-*` workflow advances.
+
+## Missing Questions
+- Which stakeholder makes the final decision?
+- Which deliverable must be production-ready first?
+- Which source assets are available?
+
+## Creative Directions
+{chr(10).join(f"- {item}" for item in directions)}
+
+## Direction Rationale
+The recommended route should privilege brief compliance, constraint handling,
+and decision usefulness over raw visual attractiveness.
+
+## Risks And Rejected Approaches
+{chr(10).join(f"- Avoid {item}" for item in fixture.avoid)}
+
+## Recommended Direction
+Direction 3: production-ready visual structure.
+
+## Decision Checklist
+- [ ] Required deliverables are represented.
+- [ ] Constraints are visible in the proposed direction.
+- [ ] Risks are named before generation.
+- [ ] Next production step is clear.
+"""
+
+
+def _production_package_md(fixture: RealBriefFixture, conditions: list[dict[str, Any]]) -> str:
+    prompt_packet = "\n".join(
+        f"- {condition['id']}: prompts/{condition['id']}.txt"
+        for condition in conditions
+    )
+    deliverables = "\n".join(
+        f"- {item.name}: {item.format} for {item.channel}"
+        for item in fixture.deliverables
+    )
+    return f"""# Production Package: {fixture.title}
+
+## Selected Direction
+Production-ready visual structure.
+
+## Prompt Packet
+{prompt_packet}
+
+## Visual Operations
+- Build around the required deliverables, not a single decorative image.
+- Keep constraints visible in composition and copy hierarchy.
+- Use preview prompts before final comp generation.
+
+## Layout And Structure Constraints
+{chr(10).join(f"- {item}" for item in fixture.constraints)}
+
+## Channel And Deliverable Constraints
+{deliverables}
+
+## Preview Or Thumbnail Plan
+- Generate rough previews for A/B/C/D only after explicit real-provider opt-in.
+- Compare previews against review_schema.json before selecting a final comp.
+
+## Evaluation Checklist
+{chr(10).join(f"- {item}" for item in REVIEW_DIMENSIONS)}
+
+## Editability And Reusability Notes
+- Prefer reusable systems over one-off hero images.
+- Preserve prompt and package provenance for later Studio rendering.
+
+## Redraw And Layer Notes
+- Do not depend on v0.22 mask refinement in Phase 1.
+- Record likely redraw targets for future `/redraw-layer` integration.
+
+## Next Iteration Plan
+- Collect human review scores.
+- Promote strongest condition into official workflow adapter in Phase 2.
+"""
+
+
+def _workflow_handoff(fixture: RealBriefFixture) -> dict[str, Any]:
+    return {
+        "schema_version": "0.1",
+        "slug": fixture.slug,
+        "structured_brief_path": "structured_brief.json",
+        "visual_discovery_seed": {
+            "slug": fixture.slug,
+            "title": fixture.title,
+            "initial_intent": fixture.source_brief,
+            "domain": fixture.domain,
+        },
+        "visual_brainstorm_seed": {
+            "slug": fixture.slug,
+            "domain": fixture.domain,
+            "physical_form": [item.to_dict() for item in fixture.deliverables],
+            "constraints": list(fixture.constraints),
+        },
+        "visual_spec_seed": {
+            "evaluation_dimensions": list(fixture.evaluation_dimensions),
+            "provider_policy": "dry_run_default",
+        },
+        "visual_plan_seed": {
+            "condition_ids": ["A", "B", "C", "D"],
+            "requires_explicit_real_provider_opt_in": True,
+        },
+        "evaluate_seed": {
+            "review_schema_path": "review_schema.json",
+            "mode": "brief_compliance",
+        },
+        "human_gate_required": True,
+    }
+
+
+def _condition_filename(condition: dict[str, Any]) -> str:
+    suffix = {
+        "A": "one-shot",
+        "B": "structured-brief",
+        "C": "vulca-planning",
+        "D": "vulca-preview-iterate",
+    }[condition["id"]]
+    return f"{condition['id']}-{suffix}.md"
+
+
+def write_real_brief_dry_run(
+    *,
+    output_root: str | Path,
+    slug: str,
+    date: str,
+    write_html_review: bool = True,
+) -> dict[str, str]:
+    fixture = get_real_brief_fixture(safe_slug(slug))
+    conditions = build_real_brief_conditions(fixture)
+    out_dir = Path(output_root) / f"{date}-{fixture.slug}"
+    prompts_dir = out_dir / "prompts"
+    conditions_dir = out_dir / "conditions"
+    images_dir = out_dir / "images"
+    evaluations_dir = out_dir / "evaluations"
+    for directory in (prompts_dir, conditions_dir, images_dir, evaluations_dir):
+        directory.mkdir(parents=True, exist_ok=True)
+
+    _write_text(out_dir / "source_brief.md", _source_brief_md(fixture))
+    _write_json(out_dir / "structured_brief.json", fixture.to_dict())
+    _write_text(out_dir / "decision_package.md", _decision_package_md(fixture))
+    _write_text(
+        out_dir / "production_package.md",
+        _production_package_md(fixture, conditions),
+    )
+    _write_json(out_dir / "workflow_handoff.json", _workflow_handoff(fixture))
+    _write_json(out_dir / "review_schema.json", _review_schema())
+
+    for condition in conditions:
+        _write_text(prompts_dir / f"{condition['id']}.txt", condition["prompt"])
+        _write_text(
+            conditions_dir / _condition_filename(condition),
+            f"# {condition['label']}\n\n"
+            f"## Purpose\n{condition['purpose']}\n\n"
+            f"## Prompt\n{condition['prompt']}\n",
+        )
+
+    _write_text(
+        images_dir / "README.md",
+        "# Images\n\nDry run only. No provider images were generated.\n",
+    )
+    _write_text(
+        evaluations_dir / "README.md",
+        "# Evaluations\n\nDry run only. Run evaluation after real images exist.\n",
+    )
+    manifest = {
+        "schema_version": "0.1",
+        "experiment": "real-brief-benchmark",
+        "mode": "dry_run",
+        "provider_execution": "disabled",
+        "fixture": {"slug": fixture.slug, "title": fixture.title},
+        "conditions": [
+            {
+                "id": condition["id"],
+                "label": condition["label"],
+                "condition_path": f"conditions/{_condition_filename(condition)}",
+                "prompt_path": f"prompts/{condition['id']}.txt",
+            }
+            for condition in conditions
+        ],
+        "review_schema_path": "review_schema.json",
+        "workflow_handoff_path": "workflow_handoff.json",
+    }
+    _write_json(out_dir / "manifest.json", manifest)
+    summary = f"""# Real Brief Benchmark Dry Run: {fixture.slug}
+
+## Status
+dry_run
+
+## Fixture
+{fixture.title}
+
+## Simulation
+simulation_only: {str(fixture.simulation_only).lower()}
+ai_policy: {fixture.ai_policy}
+
+## Conditions
+{chr(10).join(f"- {item['id']}: {item['label']}" for item in conditions)}
+
+## Decision Boundary
+No image quality conclusion can be drawn from this dry run. It validates
+brief structure, workflow handoff, review schema, prompts, and package shape.
+"""
+    _write_text(out_dir / "summary.md", summary)
+
+    if write_html_review:
+        from vulca.real_brief.review_html import write_review_html
+
+        write_review_html(out_dir)
+
+    return {
+        "output_dir": str(out_dir),
+        "manifest_json": str(out_dir / "manifest.json"),
+        "summary_md": str(out_dir / "summary.md"),
+    }
+```
+
+Update exports in `src/vulca/real_brief/__init__.py`:
+
+```python
+from vulca.real_brief.artifacts import write_real_brief_dry_run
+
+__all__ += ["write_real_brief_dry_run"]
+```
+
+- [ ] **Step 4: Run tests to verify Task 4 passes**
+
+Run:
+
+```bash
+PYTHONPATH=src python3 -m pytest tests/test_real_brief_benchmark.py -q
+```
+
+Expected: PASS through Task 4 tests when `write_html_review=False`.
+
+- [ ] **Step 5: Commit Task 4**
+
+Run:
+
+```bash
+git add src/vulca/real_brief/__init__.py src/vulca/real_brief/artifacts.py tests/test_real_brief_benchmark.py
+git commit -m "feat: write real brief benchmark artifacts"
+```
+
+---
+
+### Task 5: Local HTML Review Surface
+
+**Files:**
+- Create: `src/vulca/real_brief/review_html.py`
+- Test: `tests/test_real_brief_benchmark.py`
+
+- [ ] **Step 1: Write failing tests for HTML review rendering**
+
+Append:
+
+```python
+def test_human_review_html_contains_conditions_dimensions_and_export(tmp_path):
+    from vulca.real_brief.artifacts import write_real_brief_dry_run
+
+    result = write_real_brief_dry_run(
+        output_root=tmp_path,
+        slug="model-young-package-unpacking-taboo",
+        date="2026-05-01",
+        write_html_review=True,
+    )
+
+    html = Path(result["output_dir"], "human_review.html").read_text(encoding="utf-8")
+    assert "Real Brief Benchmark Review" in html
+    assert "A-one-shot.md" in html
+    assert "D-vulca-preview-iterate.md" in html
+    assert "brief_compliance" in html
+    assert "decision_usefulness" in html
+    assert "Export JSON" in html
+    assert "sk-" not in html
+    assert "VULCA_REAL_PROVIDER_API_KEY" not in html
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+PYTHONPATH=src python3 -m pytest tests/test_real_brief_benchmark.py::test_human_review_html_contains_conditions_dimensions_and_export -q
+```
+
+Expected: FAIL with `ModuleNotFoundError: No module named 'vulca.real_brief.review_html'`.
+
+- [ ] **Step 3: Implement HTML renderer**
+
+Create `src/vulca/real_brief/review_html.py`:
+
+```python
+"""Static HTML review board for real-brief benchmark artifacts."""
+from __future__ import annotations
+
+import html
+import json
+from pathlib import Path
+
+
+def write_review_html(out_dir: str | Path) -> Path:
+    root = Path(out_dir)
+    manifest = json.loads((root / "manifest.json").read_text(encoding="utf-8"))
+    review = json.loads((root / "review_schema.json").read_text(encoding="utf-8"))
+    structured = json.loads((root / "structured_brief.json").read_text(encoding="utf-8"))
+    condition_cards = "\n".join(
+        f"""
+        <article class="condition" data-condition="{html.escape(condition['id'])}">
+          <h3>{html.escape(condition['id'])}: {html.escape(condition['label'])}</h3>
+          <p><a href="{html.escape(condition['condition_path'])}">{html.escape(condition['condition_path'])}</a></p>
+          <p><a href="{html.escape(condition['prompt_path'])}">{html.escape(condition['prompt_path'])}</a></p>
+        </article>
+        """
+        for condition in manifest["conditions"]
+    )
+    metric_rows = "\n".join(
+        f"""
+        <label class="metric">
+          <span>{html.escape(item['id'])}</span>
+          <select data-field="{html.escape(item['id'])}">
+            <option></option>
+            <option value="0">0 weak</option>
+            <option value="1">1 usable</option>
+            <option value="2">2 strong</option>
+          </select>
+        </label>
+        """
+        for item in review["dimensions"]
+    )
+    page = f"""<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Real Brief Benchmark Review</title>
+  <style>
+    body {{ margin: 0; font: 14px/1.5 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; color: #1f2428; background: #f7f7f4; }}
+    header, main {{ max-width: 1280px; margin: 0 auto; padding: 22px; }}
+    header {{ border-bottom: 1px solid #d9ded8; }}
+    h1 {{ margin: 0 0 8px; font-size: 26px; }}
+    .grid {{ display: grid; grid-template-columns: repeat(4, minmax(180px, 1fr)); gap: 12px; }}
+    .condition, .panel {{ border: 1px solid #d9ded8; border-radius: 8px; background: white; padding: 14px; }}
+    .metrics {{ display: grid; grid-template-columns: repeat(2, minmax(220px, 1fr)); gap: 10px; }}
+    .metric {{ display: grid; grid-template-columns: 1fr 90px; gap: 8px; align-items: center; }}
+    select, textarea {{ width: 100%; border: 1px solid #d9ded8; border-radius: 6px; font: inherit; }}
+    textarea {{ min-height: 90px; padding: 8px; }}
+    button {{ border: 1px solid #0d5f59; border-radius: 6px; background: #0f766e; color: white; padding: 9px 12px; font-weight: 700; }}
+    pre {{ white-space: pre-wrap; background: #101418; color: #e6edf3; padding: 14px; border-radius: 8px; }}
+    @media (max-width: 900px) {{ .grid, .metrics {{ grid-template-columns: 1fr; }} }}
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Real Brief Benchmark Review</h1>
+    <p>{html.escape(structured['title'])}</p>
+    <p>Score A/B/C/D on workflow usefulness, not raw image beauty.</p>
+  </header>
+  <main>
+    <section class="panel">
+      <h2>Brief</h2>
+      <p><strong>Client:</strong> {html.escape(structured['client'])}</p>
+      <p><strong>Context:</strong> {html.escape(structured['context'])}</p>
+      <p><strong>AI policy:</strong> {html.escape(structured['ai_policy'])}</p>
+    </section>
+    <section>
+      <h2>Conditions</h2>
+      <div class="grid">{condition_cards}</div>
+    </section>
+    <section class="panel">
+      <h2>Review Dimensions</h2>
+      <div class="metrics">{metric_rows}</div>
+      <h3>Notes</h3>
+      <textarea data-field="notes"></textarea>
+      <p><button id="exportBtn">Export JSON</button></p>
+      <pre id="output">{{}}</pre>
+    </section>
+  </main>
+  <script>
+    const storageKey = "vulca-real-brief-review-" + {json.dumps(structured['slug'])};
+    function collect() {{
+      const data = {{ slug: {json.dumps(structured['slug'])}, scores: {{}}, notes: "" }};
+      document.querySelectorAll("[data-field]").forEach((field) => {{
+        if (field.dataset.field === "notes") data.notes = field.value || "";
+        else data.scores[field.dataset.field] = field.value || "";
+      }});
+      return data;
+    }}
+    function save() {{ localStorage.setItem(storageKey, JSON.stringify(collect())); }}
+    function load() {{
+      const raw = localStorage.getItem(storageKey);
+      if (!raw) return;
+      const data = JSON.parse(raw);
+      document.querySelectorAll("[data-field]").forEach((field) => {{
+        if (field.dataset.field === "notes") field.value = data.notes || "";
+        else field.value = (data.scores && data.scores[field.dataset.field]) || "";
+      }});
+    }}
+    document.addEventListener("input", save);
+    document.addEventListener("change", save);
+    document.getElementById("exportBtn").addEventListener("click", async () => {{
+      const text = JSON.stringify(collect(), null, 2);
+      document.getElementById("output").textContent = text;
+      try {{ await navigator.clipboard.writeText(text); }} catch (error) {{}}
+    }});
+    load();
+  </script>
+</body>
+</html>
+"""
+    path = root / "human_review.html"
+    path.write_text(page, encoding="utf-8")
+    return path
+```
+
+- [ ] **Step 4: Run tests to verify Task 5 passes**
+
+Run:
+
+```bash
+PYTHONPATH=src python3 -m pytest tests/test_real_brief_benchmark.py -q
+```
+
+Expected: PASS through Task 5 tests.
+
+- [ ] **Step 5: Commit Task 5**
+
+Run:
+
+```bash
+git add src/vulca/real_brief/review_html.py tests/test_real_brief_benchmark.py
+git commit -m "feat: render real brief review board"
+```
+
+---
+
+### Task 6: CLI And Docs Link
+
+**Files:**
+- Create: `scripts/real_brief_benchmark.py`
+- Modify: `docs/product/experiments/cultural-term-efficacy.md`
+- Test: `tests/test_real_brief_benchmark.py`
+
+- [ ] **Step 1: Write failing tests for CLI dry-run and fail-closed real-provider mode**
+
+Append:
+
+```python
+def test_real_brief_benchmark_cli_writes_all_slugs(tmp_path):
+    from scripts.real_brief_benchmark import main
+
+    rc = main([
+        "--slug",
+        "all",
+        "--date",
+        "2026-05-01",
+        "--output-root",
+        str(tmp_path),
+        "--no-html-review",
+    ])
+
+    assert rc == 0
+    assert (tmp_path / "2026-05-01-gsm-community-market-campaign").exists()
+    assert (tmp_path / "2026-05-01-music-video-treatment-low-budget").exists()
+
+
+def test_real_brief_benchmark_cli_real_provider_fails_closed(tmp_path):
+    from scripts.real_brief_benchmark import main
+
+    with pytest.raises(RuntimeError, match="not implemented"):
+        main([
+            "--slug",
+            "gsm-community-market-campaign",
+            "--date",
+            "2026-05-01",
+            "--output-root",
+            str(tmp_path),
+            "--real-provider",
+        ])
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+PYTHONPATH=src python3 -m pytest tests/test_real_brief_benchmark.py::test_real_brief_benchmark_cli_writes_all_slugs tests/test_real_brief_benchmark.py::test_real_brief_benchmark_cli_real_provider_fails_closed -q
+```
+
+Expected: FAIL with `ModuleNotFoundError: No module named 'scripts.real_brief_benchmark'`.
+
+- [ ] **Step 3: Implement CLI**
+
+Create `scripts/real_brief_benchmark.py`:
+
+```python
+"""CLI for writing real-brief benchmark dry-run artifacts."""
+from __future__ import annotations
+
+import argparse
+from datetime import date as date_type
+from pathlib import Path
+
+from vulca.real_brief.artifacts import write_real_brief_dry_run
+from vulca.real_brief.fixtures import build_real_brief_fixtures, get_real_brief_fixture
+
+
+def _slugs(raw: str) -> list[str]:
+    if raw == "all":
+        return [fixture.slug for fixture in build_real_brief_fixtures()]
+    get_real_brief_fixture(raw)
+    return [raw]
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Write real-brief benchmark dry-run artifacts."
+    )
+    parser.add_argument("--slug", default="all")
+    parser.add_argument("--date", default=date_type.today().isoformat())
+    parser.add_argument(
+        "--output-root",
+        default="docs/product/experiments/real-brief-results",
+    )
+    parser.add_argument("--real-provider", action="store_true")
+    parser.add_argument("--provider", default="openai")
+    parser.add_argument("--max-images", type=int, default=0)
+    parser.add_argument("--write-html-review", action="store_true", default=True)
+    parser.add_argument("--no-html-review", action="store_true")
+    args = parser.parse_args(argv)
+
+    if args.real_provider:
+        raise RuntimeError(
+            "real-provider execution is not implemented for real-brief benchmark "
+            "Phase 1; dry-run artifacts are available without credentials"
+        )
+    if args.provider not in {"openai", "gemini", "comfyui"}:
+        raise ValueError("provider must be one of: openai, gemini, comfyui")
+    if args.max_images < 0:
+        raise ValueError("max-images must be >= 0")
+
+    write_html = args.write_html_review and not args.no_html_review
+    for slug in _slugs(args.slug):
+        write_real_brief_dry_run(
+            output_root=Path(args.output_root),
+            slug=slug,
+            date=args.date,
+            write_html_review=write_html,
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+```
+
+- [ ] **Step 4: Add docs link from cultural-term experiment**
+
+Append to `docs/product/experiments/cultural-term-efficacy.md`:
+
+````markdown
+
+## Successor: Real-Brief Benchmark
+
+The cultural-term experiment is a prompt-signal test. It is intentionally weaker
+than a real creative brief because strong image models can make broad prompts
+look good. The successor benchmark is `scripts/real_brief_benchmark.py`, which
+uses public creative briefs/RFPs and evaluates workflow usefulness, constraint
+handling, production realism, and decision quality.
+
+Dry run:
+
+```bash
+PYTHONPATH=src python3 scripts/real_brief_benchmark.py \
+  --date 2026-05-01 \
+  --slug all \
+  --output-root docs/product/experiments/real-brief-results
+```
+````
+
+- [ ] **Step 5: Run tests to verify Task 6 passes**
+
+Run:
+
+```bash
+PYTHONPATH=src python3 -m pytest tests/test_real_brief_benchmark.py -q
+```
+
+Expected: PASS through Task 6 tests.
+
+- [ ] **Step 6: Commit Task 6**
+
+Run:
+
+```bash
+git add scripts/real_brief_benchmark.py docs/product/experiments/cultural-term-efficacy.md tests/test_real_brief_benchmark.py
+git commit -m "feat: add real brief benchmark CLI"
+```
+
+---
+
+### Task 7: End-To-End Dry Run And Regression Verification
+
+**Files:**
+- Modify only if verification reveals a defect in files created by Tasks 1-6.
+
+- [ ] **Step 1: Run focused real-brief tests**
+
+Run:
+
+```bash
+PYTHONPATH=src python3 -m pytest tests/test_real_brief_benchmark.py -q
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 2: Run existing visual discovery regression tests**
+
+Run:
+
+```bash
+PYTHONPATH=src python3 -m pytest tests/test_visual_discovery_benchmark.py tests/test_visual_discovery_artifacts.py tests/test_visual_discovery_cards.py tests/test_visual_discovery_types.py -q
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 3: Run dry-run CLI into a temporary output root**
+
+Run:
+
+```bash
+PYTHONPATH=src python3 scripts/real_brief_benchmark.py \
+  --date 2026-05-01 \
+  --slug all \
+  --output-root /private/tmp/vulca-real-brief-benchmark-check
+```
+
+Expected:
+
+- five output directories under `/private/tmp/vulca-real-brief-benchmark-check`;
+- each contains `structured_brief.json`, `decision_package.md`, `production_package.md`, `workflow_handoff.json`, `review_schema.json`, `manifest.json`, and `summary.md`;
+- `summary.md` says no image quality conclusion can be drawn.
+
+- [ ] **Step 4: Scan temporary artifacts for secret-like strings**
+
+Run:
+
+```bash
+grep -R -n -E "sk-|VULCA_REAL_PROVIDER_API_KEY|OPENAI_API_KEY|globalai" /private/tmp/vulca-real-brief-benchmark-check
+```
+
+Expected: exit code 1 and no matches.
+
+- [ ] **Step 5: Inspect git status**
+
+Run:
+
+```bash
+git status --short
+```
+
+Expected: only intended files from Tasks 1-6 are tracked or modified before the final commit.
+
+- [ ] **Step 6: Commit final verification fixes if any were needed**
+
+If Task 7 required code changes, run:
+
+```bash
+git add src/vulca/real_brief scripts/real_brief_benchmark.py tests/test_real_brief_benchmark.py docs/product/experiments/cultural-term-efficacy.md
+git commit -m "test: verify real brief benchmark harness"
+```
+
+If no code changes were needed, do not create an empty commit.
+
+---
+
+## Final Verification Checklist
+
+Before claiming implementation complete, run:
+
+```bash
+PYTHONPATH=src python3 -m pytest tests/test_real_brief_benchmark.py -q
+PYTHONPATH=src python3 -m pytest tests/test_visual_discovery_benchmark.py tests/test_visual_discovery_artifacts.py tests/test_visual_discovery_cards.py tests/test_visual_discovery_types.py -q
+PYTHONPATH=src python3 scripts/real_brief_benchmark.py --date 2026-05-01 --slug all --output-root /private/tmp/vulca-real-brief-benchmark-check
+grep -R -n -E "sk-|VULCA_REAL_PROVIDER_API_KEY|OPENAI_API_KEY|globalai" /private/tmp/vulca-real-brief-benchmark-check
+```
+
+Expected:
+
+- focused real-brief tests pass;
+- existing visual discovery tests pass;
+- dry-run CLI writes five brief directories;
+- grep exits 1 with no secret-like matches.
+
+## Spec Coverage Review
+
+- Real brief fixtures: Task 2.
+- Structured brief schema: Task 1 and Task 4.
+- A/B/C/D conditions: Task 3 and Task 4.
+- Decision package: Task 4.
+- Production package: Task 4.
+- Workflow handoff bridge for Phase 2: Task 4.
+- Review schema bridge for Phase 3: Task 4.
+- Local HTML review surface: Task 5.
+- CLI dry-run: Task 6.
+- Real-provider fail-closed behavior: Task 6.
+- No redraw/v0.22 dependency: File structure and Task 4 package text.
+- No secrets in artifacts: Task 4 test and Task 7 scan.

--- a/docs/superpowers/specs/2026-04-30-real-brief-benchmark-design.md
+++ b/docs/superpowers/specs/2026-04-30-real-brief-benchmark-design.md
@@ -1,0 +1,465 @@
+# Real Brief Benchmark Harness Design
+
+**Date:** 2026-04-30
+**Status:** Approved design for implementation planning
+**Branch:** `codex/real-brief-benchmark-design`
+**Scope:** Phase 1 benchmark harness, with artifacts designed for Phase 2 workflow integration and Phase 3 review surface.
+
+## Decision
+
+Build Phase 1 as a **script-based real-brief benchmark harness**, but design its artifacts as long-lived product contracts.
+
+The implementation should not only compare generated images. It should test whether Vulca can turn realistic creative work into a decision-ready and production-ready package:
+
+```text
+real brief
+-> structured brief
+-> decision package
+-> production package
+-> A/B/C/D workflow comparison
+-> review schema + optional preview surface
+-> summary
+```
+
+Phase 1 is not the final workflow. It creates evidence and stable artifacts that Phase 2 can route into `/visual-discovery -> /visual-brainstorm -> /visual-spec -> /visual-plan -> /evaluate`, and that Phase 3 can render in a stronger Review/Studio surface.
+
+## Why This Replaces The Old Prompt Test
+
+The cultural-term benchmark used broad prompts such as "premium tea packaging with xieyi restraint." Strong image models can make those prompts look good even when the workflow adds little value. That makes evaluation ambiguous.
+
+The new benchmark must use real constraints from public creative briefs and RFPs:
+
+- concrete client/context;
+- target audience;
+- budget and timeline;
+- required deliverables;
+- format and production constraints;
+- legal/IP/AI usage constraints;
+- review criteria;
+- risks and avoid lists.
+
+Vulca should win on decision usefulness, constraint handling, structural control, and production readiness. It does not need to win on raw image beauty.
+
+## Phase Order
+
+### Phase 1: Benchmark-First Harness
+
+Implement now.
+
+The harness reads curated real-brief fixtures and writes dry-run artifacts by default. It may later support explicit real-provider opt-in, but no live provider call should happen unless the user passes a cost-bearing flag and local credentials.
+
+Phase 1 outputs:
+
+- `structured_brief.json`
+- `decision_package.md`
+- `production_package.md`
+- A/B/C/D condition packages
+- `workflow_handoff.json`
+- `review_schema.json`
+- `human_review.html`
+- `summary.md`
+
+### Phase 2: Workflow-First Adapter
+
+Design now, implement later.
+
+Phase 2 consumes `workflow_handoff.json` and turns a real brief into official Vulca workflow artifacts:
+
+```text
+structured_brief.json
+-> discovery seed
+-> proposal.md
+-> design.md
+-> plan.md
+-> evaluation.md/evaluation.json
+```
+
+This adapter should preserve the existing human gates in `/visual-brainstorm`, `/visual-spec`, and `/visual-plan`. It should not silently auto-finalize proposal/design/plan artifacts.
+
+### Phase 3: Review Surface / Studio
+
+Design now, implement after artifact stability.
+
+The review surface consumes the Phase 1/2 artifacts and displays:
+
+- source brief;
+- structured brief;
+- decision package;
+- production package;
+- A/B/C/D conditions;
+- prompts and images;
+- evaluations;
+- human scores;
+- final recommendation and next action.
+
+The first version may be local HTML, but the data contract must not be HTML-specific.
+
+## Real Brief Fixtures
+
+Phase 1 should ship five fixtures first:
+
+1. `gsm-community-market-campaign`
+   - Source: Rogers Park Business Alliance / Glenwood Sunday Market marketing and creative services RFP.
+   - Tests campaign systems, Canva-editable templates, social channels, banners, stickers, tote concepts, real photography, and brand consistency.
+
+2. `seattle-polish-film-festival-poster`
+   - Source: Seattle Polish Film Festival poster submission brief.
+   - Tests poster layout compliance, required text, logo band, margins, print-readiness, and cultural specificity.
+
+3. `model-young-package-unpacking-taboo`
+   - Source: Model Young Package 2026 "Unpacking Taboo."
+   - Tests packaging concept, paper/cardboard structure, unboxing flow, functionality, manufacturability, sustainability, and responsible tone.
+
+4. `erie-botanical-gardens-public-art`
+   - Source: Erie County / Buffalo and Erie County Botanical Gardens public art call.
+   - Tests artist proposal structure, site response, materials, durability, installation, maintenance, budget assumptions, and public meaning.
+
+5. `music-video-treatment-low-budget`
+   - Source: Creative Commission music-video brief.
+   - Tests director treatment, low-budget execution, mood frames, scene beats, production constraints, and AI-use disclosure.
+
+The fixture set intentionally spans brand/campaign, poster/layout, packaging/product, artist proposal, and director treatment workflows.
+
+## Source Hygiene
+
+The source list was checked on 2026-04-30. Several opportunities have deadlines before or near that date, so fixtures must be treated as historical/internal benchmark material unless a source is revalidated at run time.
+
+Implementation requirements:
+
+- store `source.retrieved_on` and `source.url` with every fixture;
+- store `source.deadline` when the source publishes one;
+- store `source.usage_note` as `Internal benchmark only` by default;
+- mark expired opportunities as `simulation_only: true`;
+- mark AI-prohibited sources as `ai_policy: prohibited_for_submission` and keep generated outputs out of any submission-ready claim;
+- prefer primary source pages/PDFs over aggregator summaries; use aggregators only as backup notes.
+
+## Fixture Schema
+
+Each fixture should be structured data, not only markdown prose.
+
+Required fields:
+
+```json
+{
+  "schema_version": "0.1",
+  "slug": "seattle-polish-film-festival-poster",
+  "title": "Seattle Polish Film Festival 2026 Poster",
+  "source": {
+    "url": "https://www.polishfilms.org/submit-a-poster",
+    "retrieved_on": "2026-04-30",
+    "usage_note": "Internal benchmark only"
+  },
+  "client": "Seattle Polish Film Festival",
+  "context": "Poster concept for the 34th festival edition.",
+  "audience": ["festival attendees", "Polish and American cinema communities"],
+  "deliverables": [
+    {
+      "name": "poster concept",
+      "format": "11 x 17 in vertical",
+      "channel": "print/digital",
+      "required": true
+    }
+  ],
+  "constraints": ["required text must be present", "bottom sponsor band reserved"],
+  "budget": "not specified by source",
+  "timeline": "source-specific contest deadline",
+  "required_outputs": ["decision_package", "production_package"],
+  "ai_policy": "allowed | prohibited_for_submission | unspecified",
+  "risks": ["broken text rendering", "unsafe margins", "generic national symbols"],
+  "avoid": ["illegible typography", "missing sponsor area"],
+  "evaluation_dimensions": ["brief_compliance", "constraint_handling"]
+}
+```
+
+For sources that prohibit AI submissions, the fixture must mark the run as simulation-only. The harness must not imply that outputs are submission-ready.
+
+## Output Artifact Tree
+
+Default output root:
+
+```text
+docs/product/experiments/real-brief-results/<date>-<slug>/
+  source_brief.md
+  structured_brief.json
+  decision_package.md
+  production_package.md
+  workflow_handoff.json
+  review_schema.json
+  conditions/
+    A-one-shot.md
+    B-structured-brief.md
+    C-vulca-planning.md
+    D-vulca-preview-iterate.md
+  prompts/
+    A.txt
+    B.txt
+    C.txt
+    D.txt
+  images/
+    README.md
+  evaluations/
+    README.md
+  human_review.html
+  summary.md
+  manifest.json
+```
+
+Dry-run outputs must be complete enough to inspect without images. `images/README.md` and `evaluations/README.md` explain that no image quality conclusion is available until real-provider generation and evaluation run.
+
+## Condition Design
+
+The old cultural-term A/B/C/D conditions should be replaced.
+
+### A. One-Shot Model Baseline
+
+Raw real brief condensed into a single ask. This represents what a user might paste into a strong model directly.
+
+Purpose: measure what one-click or chat-first generation can already do.
+
+### B. Structured Brief Baseline
+
+Same brief normalized into:
+
+- client;
+- context;
+- audience;
+- deliverables;
+- constraints;
+- success criteria;
+- avoid list.
+
+Purpose: measure the value of structure alone.
+
+### C. Vulca Planning Workflow
+
+Adds Vulca-style planning artifacts:
+
+- ambiguity detection;
+- missing questions;
+- cultural/taste/intent analysis;
+- 2-3 creative directions;
+- direction card;
+- visual operations;
+- evaluation rubric.
+
+Purpose: measure whether Vulca makes the user's intent clearer before generation.
+
+### D. Vulca Preview-And-Iterate Workflow
+
+Adds preview-oriented planning:
+
+- rough thumbnail prompts;
+- per-direction preview plan;
+- critique pass against the real brief;
+- refined direction;
+- final comp prompt;
+- editability/redraw notes.
+
+Purpose: measure the higher-value loop: chat while demonstrating, then deepen the chosen direction.
+
+## Decision Package Contract
+
+`decision_package.md` is for the client, artist, director, or designer to choose a direction.
+
+Required sections:
+
+- brief digest;
+- assumptions;
+- missing questions;
+- 2-3 creative directions;
+- direction rationale;
+- risks and rejected approaches;
+- recommended direction;
+- decision checklist.
+
+This package should be readable without knowing Vulca internals.
+
+## Production Package Contract
+
+`production_package.md` is for downstream execution.
+
+Required sections:
+
+- selected direction;
+- prompt packet;
+- visual operations;
+- layout/structure constraints;
+- channel/deliverable constraints;
+- preview or thumbnail plan;
+- evaluation checklist;
+- editability/reusability notes;
+- redraw/layer notes for future v0.22+ integration;
+- next iteration plan.
+
+This package may reference existing Vulca capabilities but must not require the redraw branch to be merged.
+
+## Workflow Handoff Contract
+
+`workflow_handoff.json` is the Phase 2 bridge.
+
+Required top-level shape:
+
+```json
+{
+  "schema_version": "0.1",
+  "slug": "seattle-polish-film-festival-poster",
+  "structured_brief_path": "structured_brief.json",
+  "visual_discovery_seed": {},
+  "visual_brainstorm_seed": {},
+  "visual_spec_seed": {},
+  "visual_plan_seed": {},
+  "evaluate_seed": {},
+  "human_gate_required": true
+}
+```
+
+Phase 1 only writes the seed data. Phase 2 will teach the official `/visual-*` workflows to consume or import this handoff.
+
+Important invariant: `human_gate_required` remains true. Benchmark automation must not bypass approval gates that current skills require.
+
+## Review Schema Contract
+
+`review_schema.json` is the Phase 3 bridge.
+
+Default dimensions use a 0/1/2 scale:
+
+1. `brief_compliance`
+2. `audience_fit`
+3. `deliverable_fit`
+4. `constraint_handling`
+5. `cultural_taste_specificity`
+6. `structural_control`
+7. `editability_reusability`
+8. `production_realism`
+9. `risk_avoidance`
+10. `decision_usefulness`
+
+Winning condition:
+
+- A/B may win visual attractiveness.
+- C/D should win decision usefulness, constraint handling, next-step clarity, and production realism.
+- If C/D do not win those, Vulca's product claim is weak for that brief type.
+
+## Human Review Surface
+
+Phase 1 should generate a lightweight `human_review.html` from `review_schema.json` and manifest data.
+
+Requirements:
+
+- group by brief and condition;
+- show condition descriptions;
+- show decision and production package links;
+- expose 0/1/2 scoring controls;
+- persist local browser notes;
+- export JSON;
+- avoid embedding provider keys or live endpoint information.
+
+This HTML is a prototype of Phase 3, not the final product.
+
+## Internal Vulca Tool Usage
+
+Phase 1 should reuse existing internals where possible:
+
+- `vulca.discovery.profile.infer_taste_profile` for early taste/domain signals;
+- `vulca.discovery.cards.generate_direction_cards` for Vulca-style direction candidates;
+- `vulca.discovery.prompting.compose_prompt_from_direction_card` for prompt assembly;
+- `vulca.studio.Brief` as a compatibility bridge to existing Studio concepts;
+- `vulca.studio.eval_criteria` for L1-L5 criteria generation or fallback;
+- provider interfaces only behind explicit real-provider opt-in;
+- `/evaluate` concepts for future image scoring after images exist.
+
+Phase 1 must not:
+
+- change redraw internals;
+- depend on v0.22 mask refinement;
+- bypass `/visual-*` human gates;
+- require network calls during tests;
+- write secrets to artifacts.
+
+## CLI Design
+
+Add a new script rather than overloading the cultural-term harness:
+
+```bash
+PYTHONPATH=src python3 scripts/real_brief_benchmark.py \
+  --date 2026-04-30 \
+  --slug all \
+  --output-root docs/product/experiments/real-brief-results
+```
+
+Flags:
+
+- `--slug <slug|all>`
+- `--date YYYY-MM-DD`
+- `--output-root <path>`
+- `--real-provider`
+- `--provider openai|gemini|comfyui`
+- `--max-images <n>`
+- `--write-html-review`
+
+Default mode is dry-run. Real-provider mode must fail closed without credentials and must not serialize credentials.
+
+## Error Handling
+
+- Unknown slug: fail with known slug list.
+- Missing fixture field: fail with field name and fixture path.
+- Unsafe slug: reject path traversal, absolute paths, `..`, and shell-like names.
+- Real-provider requested without credentials: fail before writing partial image artifacts.
+- AI-prohibited source: allow simulation artifacts, but mark `ai_policy` and `summary.md` clearly.
+- HTML export failure: still write core markdown/json artifacts and mark review surface as unavailable.
+- Evaluation absent: write `evaluations/README.md` and keep `summary.md` honest.
+
+## Testing Plan
+
+Unit tests:
+
+- fixture schema validation;
+- slug safety;
+- A/B/C/D condition generation;
+- artifact tree creation;
+- `workflow_handoff.json` schema;
+- `review_schema.json` schema;
+- dry-run no-provider behavior;
+- real-provider fail-closed behavior without credentials;
+- secret scanning for generated artifacts.
+
+Golden tests:
+
+- one fixture dry-run produces stable key files;
+- `summary.md` contains no quality conclusion in dry-run;
+- HTML review includes all condition ids and rubric dimensions.
+
+Existing regression tests to keep green:
+
+- visual discovery benchmark tests;
+- visual discovery artifact tests;
+- visual discovery cards/types tests.
+
+## Implementation Boundaries
+
+Keep Phase 1 implementation tightly scoped:
+
+- add real-brief fixture data;
+- add harness code;
+- add artifact writers;
+- add tests;
+- add docs update pointing to the benchmark.
+
+Do not implement Phase 2 workflow import or Phase 3 Studio in the first implementation PR. Only design the artifacts so those phases can consume them without reshaping the output tree.
+
+## Open Questions
+
+- Whether real brief fixtures should live under `docs/product/experiments/real-brief-fixtures/` or `src/vulca/real_brief/fixtures/`.
+- Whether Phase 1 should generate `proposal_seed.md` files for easier `/visual-brainstorm` import in Phase 2.
+- Whether music-video treatment should remain in the same fixture set even though current `/visual-brainstorm` explicitly excludes video; for Phase 1 benchmark it is valuable, but Phase 2 needs a video-specific adapter or a scoped redirect.
+
+## Sources
+
+- Glenwood Sunday Market marketing/creative services RFP: `https://rpba.org/wp-content/uploads/2026/02/Marketing-Creative-Services-for-GSM-RFP-2026.pdf`
+- ImageOut 2026 Theme Contest: `https://imageout.org/contest/`
+- Seattle Polish Film Festival poster brief: `https://www.polishfilms.org/submit-a-poster`
+- Model Young Package 2026: `https://www.modelgroup.com/language-masters/en/model-young-package.html`
+- Erie County Botanical Gardens public art call: `https://www4.erie.gov/publicart/2026-call-artists-buffalo-and-erie-county-botanical-gardens`
+- Los Angeles County Sanitation Districts graphic design RFP: `https://www.lacsd.org/Home/Components/RFP/RFP/853/488`
+- Charlotte-Mecklenburg Storm Water Services summary: `https://govtribe.com/opportunity/state-local-contract-opportunity/creative-services-for-storm-water-services-fy27rfp02`
+- Creative Commission music-video brief: `https://creative-commission.com/briefs/brief-10642`

--- a/scripts/real_brief_benchmark.py
+++ b/scripts/real_brief_benchmark.py
@@ -4,12 +4,6 @@ from __future__ import annotations
 import argparse
 from datetime import date as date_type
 
-from vulca.real_brief.artifacts import write_real_brief_dry_run
-from vulca.real_brief.fixtures import (
-    build_real_brief_fixtures,
-    get_real_brief_fixture,
-)
-
 
 def _non_negative_int(value: str) -> int:
     parsed = int(value)
@@ -19,6 +13,11 @@ def _non_negative_int(value: str) -> int:
 
 
 def _selected_slugs(slug: str) -> list[str]:
+    from vulca.real_brief.fixtures import (
+        build_real_brief_fixtures,
+        get_real_brief_fixture,
+    )
+
     if slug == "all":
         return [fixture.slug for fixture in build_real_brief_fixtures()]
     return [get_real_brief_fixture(slug).slug]
@@ -54,10 +53,12 @@ def main(argv: list[str] | None = None) -> int:
     )
     args = parser.parse_args(argv)
 
-    slugs = _selected_slugs(args.slug)
     if args.real_provider:
         raise RuntimeError("real provider execution is not implemented")
 
+    from vulca.real_brief.artifacts import write_real_brief_dry_run
+
+    slugs = _selected_slugs(args.slug)
     for slug in slugs:
         write_real_brief_dry_run(
             output_root=args.output_root,
@@ -68,5 +69,12 @@ def main(argv: list[str] | None = None) -> int:
     return 0
 
 
+def _cli() -> int:
+    try:
+        return main()
+    except (RuntimeError, ValueError) as exc:
+        raise SystemExit(f"error: {exc}") from None
+
+
 if __name__ == "__main__":
-    raise SystemExit(main())
+    raise SystemExit(_cli())

--- a/scripts/real_brief_benchmark.py
+++ b/scripts/real_brief_benchmark.py
@@ -1,0 +1,72 @@
+"""CLI harness for real-brief benchmark dry runs."""
+from __future__ import annotations
+
+import argparse
+from datetime import date as date_type
+
+from vulca.real_brief.artifacts import write_real_brief_dry_run
+from vulca.real_brief.fixtures import (
+    build_real_brief_fixtures,
+    get_real_brief_fixture,
+)
+
+
+def _non_negative_int(value: str) -> int:
+    parsed = int(value)
+    if parsed < 0:
+        raise argparse.ArgumentTypeError("must be >= 0")
+    return parsed
+
+
+def _selected_slugs(slug: str) -> list[str]:
+    if slug == "all":
+        return [fixture.slug for fixture in build_real_brief_fixtures()]
+    return [get_real_brief_fixture(slug).slug]
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Write real-brief benchmark dry-run artifacts."
+    )
+    parser.add_argument("--slug", default="all")
+    parser.add_argument("--date", default=date_type.today().isoformat())
+    parser.add_argument(
+        "--output-root",
+        default="docs/product/experiments/real-brief-results",
+    )
+    parser.add_argument("--real-provider", action="store_true")
+    parser.add_argument(
+        "--provider",
+        default="openai",
+        choices=["openai", "gemini", "comfyui"],
+    )
+    parser.add_argument("--max-images", type=_non_negative_int, default=0)
+    parser.add_argument(
+        "--write-html-review",
+        dest="write_html_review",
+        action="store_true",
+        default=True,
+    )
+    parser.add_argument(
+        "--no-html-review",
+        dest="write_html_review",
+        action="store_false",
+    )
+    args = parser.parse_args(argv)
+
+    slugs = _selected_slugs(args.slug)
+    if args.real_provider:
+        raise RuntimeError("real provider execution is not implemented")
+
+    for slug in slugs:
+        write_real_brief_dry_run(
+            output_root=args.output_root,
+            slug=slug,
+            date=args.date,
+            write_html_review=args.write_html_review,
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/real_brief_benchmark.py
+++ b/scripts/real_brief_benchmark.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import argparse
 from datetime import date as date_type
+import os
 
 
 def _non_negative_int(value: str) -> int:
@@ -21,6 +22,10 @@ def _selected_slugs(slug: str) -> list[str]:
     if slug == "all":
         return [fixture.slug for fixture in build_real_brief_fixtures()]
     return [get_real_brief_fixture(slug).slug]
+
+
+def _force_local_cost_map() -> None:
+    os.environ.setdefault("LITELLM_LOCAL_MODEL_COST_MAP", "true")
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -56,6 +61,7 @@ def main(argv: list[str] | None = None) -> int:
     if args.real_provider:
         raise RuntimeError("real provider execution is not implemented")
 
+    _force_local_cost_map()
     from vulca.real_brief.artifacts import write_real_brief_dry_run
 
     slugs = _selected_slugs(args.slug)

--- a/src/vulca/real_brief/__init__.py
+++ b/src/vulca/real_brief/__init__.py
@@ -1,6 +1,10 @@
 """Real creative brief benchmark harness."""
 from __future__ import annotations
 
+from vulca.real_brief.fixtures import (
+    build_real_brief_fixtures,
+    get_real_brief_fixture,
+)
 from vulca.real_brief.types import (
     CONDITION_IDS,
     REVIEW_DIMENSIONS,
@@ -13,7 +17,9 @@ from vulca.real_brief.types import (
 __all__ = [
     "CONDITION_IDS",
     "REVIEW_DIMENSIONS",
+    "build_real_brief_fixtures",
     "Deliverable",
+    "get_real_brief_fixture",
     "RealBriefFixture",
     "SourceInfo",
     "safe_slug",

--- a/src/vulca/real_brief/__init__.py
+++ b/src/vulca/real_brief/__init__.py
@@ -9,6 +9,7 @@ from vulca.real_brief.conditions import (
     brief_digest,
     build_real_brief_conditions,
 )
+from vulca.real_brief.artifacts import write_real_brief_dry_run
 from vulca.real_brief.types import (
     CONDITION_IDS,
     REVIEW_DIMENSIONS,
@@ -29,4 +30,5 @@ __all__ = [
     "RealBriefFixture",
     "SourceInfo",
     "safe_slug",
+    "write_real_brief_dry_run",
 ]

--- a/src/vulca/real_brief/__init__.py
+++ b/src/vulca/real_brief/__init__.py
@@ -5,11 +5,6 @@ from vulca.real_brief.fixtures import (
     build_real_brief_fixtures,
     get_real_brief_fixture,
 )
-from vulca.real_brief.conditions import (
-    brief_digest,
-    build_real_brief_conditions,
-)
-from vulca.real_brief.artifacts import write_real_brief_dry_run
 from vulca.real_brief.types import (
     CONDITION_IDS,
     REVIEW_DIMENSIONS,
@@ -32,3 +27,27 @@ __all__ = [
     "safe_slug",
     "write_real_brief_dry_run",
 ]
+
+_LAZY_EXPORTS = {
+    "brief_digest": ("vulca.real_brief.conditions", "brief_digest"),
+    "build_real_brief_conditions": (
+        "vulca.real_brief.conditions",
+        "build_real_brief_conditions",
+    ),
+    "write_real_brief_dry_run": (
+        "vulca.real_brief.artifacts",
+        "write_real_brief_dry_run",
+    ),
+}
+
+
+def __getattr__(name: str):
+    if name not in _LAZY_EXPORTS:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+    module_name, attr_name = _LAZY_EXPORTS[name]
+    from importlib import import_module
+
+    value = getattr(import_module(module_name), attr_name)
+    globals()[name] = value
+    return value

--- a/src/vulca/real_brief/__init__.py
+++ b/src/vulca/real_brief/__init__.py
@@ -1,0 +1,20 @@
+"""Real creative brief benchmark harness."""
+from __future__ import annotations
+
+from vulca.real_brief.types import (
+    CONDITION_IDS,
+    REVIEW_DIMENSIONS,
+    Deliverable,
+    RealBriefFixture,
+    SourceInfo,
+    safe_slug,
+)
+
+__all__ = [
+    "CONDITION_IDS",
+    "REVIEW_DIMENSIONS",
+    "Deliverable",
+    "RealBriefFixture",
+    "SourceInfo",
+    "safe_slug",
+]

--- a/src/vulca/real_brief/__init__.py
+++ b/src/vulca/real_brief/__init__.py
@@ -5,6 +5,10 @@ from vulca.real_brief.fixtures import (
     build_real_brief_fixtures,
     get_real_brief_fixture,
 )
+from vulca.real_brief.conditions import (
+    brief_digest,
+    build_real_brief_conditions,
+)
 from vulca.real_brief.types import (
     CONDITION_IDS,
     REVIEW_DIMENSIONS,
@@ -17,6 +21,8 @@ from vulca.real_brief.types import (
 __all__ = [
     "CONDITION_IDS",
     "REVIEW_DIMENSIONS",
+    "brief_digest",
+    "build_real_brief_conditions",
     "build_real_brief_fixtures",
     "Deliverable",
     "get_real_brief_fixture",

--- a/src/vulca/real_brief/artifacts.py
+++ b/src/vulca/real_brief/artifacts.py
@@ -373,10 +373,9 @@ def write_real_brief_dry_run(
     )
     written_files.extend(["images/README.md", "evaluations/README.md"])
 
-    summary = _summary_markdown(fixture.slug, date, len(conditions))
+    summary = _summary_markdown(fixture.slug, safe_date, len(conditions))
     _write_text(out_dir / "summary.md", summary)
     if write_html_review:
-        _write_html_review(out_dir)
         written_files.append("human_review.html")
 
     manifest = {
@@ -398,6 +397,8 @@ def write_real_brief_dry_run(
         "files": sorted(written_files),
     }
     _write_json(out_dir / "manifest.json", manifest)
+    if write_html_review:
+        _write_html_review(out_dir)
 
     return {
         "output_dir": str(out_dir),

--- a/src/vulca/real_brief/artifacts.py
+++ b/src/vulca/real_brief/artifacts.py
@@ -99,6 +99,7 @@ def _condition_manifest(conditions: list[dict[str, Any]]) -> list[dict[str, str]
         {
             "id": condition["id"],
             "label": condition["label"],
+            "purpose": condition["purpose"],
             **_condition_paths(condition),
         }
         for condition in conditions

--- a/src/vulca/real_brief/artifacts.py
+++ b/src/vulca/real_brief/artifacts.py
@@ -1,0 +1,197 @@
+"""Dry-run artifact writing for the real-brief benchmark."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from vulca.real_brief.conditions import build_real_brief_conditions
+from vulca.real_brief.fixtures import get_real_brief_fixture
+from vulca.real_brief.types import CONDITION_IDS, REVIEW_DIMENSIONS, safe_slug
+
+
+_CONDITION_FILENAMES = {
+    "A": "A-one-shot.md",
+    "B": "B-structured-brief.md",
+    "C": "C-vulca-planning.md",
+    "D": "D-vulca-preview-iterate.md",
+}
+
+
+def _write_text(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    _write_text(path, json.dumps(payload, indent=2, sort_keys=True) + "\n")
+
+
+def _condition_markdown(condition: dict[str, Any]) -> str:
+    return "\n\n".join(
+        [
+            f"# Condition {condition['id']}: {condition['label']}",
+            f"workflow_stage: {condition['workflow_stage']}",
+            f"purpose: {condition['purpose']}",
+            "## Prompt",
+            condition["prompt"],
+        ]
+    ) + "\n"
+
+
+def _summary_markdown(fixture_slug: str, date: str, condition_count: int) -> str:
+    return "\n".join(
+        [
+            f"# Real Brief Dry Run: {fixture_slug}",
+            "",
+            f"date: {date}",
+            "simulation_only: true",
+            f"condition_count: {condition_count}",
+            "",
+            "No image quality conclusion is made by this dry run.",
+            "It writes benchmark prompts, handoff data, and review scaffolding only.",
+            "",
+        ]
+    )
+
+
+def _workflow_handoff(fixture: Any, conditions: list[dict[str, Any]]) -> dict[str, Any]:
+    return {
+        "schema_version": "0.1",
+        "human_gate_required": True,
+        "simulation_only": True,
+        "fixture_slug": fixture.slug,
+        "condition_ids": [condition["id"] for condition in conditions],
+        "visual_discovery_seed": {
+            "slug": fixture.slug,
+            "title": fixture.title,
+            "domain": fixture.domain,
+            "tags": list(fixture.tags),
+            "source_usage_note": fixture.source.usage_note,
+        },
+        "visual_brainstorm_seed": {
+            "slug": fixture.slug,
+            "domain": fixture.domain,
+            "client": fixture.client,
+            "audience": list(fixture.audience),
+            "deliverables": [item.to_dict() for item in fixture.deliverables],
+            "constraints": list(fixture.constraints),
+            "risks": list(fixture.risks),
+            "avoid": list(fixture.avoid),
+        },
+    }
+
+
+def _review_schema() -> dict[str, Any]:
+    return {
+        "schema_version": "0.1",
+        "scale": {"min": 0, "max": 2, "step": 1},
+        "condition_ids": list(CONDITION_IDS),
+        "dimensions": [
+            {
+                "id": dimension,
+                "label": dimension.replace("_", " "),
+            }
+            for dimension in REVIEW_DIMENSIONS
+        ],
+    }
+
+
+def write_real_brief_dry_run(
+    output_root: str | Path,
+    slug: str,
+    date: str,
+    write_html_review: bool = True,
+) -> dict[str, str]:
+    """Write dry-run benchmark artifacts without invoking image providers."""
+    fixture = get_real_brief_fixture(safe_slug(slug))
+    conditions = build_real_brief_conditions(fixture)
+    output_root_path = Path(output_root)
+    out_dir = output_root_path / f"{date}-{fixture.slug}"
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    structured_brief = fixture.to_dict()
+    decision_package = "\n\n".join(
+        [
+            f"# Decision Package: {fixture.title}",
+            f"Client: {fixture.client}",
+            f"Domain: {fixture.domain}",
+            "## Risks",
+            "\n".join(f"- {item}" for item in fixture.risks),
+            "## Avoid",
+            "\n".join(f"- {item}" for item in fixture.avoid),
+        ]
+    ) + "\n"
+    production_package = "\n\n".join(
+        [
+            f"# Production Package: {fixture.title}",
+            "## Deliverables",
+            "\n".join(
+                f"- {item.name} ({item.format}, {item.channel})"
+                for item in fixture.deliverables
+            ),
+            "## Constraints",
+            "\n".join(f"- {item}" for item in fixture.constraints),
+            f"Timeline: {fixture.timeline}",
+            f"Budget: {fixture.budget}",
+        ]
+    ) + "\n"
+
+    written_files = [
+        "source_brief.md",
+        "structured_brief.json",
+        "decision_package.md",
+        "production_package.md",
+        "workflow_handoff.json",
+        "review_schema.json",
+        "summary.md",
+        "manifest.json",
+    ]
+
+    _write_text(out_dir / "source_brief.md", fixture.source_brief + "\n")
+    _write_json(out_dir / "structured_brief.json", structured_brief)
+    _write_text(out_dir / "decision_package.md", decision_package)
+    _write_text(out_dir / "production_package.md", production_package)
+    _write_json(out_dir / "workflow_handoff.json", _workflow_handoff(fixture, conditions))
+    _write_json(out_dir / "review_schema.json", _review_schema())
+
+    for condition in conditions:
+        condition_id = condition["id"]
+        condition_rel = f"conditions/{_CONDITION_FILENAMES[condition_id]}"
+        prompt_rel = f"prompts/{condition_id}.txt"
+        _write_text(out_dir / condition_rel, _condition_markdown(condition))
+        _write_text(out_dir / prompt_rel, condition["prompt"] + "\n")
+        written_files.extend([condition_rel, prompt_rel])
+
+    _write_text(
+        out_dir / "images/README.md",
+        "# Images\n\nDry-run placeholder. No images are generated here.\n",
+    )
+    _write_text(
+        out_dir / "evaluations/README.md",
+        "# Evaluations\n\nDry-run placeholder. No image evaluations are run here.\n",
+    )
+    written_files.extend(["images/README.md", "evaluations/README.md"])
+
+    summary = _summary_markdown(fixture.slug, date, len(conditions))
+    _write_text(out_dir / "summary.md", summary)
+    manifest = {
+        "schema_version": "0.1",
+        "fixture_slug": fixture.slug,
+        "date": date,
+        "simulation_only": True,
+        "condition_ids": [condition["id"] for condition in conditions],
+        "files": sorted(written_files),
+    }
+    _write_json(out_dir / "manifest.json", manifest)
+
+    if write_html_review:
+        from vulca.real_brief.review_html import write_review_html
+
+        write_review_html(out_dir)
+
+    return {
+        "output_dir": str(out_dir),
+        "manifest_json": str(out_dir / "manifest.json"),
+        "summary_md": str(out_dir / "summary.md"),
+    }

--- a/src/vulca/real_brief/artifacts.py
+++ b/src/vulca/real_brief/artifacts.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import json
+import re
 from pathlib import Path
 from typing import Any
 
@@ -16,6 +17,7 @@ _CONDITION_FILENAMES = {
     "C": "C-vulca-planning.md",
     "D": "D-vulca-preview-iterate.md",
 }
+_RUN_DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 
 
 def _write_text(path: Path, text: str) -> None:
@@ -25,6 +27,12 @@ def _write_text(path: Path, text: str) -> None:
 
 def _write_json(path: Path, payload: dict[str, Any]) -> None:
     _write_text(path, json.dumps(payload, indent=2, sort_keys=True) + "\n")
+
+
+def _safe_run_date(date: str) -> str:
+    if not _RUN_DATE_RE.fullmatch(date):
+        raise ValueError("run date must use YYYY-MM-DD")
+    return date
 
 
 def _condition_markdown(condition: dict[str, Any]) -> str:
@@ -55,9 +63,180 @@ def _summary_markdown(fixture_slug: str, date: str, condition_count: int) -> str
     )
 
 
+def _bullet_list(items: list[str]) -> str:
+    return "\n".join(f"- {item}" for item in items)
+
+
+def _deliverable_list(fixture: Any) -> str:
+    return "\n".join(
+        f"- {item.name} ({item.format}, {item.channel})"
+        for item in fixture.deliverables
+    )
+
+
+def _missing_questions() -> list[str]:
+    return [
+        "Which stakeholder approves the final direction?",
+        "Which deliverable must be most production-ready first?",
+        "Which source assets already exist?",
+    ]
+
+
+def _physical_form(fixture: Any) -> str:
+    return fixture.deliverables[0].name if fixture.deliverables else fixture.domain
+
+
+def _condition_paths(condition: dict[str, Any]) -> dict[str, str]:
+    condition_id = condition["id"]
+    return {
+        "condition_path": f"conditions/{_CONDITION_FILENAMES[condition_id]}",
+        "prompt_path": f"prompts/{condition_id}.txt",
+    }
+
+
+def _condition_manifest(conditions: list[dict[str, Any]]) -> list[dict[str, str]]:
+    return [
+        {
+            "id": condition["id"],
+            "label": condition["label"],
+            **_condition_paths(condition),
+        }
+        for condition in conditions
+    ]
+
+
+def _selected_card(conditions: list[dict[str, Any]]) -> dict[str, Any]:
+    for condition in conditions:
+        if condition.get("selected_direction_card"):
+            return condition["selected_direction_card"]
+    return {}
+
+
+def _decision_package(fixture: Any, conditions: list[dict[str, Any]]) -> str:
+    selected = _selected_card(conditions)
+    directions = conditions[2].get("direction_cards", []) if len(conditions) > 2 else []
+    direction_lines = [
+        f"- {card['label']}: {card['summary']}" for card in directions
+    ] or ["- Direction cards are unavailable in this dry run."]
+    checklist = [
+        "Required deliverables represented",
+        "Constraints acknowledged",
+        "Known risks documented",
+        "Human approval required before provider execution",
+    ]
+    return "\n\n".join(
+        [
+            f"# Decision Package: {fixture.title}",
+            "## Brief Digest",
+            "\n".join(
+                [
+                    f"Client: {fixture.client}",
+                    f"Domain: {fixture.domain}",
+                    f"Context: {fixture.context}",
+                    "Audience:",
+                    _bullet_list(fixture.audience),
+                    "Deliverables:",
+                    _deliverable_list(fixture),
+                    "Constraints:",
+                    _bullet_list(fixture.constraints),
+                ]
+            ),
+            "## Assumptions",
+            _bullet_list(
+                [
+                    "This package is a simulation-only planning artifact.",
+                    "No image provider is invoked by this dry run.",
+                    "Final production requires a human gate and source-asset review.",
+                ]
+            ),
+            "## Missing Questions",
+            _bullet_list(_missing_questions()),
+            "## Creative Directions",
+            "\n".join(direction_lines),
+            "## Direction Rationale",
+            selected.get("summary", "Use the strongest generated direction card."),
+            "## Risks And Rejected Approaches",
+            "\n".join(
+                [
+                    "Risks:",
+                    _bullet_list(fixture.risks),
+                    "Rejected approaches:",
+                    _bullet_list(fixture.avoid),
+                ]
+            ),
+            "## Recommended Direction",
+            selected.get("label", conditions[0]["label"]),
+            "## Decision Checklist",
+            _bullet_list(checklist),
+        ]
+    ) + "\n"
+
+
+def _production_package(fixture: Any, conditions: list[dict[str, Any]]) -> str:
+    selected = _selected_card(conditions)
+    visual_ops = selected.get("visual_ops", {})
+    visual_ops_lines = [
+        f"- {key.replace('_', ' ').title()}: {value}"
+        for key, value in visual_ops.items()
+    ] or ["- Use condition C/D visual operation notes."]
+    prompt_paths = [
+        f"- Condition {condition['id']}: {_condition_paths(condition)['prompt_path']}"
+        for condition in conditions
+    ]
+    return "\n\n".join(
+        [
+            f"# Production Package: {fixture.title}",
+            "## Selected Direction",
+            selected.get("label", conditions[0]["label"]),
+            "## Prompt Packet",
+            "\n".join(prompt_paths),
+            "## Visual Operations",
+            "\n".join(visual_ops_lines),
+            "## Layout And Structure Constraints",
+            _bullet_list(fixture.constraints),
+            "## Channel And Deliverable Constraints",
+            _deliverable_list(fixture),
+            "## Preview Or Thumbnail Plan",
+            _bullet_list(
+                [
+                    "Produce 2-3 low-cost thumbnail directions before final comp.",
+                    "Critique thumbnails against constraints, risks, and deliverables.",
+                    "Refine the strongest route into a final comp prompt.",
+                ]
+            ),
+            "## Evaluation Checklist",
+            _bullet_list(fixture.evaluation_dimensions),
+            "## Editability And Reusability Notes",
+            _bullet_list(
+                [
+                    "Document reusable components before final execution.",
+                    "Keep source constraints visible in the handoff package.",
+                ]
+            ),
+            "## Redraw And Layer Notes",
+            _bullet_list(
+                [
+                    "No redraw or mask provider runs in dry-run mode.",
+                    "Layer decisions should wait for explicit real-provider opt-in.",
+                ]
+            ),
+            "## Next Iteration Plan",
+            _bullet_list(
+                [
+                    "Review human scoring schema.",
+                    "Select one direction for Task 5 review rendering.",
+                    "Proceed only after the human gate is cleared.",
+                ]
+            ),
+        ]
+    ) + "\n"
+
+
 def _workflow_handoff(fixture: Any, conditions: list[dict[str, Any]]) -> dict[str, Any]:
     return {
         "schema_version": "0.1",
+        "slug": fixture.slug,
+        "structured_brief_path": "structured_brief.json",
         "human_gate_required": True,
         "simulation_only": True,
         "fixture_slug": fixture.slug,
@@ -65,6 +244,7 @@ def _workflow_handoff(fixture: Any, conditions: list[dict[str, Any]]) -> dict[st
         "visual_discovery_seed": {
             "slug": fixture.slug,
             "title": fixture.title,
+            "initial_intent": fixture.source_brief or fixture.context,
             "domain": fixture.domain,
             "tags": list(fixture.tags),
             "source_usage_note": fixture.source.usage_note,
@@ -72,12 +252,25 @@ def _workflow_handoff(fixture: Any, conditions: list[dict[str, Any]]) -> dict[st
         "visual_brainstorm_seed": {
             "slug": fixture.slug,
             "domain": fixture.domain,
+            "physical_form": _physical_form(fixture),
+            "constraints": list(fixture.constraints),
             "client": fixture.client,
             "audience": list(fixture.audience),
             "deliverables": [item.to_dict() for item in fixture.deliverables],
-            "constraints": list(fixture.constraints),
             "risks": list(fixture.risks),
             "avoid": list(fixture.avoid),
+        },
+        "visual_spec_seed": {
+            "evaluation_dimensions": list(fixture.evaluation_dimensions),
+            "provider_policy": "dry_run_default",
+        },
+        "visual_plan_seed": {
+            "condition_ids": [condition["id"] for condition in conditions],
+            "requires_explicit_real_provider_opt_in": True,
+        },
+        "evaluate_seed": {
+            "review_schema_path": "review_schema.json",
+            "mode": "brief_compliance",
         },
     }
 
@@ -97,6 +290,34 @@ def _review_schema() -> dict[str, Any]:
     }
 
 
+def _write_html_review(out_dir: Path) -> None:
+    try:
+        from vulca.real_brief.review_html import write_review_html
+    except ModuleNotFoundError as exc:
+        if exc.name != "vulca.real_brief.review_html":
+            raise
+        _write_text(
+            out_dir / "human_review.html",
+            "\n".join(
+                [
+                    "<!doctype html>",
+                    "<html><head><meta charset=\"utf-8\"><title>Human Review</title></head>",
+                    "<body>",
+                    "<h1>Full renderer pending</h1>",
+                    "<p>Task 5 will provide the full review renderer.</p>",
+                    "<p>Use <a href=\"manifest.json\">manifest.json</a> and "
+                    "<a href=\"review_schema.json\">review_schema.json</a> for "
+                    "this dry-run review.</p>",
+                    "</body></html>",
+                    "",
+                ]
+            ),
+        )
+        return
+
+    write_review_html(out_dir)
+
+
 def write_real_brief_dry_run(
     output_root: str | Path,
     slug: str,
@@ -106,36 +327,14 @@ def write_real_brief_dry_run(
     """Write dry-run benchmark artifacts without invoking image providers."""
     fixture = get_real_brief_fixture(safe_slug(slug))
     conditions = build_real_brief_conditions(fixture)
+    safe_date = _safe_run_date(date)
     output_root_path = Path(output_root)
-    out_dir = output_root_path / f"{date}-{fixture.slug}"
+    out_dir = output_root_path / f"{safe_date}-{fixture.slug}"
     out_dir.mkdir(parents=True, exist_ok=True)
 
     structured_brief = fixture.to_dict()
-    decision_package = "\n\n".join(
-        [
-            f"# Decision Package: {fixture.title}",
-            f"Client: {fixture.client}",
-            f"Domain: {fixture.domain}",
-            "## Risks",
-            "\n".join(f"- {item}" for item in fixture.risks),
-            "## Avoid",
-            "\n".join(f"- {item}" for item in fixture.avoid),
-        ]
-    ) + "\n"
-    production_package = "\n\n".join(
-        [
-            f"# Production Package: {fixture.title}",
-            "## Deliverables",
-            "\n".join(
-                f"- {item.name} ({item.format}, {item.channel})"
-                for item in fixture.deliverables
-            ),
-            "## Constraints",
-            "\n".join(f"- {item}" for item in fixture.constraints),
-            f"Timeline: {fixture.timeline}",
-            f"Budget: {fixture.budget}",
-        ]
-    ) + "\n"
+    decision_package = _decision_package(fixture, conditions)
+    production_package = _production_package(fixture, conditions)
 
     written_files = [
         "source_brief.md",
@@ -157,8 +356,9 @@ def write_real_brief_dry_run(
 
     for condition in conditions:
         condition_id = condition["id"]
-        condition_rel = f"conditions/{_CONDITION_FILENAMES[condition_id]}"
-        prompt_rel = f"prompts/{condition_id}.txt"
+        paths = _condition_paths(condition)
+        condition_rel = paths["condition_path"]
+        prompt_rel = paths["prompt_path"]
         _write_text(out_dir / condition_rel, _condition_markdown(condition))
         _write_text(out_dir / prompt_rel, condition["prompt"] + "\n")
         written_files.extend([condition_rel, prompt_rel])
@@ -175,20 +375,29 @@ def write_real_brief_dry_run(
 
     summary = _summary_markdown(fixture.slug, date, len(conditions))
     _write_text(out_dir / "summary.md", summary)
+    if write_html_review:
+        _write_html_review(out_dir)
+        written_files.append("human_review.html")
+
     manifest = {
         "schema_version": "0.1",
+        "experiment": "real-brief-benchmark",
+        "mode": "dry_run",
+        "provider_execution": "disabled",
+        "fixture": {
+            "slug": fixture.slug,
+            "title": fixture.title,
+        },
+        "conditions": _condition_manifest(conditions),
+        "review_schema_path": "review_schema.json",
+        "workflow_handoff_path": "workflow_handoff.json",
         "fixture_slug": fixture.slug,
-        "date": date,
+        "date": safe_date,
         "simulation_only": True,
         "condition_ids": [condition["id"] for condition in conditions],
         "files": sorted(written_files),
     }
     _write_json(out_dir / "manifest.json", manifest)
-
-    if write_html_review:
-        from vulca.real_brief.review_html import write_review_html
-
-        write_review_html(out_dir)
 
     return {
         "output_dir": str(out_dir),

--- a/src/vulca/real_brief/conditions.py
+++ b/src/vulca/real_brief/conditions.py
@@ -56,14 +56,12 @@ def _success_criteria() -> str:
     )
 
 
-def _missing_questions(fixture: RealBriefFixture) -> str:
+def _missing_questions() -> str:
     questions = [
-        "Which brand assets, copy, logos, or required text are final?",
-        "Which production format and review milestone should be optimized first?",
-        "What editability handoff standard will the client actually use?",
+        "Which stakeholder approves the final direction?",
+        "Which deliverable must be most production-ready first?",
+        "Which source assets already exist?",
     ]
-    if fixture.ai_policy == "unspecified":
-        questions.append("What AI-use disclosure or usage limit should apply?")
     return "Missing questions:\n" + _bullet_list(questions)
 
 
@@ -87,7 +85,7 @@ def _condition(
 
 
 def _direction_set(direction_cards: list[Any]) -> str:
-    lines = ["Generated direction set:"]
+    lines = ["Generated direction set for comparison:"]
     for idx, card in enumerate(direction_cards, start=1):
         payload = card.to_dict()
         lines.extend(
@@ -106,7 +104,7 @@ def _selected_card_details(card_payload: dict[str, Any]) -> str:
             f"Selected direction card: {card_payload['label']}",
             "Direction summary:",
             card_payload["summary"],
-            "Visual ops:",
+            "Visual operations:",
             f"- Composition: {card_payload['visual_ops']['composition']}",
             f"- Color: {card_payload['visual_ops']['color']}",
             f"- Texture/material: {card_payload['visual_ops']['texture']}",
@@ -189,15 +187,15 @@ def build_real_brief_conditions(fixture: RealBriefFixture) -> list[dict[str, Any
             CONDITION_IDS[0],
             "One-shot model baseline",
             "one-shot",
-            "Raw real brief broad ask without structured planning.",
+            "Raw real brief condensed into a single model ask.",
             "\n\n".join(
                 [
-                    "Create the requested creative work from this raw real brief.",
+                    "Create the requested creative output for this real brief.",
+                    digest,
                     (
                         "Return a polished concept and any visual prompt needed "
                         "to generate it."
                     ),
-                    digest,
                 ]
             ),
         ),
@@ -205,10 +203,13 @@ def build_real_brief_conditions(fixture: RealBriefFixture) -> list[dict[str, Any
             CONDITION_IDS[1],
             "Structured brief baseline",
             "structured-brief",
-            "Normalized fields and success criteria before generation.",
+            (
+                "Same brief normalized into structured client, deliverable, "
+                "and constraint fields."
+            ),
             "\n\n".join(
                 [
-                    "Use the normalized brief fields below to produce a complete response.",
+                    "Create a direction from the structured brief below.",
                     digest,
                     _success_criteria(),
                 ]
@@ -226,9 +227,9 @@ def build_real_brief_conditions(fixture: RealBriefFixture) -> list[dict[str, Any
                 [
                     "Build a Vulca planning package before generating final pixels.",
                     digest,
-                    _missing_questions(fixture),
-                    direction_set,
+                    _missing_questions(),
                     card_details,
+                    direction_set,
                     "Plan a candidate route before making final assets.",
                 ]
             ),
@@ -245,6 +246,7 @@ def build_real_brief_conditions(fixture: RealBriefFixture) -> list[dict[str, Any
             ),
             "\n\n".join(
                 [
+                    "Build a Vulca preview-and-iterate package for this brief.",
                     digest,
                     preview_plan,
                     direction_set,

--- a/src/vulca/real_brief/conditions.py
+++ b/src/vulca/real_brief/conditions.py
@@ -15,10 +15,7 @@ def _bullet_list(items: list[str]) -> str:
 
 def _deliverable_list(fixture: RealBriefFixture) -> str:
     return "\n".join(
-        (
-            f"- {item.name}: {item.format} for {item.channel}"
-            f"{' (required)' if item.required else ''}"
-        )
+        f"- {item.name} ({item.format}, {item.channel})"
         for item in fixture.deliverables
     )
 
@@ -26,13 +23,10 @@ def _deliverable_list(fixture: RealBriefFixture) -> str:
 def brief_digest(fixture: RealBriefFixture) -> str:
     """Return a readable normalized digest for a real-brief fixture."""
     fixture.validate()
-    source_brief = fixture.source_brief.strip() or fixture.context
     return "\n".join(
         [
-            f"Brief: {fixture.title}",
             f"Client: {fixture.client}",
             f"Context: {fixture.context}",
-            f"Source brief: {source_brief}",
             "Audience:",
             _bullet_list(fixture.audience),
             "Required deliverables:",
@@ -41,28 +35,23 @@ def brief_digest(fixture: RealBriefFixture) -> str:
             _bullet_list(fixture.constraints),
             f"Budget: {fixture.budget}",
             f"Timeline: {fixture.timeline}",
-            f"Source deadline: {fixture.source.deadline or 'not specified'}",
-            "Required outputs:",
-            _bullet_list(fixture.required_outputs),
             "Risks:",
             _bullet_list(fixture.risks),
             "Avoid:",
             _bullet_list(fixture.avoid),
             f"AI policy: {fixture.ai_policy}",
-            f"simulation_only: {fixture.simulation_only}",
+            f"Simulation only: {fixture.simulation_only}",
         ]
     )
 
 
-def _success_criteria(fixture: RealBriefFixture) -> str:
+def _success_criteria() -> str:
     return "\n".join(
         [
             "Success criteria:",
-            "- Address every required deliverable and output package.",
-            "- Preserve all constraints and avoid known failure modes.",
-            "- Make production assumptions explicit for budget and timeline.",
-            "- Support evaluation dimensions: "
-            + ", ".join(fixture.evaluation_dimensions),
+            "- satisfy required deliverables",
+            "- respect every listed constraint",
+            "- identify the most production-relevant risk",
         ]
     )
 
@@ -97,21 +86,26 @@ def _condition(
     return payload
 
 
-def build_real_brief_conditions(fixture: RealBriefFixture) -> list[dict[str, Any]]:
-    """Build A/B/C/D benchmark condition prompts from a fixture."""
-    fixture.validate()
-    digest = brief_digest(fixture)
-    profile = infer_taste_profile(fixture.slug, digest)
-    direction_cards = generate_direction_cards(profile, count=3)
-    selected_card = direction_cards[0]
-    card_payload = selected_card.to_dict()
-    final_prompt = compose_prompt_from_direction_card(selected_card, target="final")
-    prompt_payload = final_prompt.to_dict()
+def _direction_set(direction_cards: list[Any]) -> str:
+    lines = ["Generated direction set:"]
+    for idx, card in enumerate(direction_cards, start=1):
+        payload = card.to_dict()
+        lines.extend(
+            [
+                f"Direction {idx} id: {payload['id']}",
+                f"Direction {idx} label: {payload['label']}",
+                f"Direction {idx} summary: {payload['summary']}",
+            ]
+        )
+    return "\n".join(lines)
 
-    card_details = "\n".join(
+
+def _selected_card_details(card_payload: dict[str, Any]) -> str:
+    return "\n".join(
         [
             f"Selected direction card: {card_payload['label']}",
-            f"Summary: {card_payload['summary']}",
+            "Direction summary:",
+            card_payload["summary"],
             "Visual ops:",
             f"- Composition: {card_payload['visual_ops']['composition']}",
             f"- Color: {card_payload['visual_ops']['color']}",
@@ -128,12 +122,65 @@ def build_real_brief_conditions(fixture: RealBriefFixture) -> list[dict[str, Any
         ]
     )
 
+
+def _preview_prompts(direction_cards: list[Any]) -> str:
+    lines = [
+        "Preview prompts:",
+        "- produce 2-3 low-cost thumbnail directions before final comp",
+    ]
+    for idx, card in enumerate(direction_cards[:3], start=1):
+        payload = card.to_dict()
+        lines.append(
+            (
+                f"- Thumbnail {idx}: {payload['label']} ({payload['id']}) - "
+                f"{payload['summary']}"
+            )
+        )
+    return "\n".join(lines)
+
+
+def _preview_iteration_sections() -> str:
+    return "\n".join(
+        [
+            "Critique criteria:",
+            (
+                "- critique each direction against constraints and risks, "
+                "required deliverables, audience fit, and editability"
+            ),
+            "Refinement notes:",
+            (
+                "- refine the strongest direction into a final comp prompt "
+                "after comparing the thumbnail critiques"
+            ),
+            "Editability, redraw, and reuse notes:",
+            (
+                "- document editability, redraw, and reuse notes for the "
+                "chosen route and production handoff"
+            ),
+        ]
+    )
+
+
+def build_real_brief_conditions(fixture: RealBriefFixture) -> list[dict[str, Any]]:
+    """Build A/B/C/D benchmark condition prompts from a fixture."""
+    fixture.validate()
+    digest = brief_digest(fixture)
+    profile = infer_taste_profile(fixture.slug, digest)
+    direction_cards = generate_direction_cards(profile, count=3)
+    selected_card = direction_cards[0]
+    card_payload = selected_card.to_dict()
+    final_prompt = compose_prompt_from_direction_card(selected_card, target="final")
+    prompt_payload = final_prompt.to_dict()
+    direction_set = _direction_set(direction_cards)
+    card_details = _selected_card_details(card_payload)
+
     preview_plan = "\n".join(
         [
             "Preview plan:",
-            "- Generate low-risk preview prompts from the selected direction card.",
-            "- Critique against deliverables, constraints, risks, and editability.",
-            "- Refine the chosen route before final production prompting.",
+            "- produce 2-3 low-cost thumbnail directions before final comp",
+            "- critique each direction against constraints and risks",
+            "- refine the strongest direction into a final comp prompt",
+            "- document editability, redraw, and reuse notes",
         ]
     )
 
@@ -146,6 +193,10 @@ def build_real_brief_conditions(fixture: RealBriefFixture) -> list[dict[str, Any
             "\n\n".join(
                 [
                     "Create the requested creative work from this raw real brief.",
+                    (
+                        "Return a polished concept and any visual prompt needed "
+                        "to generate it."
+                    ),
                     digest,
                 ]
             ),
@@ -159,7 +210,7 @@ def build_real_brief_conditions(fixture: RealBriefFixture) -> list[dict[str, Any
                 [
                     "Use the normalized brief fields below to produce a complete response.",
                     digest,
-                    _success_criteria(fixture),
+                    _success_criteria(),
                 ]
             ),
         ),
@@ -173,8 +224,10 @@ def build_real_brief_conditions(fixture: RealBriefFixture) -> list[dict[str, Any
             ),
             "\n\n".join(
                 [
+                    "Build a Vulca planning package before generating final pixels.",
                     digest,
                     _missing_questions(fixture),
+                    direction_set,
                     card_details,
                     "Plan a candidate route before making final assets.",
                 ]
@@ -194,6 +247,9 @@ def build_real_brief_conditions(fixture: RealBriefFixture) -> list[dict[str, Any
                 [
                     digest,
                     preview_plan,
+                    direction_set,
+                    _preview_prompts(direction_cards),
+                    _preview_iteration_sections(),
                     card_details,
                     f"Final comp prompt: {prompt_payload['prompt']}",
                     f"Negative prompt: {prompt_payload['negative_prompt']}",

--- a/src/vulca/real_brief/conditions.py
+++ b/src/vulca/real_brief/conditions.py
@@ -1,0 +1,206 @@
+"""Condition generation for the real-brief benchmark."""
+from __future__ import annotations
+
+from typing import Any
+
+from vulca.discovery.cards import generate_direction_cards
+from vulca.discovery.profile import infer_taste_profile
+from vulca.discovery.prompting import compose_prompt_from_direction_card
+from vulca.real_brief.types import CONDITION_IDS, RealBriefFixture
+
+
+def _bullet_list(items: list[str]) -> str:
+    return "\n".join(f"- {item}" for item in items)
+
+
+def _deliverable_list(fixture: RealBriefFixture) -> str:
+    return "\n".join(
+        (
+            f"- {item.name}: {item.format} for {item.channel}"
+            f"{' (required)' if item.required else ''}"
+        )
+        for item in fixture.deliverables
+    )
+
+
+def brief_digest(fixture: RealBriefFixture) -> str:
+    """Return a readable normalized digest for a real-brief fixture."""
+    fixture.validate()
+    source_brief = fixture.source_brief.strip() or fixture.context
+    return "\n".join(
+        [
+            f"Brief: {fixture.title}",
+            f"Client: {fixture.client}",
+            f"Context: {fixture.context}",
+            f"Source brief: {source_brief}",
+            "Audience:",
+            _bullet_list(fixture.audience),
+            "Required deliverables:",
+            _deliverable_list(fixture),
+            "Constraints:",
+            _bullet_list(fixture.constraints),
+            f"Budget: {fixture.budget}",
+            f"Timeline: {fixture.timeline}",
+            f"Source deadline: {fixture.source.deadline or 'not specified'}",
+            "Required outputs:",
+            _bullet_list(fixture.required_outputs),
+            "Risks:",
+            _bullet_list(fixture.risks),
+            "Avoid:",
+            _bullet_list(fixture.avoid),
+            f"AI policy: {fixture.ai_policy}",
+            f"simulation_only: {fixture.simulation_only}",
+        ]
+    )
+
+
+def _success_criteria(fixture: RealBriefFixture) -> str:
+    return "\n".join(
+        [
+            "Success criteria:",
+            "- Address every required deliverable and output package.",
+            "- Preserve all constraints and avoid known failure modes.",
+            "- Make production assumptions explicit for budget and timeline.",
+            "- Support evaluation dimensions: "
+            + ", ".join(fixture.evaluation_dimensions),
+        ]
+    )
+
+
+def _missing_questions(fixture: RealBriefFixture) -> str:
+    questions = [
+        "Which brand assets, copy, logos, or required text are final?",
+        "Which production format and review milestone should be optimized first?",
+        "What editability handoff standard will the client actually use?",
+    ]
+    if fixture.ai_policy == "unspecified":
+        questions.append("What AI-use disclosure or usage limit should apply?")
+    return "Missing questions:\n" + _bullet_list(questions)
+
+
+def _condition(
+    condition_id: str,
+    label: str,
+    workflow_stage: str,
+    purpose: str,
+    prompt: str,
+    **extra: Any,
+) -> dict[str, Any]:
+    payload = {
+        "id": condition_id,
+        "label": label,
+        "workflow_stage": workflow_stage,
+        "purpose": purpose,
+        "prompt": prompt,
+    }
+    payload.update(extra)
+    return payload
+
+
+def build_real_brief_conditions(fixture: RealBriefFixture) -> list[dict[str, Any]]:
+    """Build A/B/C/D benchmark condition prompts from a fixture."""
+    fixture.validate()
+    digest = brief_digest(fixture)
+    profile = infer_taste_profile(fixture.slug, digest)
+    direction_cards = generate_direction_cards(profile, count=3)
+    selected_card = direction_cards[0]
+    card_payload = selected_card.to_dict()
+    final_prompt = compose_prompt_from_direction_card(selected_card, target="final")
+    prompt_payload = final_prompt.to_dict()
+
+    card_details = "\n".join(
+        [
+            f"Selected direction card: {card_payload['label']}",
+            f"Summary: {card_payload['summary']}",
+            "Visual ops:",
+            f"- Composition: {card_payload['visual_ops']['composition']}",
+            f"- Color: {card_payload['visual_ops']['color']}",
+            f"- Texture/material: {card_payload['visual_ops']['texture']}",
+            f"- Typography: {card_payload['visual_ops']['typography']}",
+            f"- Symbol strategy: {card_payload['visual_ops']['symbol_strategy']}",
+            "Evaluation focus:",
+            _bullet_list(
+                [
+                    f"{key}: {value}"
+                    for key, value in card_payload["evaluation_focus"].items()
+                ]
+            ),
+        ]
+    )
+
+    preview_plan = "\n".join(
+        [
+            "Preview plan:",
+            "- Generate low-risk preview prompts from the selected direction card.",
+            "- Critique against deliverables, constraints, risks, and editability.",
+            "- Refine the chosen route before final production prompting.",
+        ]
+    )
+
+    return [
+        _condition(
+            CONDITION_IDS[0],
+            "One-shot model baseline",
+            "one-shot",
+            "Raw real brief broad ask without structured planning.",
+            "\n\n".join(
+                [
+                    "Create the requested creative work from this raw real brief.",
+                    digest,
+                ]
+            ),
+        ),
+        _condition(
+            CONDITION_IDS[1],
+            "Structured brief baseline",
+            "structured-brief",
+            "Normalized fields and success criteria before generation.",
+            "\n\n".join(
+                [
+                    "Use the normalized brief fields below to produce a complete response.",
+                    digest,
+                    _success_criteria(fixture),
+                ]
+            ),
+        ),
+        _condition(
+            CONDITION_IDS[2],
+            "Vulca planning workflow",
+            "vulca-planning",
+            (
+                "Ambiguity handling, direction cards, visual operations, and "
+                "evaluation focus before generation."
+            ),
+            "\n\n".join(
+                [
+                    digest,
+                    _missing_questions(fixture),
+                    card_details,
+                    "Plan a candidate route before making final assets.",
+                ]
+            ),
+            taste_profile=profile.to_dict(),
+            direction_cards=[card.to_dict() for card in direction_cards],
+        ),
+        _condition(
+            CONDITION_IDS[3],
+            "Vulca preview-and-iterate workflow",
+            "vulca-preview-iterate",
+            (
+                "Preview prompts, critique, refinement, and editability checks "
+                "before final composition."
+            ),
+            "\n\n".join(
+                [
+                    digest,
+                    preview_plan,
+                    card_details,
+                    f"Final comp prompt: {prompt_payload['prompt']}",
+                    f"Negative prompt: {prompt_payload['negative_prompt']}",
+                ]
+            ),
+            taste_profile=profile.to_dict(),
+            selected_direction_card=card_payload,
+            final_prompt=prompt_payload,
+        ),
+    ]

--- a/src/vulca/real_brief/fixtures.py
+++ b/src/vulca/real_brief/fixtures.py
@@ -26,6 +26,7 @@ def build_real_brief_fixtures() -> list[RealBriefFixture]:
                 ),
                 retrieved_on="2026-04-30",
                 usage_note="Internal benchmark only",
+                deadline="2026-03-13 17:00",
             ),
             client="Rogers Park Business Alliance / Glenwood Sunday Market",
             context=(
@@ -76,6 +77,7 @@ def build_real_brief_fixtures() -> list[RealBriefFixture]:
                 url="https://www.polishfilms.org/submit-a-poster",
                 retrieved_on="2026-04-30",
                 usage_note="Internal benchmark only",
+                deadline="2026-06-01 23:59",
             ),
             client="Seattle Polish Film Festival",
             context="Signature poster concept for the 34th festival edition.",
@@ -125,6 +127,7 @@ def build_real_brief_fixtures() -> list[RealBriefFixture]:
                 ),
                 retrieved_on="2026-04-30",
                 usage_note="Internal benchmark only",
+                deadline="2026-04-17",
             ),
             client="Model Young Package",
             context=(
@@ -173,6 +176,7 @@ def build_real_brief_fixtures() -> list[RealBriefFixture]:
                 ),
                 retrieved_on="2026-04-30",
                 usage_note="Internal benchmark only",
+                deadline="2026-04-20 12:00",
             ),
             client="Erie County / Buffalo and Erie County Botanical Gardens",
             context=(
@@ -217,6 +221,7 @@ def build_real_brief_fixtures() -> list[RealBriefFixture]:
                 url="https://creative-commission.com/briefs/brief-10642",
                 retrieved_on="2026-04-30",
                 usage_note="Internal benchmark only",
+                deadline="2026-01-31",
             ),
             client="Music artist / label brief",
             context=(

--- a/src/vulca/real_brief/fixtures.py
+++ b/src/vulca/real_brief/fixtures.py
@@ -1,0 +1,267 @@
+"""Built-in public creative brief fixtures for the real-brief benchmark."""
+from __future__ import annotations
+
+from vulca.real_brief.types import (
+    REVIEW_DIMENSIONS,
+    Deliverable,
+    RealBriefFixture,
+    SourceInfo,
+    safe_slug,
+)
+
+
+def _dims() -> list[str]:
+    return list(REVIEW_DIMENSIONS)
+
+
+def build_real_brief_fixtures() -> list[RealBriefFixture]:
+    return [
+        RealBriefFixture(
+            slug="gsm-community-market-campaign",
+            title="Glenwood Sunday Market Campaign System",
+            source=SourceInfo(
+                url=(
+                    "https://rpba.org/wp-content/uploads/2026/02/"
+                    "Marketing-Creative-Services-for-GSM-RFP-2026.pdf"
+                ),
+                retrieved_on="2026-04-30",
+                usage_note="Internal benchmark only",
+            ),
+            client="Rogers Park Business Alliance / Glenwood Sunday Market",
+            context=(
+                "Community farmers market marketing system for a 19-week 2026 "
+                "market season."
+            ),
+            audience=[
+                "local shoppers",
+                "SNAP and matching-program participants",
+                "vendors and community partners",
+            ],
+            deliverables=[
+                Deliverable("content framework", "19-week system", "planning"),
+                Deliverable("social templates", "editable Canva templates", "social"),
+                Deliverable("banner concepts", "market signage", "print"),
+                Deliverable("sticker and tote concepts", "merchandise preview", "print"),
+            ],
+            constraints=[
+                "must use existing logo, colors, and fonts",
+                "must use real photography",
+                "must avoid illustrations and clip art",
+                "must remain Canva-editable",
+            ],
+            budget="$5,000",
+            timeline="2026 market season",
+            required_outputs=["decision_package", "production_package"],
+            ai_policy="unspecified",
+            simulation_only=True,
+            risks=[
+                "generic farmers market aesthetic",
+                "template set not reusable for 19 weeks",
+                "visual system not editable by the client",
+            ],
+            avoid=["clip art", "illustration-first campaign", "single poster only"],
+            evaluation_dimensions=_dims(),
+            source_brief=(
+                "Design a reusable community market campaign system with evergreen "
+                "templates, real-photo usage rules, social examples, and print/merch "
+                "preview assets."
+            ),
+            domain="brand_visual",
+            tags=["campaign", "community", "templates"],
+        ),
+        RealBriefFixture(
+            slug="seattle-polish-film-festival-poster",
+            title="Seattle Polish Film Festival Poster",
+            source=SourceInfo(
+                url="https://www.polishfilms.org/submit-a-poster",
+                retrieved_on="2026-04-30",
+                usage_note="Internal benchmark only",
+            ),
+            client="Seattle Polish Film Festival",
+            context="Signature poster concept for the 34th festival edition.",
+            audience=[
+                "festival attendees",
+                "Polish cinema community",
+                "Seattle arts audience",
+            ],
+            deliverables=[
+                Deliverable("poster concept", "11 x 17 in vertical", "print/digital"),
+                Deliverable("program cover adaptation", "same key art", "print"),
+            ],
+            constraints=[
+                "required festival text must be present",
+                "dates, venues, website, and producer line must be accounted for",
+                "bottom sponsor or patron logo band must remain available",
+                "print output should anticipate CMYK and 300 dpi production",
+            ],
+            budget="not specified by source",
+            timeline="source-specific contest deadline",
+            required_outputs=["decision_package", "production_package"],
+            ai_policy="unspecified",
+            simulation_only=True,
+            risks=[
+                "broken generated text",
+                "unsafe margins",
+                "generic Polish national symbolism",
+                "missing sponsor band",
+            ],
+            avoid=["illegible typography", "crowded logo area", "flag-only concept"],
+            evaluation_dimensions=_dims(),
+            source_brief=(
+                "Create layout-safe poster concept directions for a Polish film "
+                "festival, including required text strategy, margins, sponsor band, "
+                "and print-risk notes."
+            ),
+            domain="poster",
+            tags=["poster", "film", "layout"],
+        ),
+        RealBriefFixture(
+            slug="model-young-package-unpacking-taboo",
+            title="Model Young Package 2026: Unpacking Taboo",
+            source=SourceInfo(
+                url=(
+                    "https://www.modelgroup.com/language-masters/en/"
+                    "model-young-package.html"
+                ),
+                retrieved_on="2026-04-30",
+                usage_note="Internal benchmark only",
+            ),
+            client="Model Young Package",
+            context=(
+                "Paper or cardboard packaging concept around sensitive or "
+                "stigmatized topics."
+            ),
+            audience=["competition jury", "design educators", "social-impact brands"],
+            deliverables=[
+                Deliverable("packaging concept", "paper/cardboard structure", "product"),
+                Deliverable("unboxing flow", "step sequence", "prototype planning"),
+                Deliverable("structure diagram prompt", "blueprint-style view", "planning"),
+            ],
+            constraints=[
+                "must be respectful toward taboo-adjacent subject matter",
+                "must consider manufacturability",
+                "must consider sustainability and material economy",
+                "must explain function and ergonomics",
+            ],
+            budget="competition entry; production budget not specified",
+            timeline="2026 competition cycle",
+            required_outputs=["decision_package", "production_package"],
+            ai_policy="unspecified",
+            simulation_only=True,
+            risks=[
+                "sensationalizing sensitive topics",
+                "beautiful render without structural logic",
+                "unmanufacturable packaging form",
+            ],
+            avoid=["shock-value visuals", "decorative box only", "plastic-first concept"],
+            evaluation_dimensions=_dims(),
+            source_brief=(
+                "Design a paper-based packaging proposal for a taboo-adjacent "
+                "product with respectful concept, structure, unboxing sequence, "
+                "material constraints, and prototype-oriented visuals."
+            ),
+            domain="packaging",
+            tags=["packaging", "structure", "social-design"],
+        ),
+        RealBriefFixture(
+            slug="erie-botanical-gardens-public-art",
+            title="Buffalo and Erie County Botanical Gardens Public Art",
+            source=SourceInfo(
+                url=(
+                    "https://www4.erie.gov/publicart/"
+                    "2026-call-artists-buffalo-and-erie-county-botanical-gardens"
+                ),
+                retrieved_on="2026-04-30",
+                usage_note="Internal benchmark only",
+            ),
+            client="Erie County / Buffalo and Erie County Botanical Gardens",
+            context=(
+                "Site-specific public art proposal for a botanical garden setting."
+            ),
+            audience=["public art panel", "garden visitors", "local community"],
+            deliverables=[
+                Deliverable("artist proposal", "concept package", "proposal"),
+                Deliverable("site-response rationale", "written narrative", "proposal"),
+                Deliverable("installation sketch prompts", "visual thumbnails", "planning"),
+            ],
+            constraints=[
+                "must respond to site history and future",
+                "must address durability and maintenance",
+                "must include installation and engineering assumptions",
+                "must respect public access and safety",
+            ],
+            budget="up to $75,000",
+            timeline="2026 public art process",
+            required_outputs=["decision_package", "production_package"],
+            ai_policy="unspecified",
+            simulation_only=True,
+            risks=[
+                "gallery object rather than site-specific public work",
+                "missing maintenance plan",
+                "budget fantasy",
+            ],
+            avoid=["temporary-looking materials", "unanchored decorative sculpture"],
+            evaluation_dimensions=_dims(),
+            source_brief=(
+                "Create a site-specific public art proposal package with concept, "
+                "site rationale, material palette, installation assumptions, "
+                "maintenance risks, budget notes, and review thumbnails."
+            ),
+            domain="public_art",
+            tags=["public-art", "site-specific", "proposal"],
+        ),
+        RealBriefFixture(
+            slug="music-video-treatment-low-budget",
+            title="Low-Budget Music Video Treatment",
+            source=SourceInfo(
+                url="https://creative-commission.com/briefs/brief-10642",
+                retrieved_on="2026-04-30",
+                usage_note="Internal benchmark only",
+            ),
+            client="Music artist / label brief",
+            context=(
+                "Director or producer treatment for a low-budget music video, "
+                "with AI elements allowed by the brief."
+            ),
+            audience=["artist team", "label commissioner", "director shortlist panel"],
+            deliverables=[
+                Deliverable("director treatment", "written concept", "pitch"),
+                Deliverable("mood frames", "visual references", "pitch"),
+                Deliverable("scene beats", "sequence outline", "production planning"),
+            ],
+            constraints=[
+                "must fit low-budget execution",
+                "must disclose AI-use approach",
+                "must not assume expensive locations or large crew",
+                "must avoid asking for unpaid full treatment before shortlist",
+            ],
+            budget="about GBP 1,000",
+            timeline="source-specific commission window",
+            required_outputs=["decision_package", "production_package"],
+            ai_policy="allowed",
+            simulation_only=True,
+            risks=[
+                "overproduced concept",
+                "moodboard without executable scenes",
+                "unclear AI disclosure",
+            ],
+            avoid=["large crew assumptions", "expensive VFX-heavy production"],
+            evaluation_dimensions=_dims(),
+            source_brief=(
+                "Simulate a shortlisted director treatment with concept, mood "
+                "frames, scene structure, production constraints, AI-use disclosure, "
+                "and deliverables plan."
+            ),
+            domain="video_treatment",
+            tags=["video", "treatment", "low-budget"],
+        ),
+    ]
+
+
+def get_real_brief_fixture(slug: str) -> RealBriefFixture:
+    safe = safe_slug(slug)
+    for fixture in build_real_brief_fixtures():
+        if fixture.slug == safe:
+            return fixture
+    known = ", ".join(fixture.slug for fixture in build_real_brief_fixtures())
+    raise ValueError(f"unknown real brief slug: {slug!r}; expected one of: {known}")

--- a/src/vulca/real_brief/review_html.py
+++ b/src/vulca/real_brief/review_html.py
@@ -1,0 +1,201 @@
+"""Offline HTML review renderer for real-brief benchmark dry runs."""
+from __future__ import annotations
+
+import html
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+
+_SECRET_PATTERNS = [
+    re.compile(r"sk-[A-Za-z0-9_-]+"),
+]
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _escape(value: Any) -> str:
+    return html.escape(str(value), quote=True)
+
+
+def _safe_json_script(payload: dict[str, Any]) -> str:
+    text = json.dumps(payload, sort_keys=True)
+    for pattern in _SECRET_PATTERNS:
+        text = pattern.sub("[redacted]", text)
+    return text.replace("</", "<\\/")
+
+
+def _condition_cards(manifest: dict[str, Any]) -> str:
+    cards = []
+    for condition in manifest.get("conditions", []):
+        condition_id = _escape(condition.get("id", ""))
+        label = _escape(condition.get("label", "Untitled condition"))
+        condition_path = _escape(condition.get("condition_path", ""))
+        prompt_path = _escape(condition.get("prompt_path", ""))
+        cards.append(
+            "\n".join(
+                [
+                    '<article class="card condition-card">',
+                    f"<h2>Condition {condition_id}</h2>",
+                    f"<p>{label}</p>",
+                    '<div class="links">',
+                    f'<a href="{condition_path}">{condition_path}</a>',
+                    f'<a href="{prompt_path}">{prompt_path}</a>',
+                    "</div>",
+                    "</article>",
+                ]
+            )
+        )
+    return "\n".join(cards)
+
+
+def _dimension_rows(review_schema: dict[str, Any]) -> str:
+    scale = review_schema.get("scale", {})
+    min_score = int(scale.get("min", 0))
+    max_score = int(scale.get("max", 2))
+    options = "\n".join(
+        f'<option value="{score}">{score}</option>'
+        for score in range(min_score, max_score + 1)
+    )
+    rows = []
+    for dimension in review_schema.get("dimensions", []):
+        dimension_id = _escape(dimension.get("id", ""))
+        label = _escape(dimension.get("label", dimension.get("id", "")))
+        rows.append(
+            "\n".join(
+                [
+                    "<tr>",
+                    f"<th scope=\"row\"><code>{dimension_id}</code><span>{label}</span></th>",
+                    f'<td><select data-score="{dimension_id}"><option value="">-</option>{options}</select></td>',
+                    f'<td><textarea data-note="{dimension_id}" rows="2"></textarea></td>',
+                    "</tr>",
+                ]
+            )
+        )
+    return "\n".join(rows)
+
+
+def _brief_summary(structured_brief: dict[str, Any]) -> str:
+    title = _escape(structured_brief.get("title", "Untitled brief"))
+    client = _escape(structured_brief.get("client", "Unknown client"))
+    slug = _escape(structured_brief.get("slug", "unknown-slug"))
+    return "\n".join(
+        [
+            '<section class="summary">',
+            f"<h2>{title}</h2>",
+            f"<p><strong>Client:</strong> {client}</p>",
+            f"<p><strong>Slug:</strong> <code>{slug}</code></p>",
+            "</section>",
+        ]
+    )
+
+
+def _html_document(
+    manifest: dict[str, Any],
+    review_schema: dict[str, Any],
+    structured_brief: dict[str, Any],
+) -> str:
+    review_payload = {
+        "manifest": manifest,
+        "review_schema": review_schema,
+        "structured_brief": {
+            "slug": structured_brief.get("slug"),
+            "title": structured_brief.get("title"),
+            "client": structured_brief.get("client"),
+        },
+    }
+    storage_key = _escape(
+        "real-brief-review:"
+        + str(manifest.get("fixture_slug") or structured_brief.get("slug") or "run")
+    )
+    return "\n".join(
+        [
+            "<!doctype html>",
+            '<html lang="en">',
+            "<head>",
+            '<meta charset="utf-8">',
+            '<meta name="viewport" content="width=device-width, initial-scale=1">',
+            "<title>Real Brief Benchmark Review</title>",
+            "<style>",
+            ":root{color-scheme:light;font-family:Arial,sans-serif;background:#f6f4ef;color:#1d2329}",
+            "body{margin:0;padding:32px}",
+            "main{max-width:1120px;margin:0 auto}",
+            "header{display:flex;justify-content:space-between;gap:24px;align-items:flex-start}",
+            "h1{font-size:32px;line-height:1.1;margin:0 0 12px}",
+            "h2{font-size:18px;margin:0 0 10px}",
+            ".summary,.card,table{background:#fff;border:1px solid #d8d2c6;border-radius:8px}",
+            ".summary{padding:16px;margin:20px 0}",
+            ".grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:12px}",
+            ".card{padding:14px}",
+            ".links{display:flex;flex-direction:column;gap:6px}",
+            "a{color:#154f7f}",
+            "table{width:100%;border-collapse:collapse;margin-top:12px;overflow:hidden}",
+            "th,td{padding:12px;border-top:1px solid #e6e0d5;text-align:left;vertical-align:top}",
+            "th span{display:block;font-weight:400;color:#5c6670;margin-top:4px}",
+            "select,textarea{width:100%;box-sizing:border-box;border:1px solid #b8c0c8;border-radius:6px;padding:8px;font:inherit}",
+            "textarea{resize:vertical}",
+            "button{border:1px solid #1d2329;background:#1d2329;color:#fff;border-radius:6px;padding:9px 12px;font:inherit;cursor:pointer}",
+            ".actions{display:flex;gap:8px;align-items:center;margin:18px 0}",
+            ".muted{color:#66717c}",
+            "</style>",
+            "</head>",
+            "<body>",
+            "<main>",
+            "<header>",
+            "<div>",
+            "<h1>Real Brief Benchmark Review</h1>",
+            '<p class="muted">Offline scoring form for dry-run benchmark artifacts.</p>',
+            "</div>",
+            '<button id="export-json" type="button">Export JSON</button>',
+            "</header>",
+            _brief_summary(structured_brief),
+            "<section>",
+            "<h2>Conditions</h2>",
+            f'<div class="grid">{_condition_cards(manifest)}</div>',
+            "</section>",
+            "<section>",
+            "<h2>Review Dimensions</h2>",
+            "<table>",
+            "<thead><tr><th>Dimension</th><th>Score</th><th>Notes</th></tr></thead>",
+            f"<tbody>{_dimension_rows(review_schema)}</tbody>",
+            "</table>",
+            '<div class="actions"><button id="save-review" type="button">Save</button><span id="status" class="muted"></span></div>',
+            "</section>",
+            f'<script id="review-data" type="application/json">{_safe_json_script(review_payload)}</script>',
+            "<script>",
+            "(function(){",
+            f"const storageKey = {json.dumps(storage_key)};",
+            "const data = JSON.parse(document.getElementById('review-data').textContent);",
+            "const status = document.getElementById('status');",
+            "function collect(){const scores={};document.querySelectorAll('[data-score]').forEach(function(el){scores[el.dataset.score]=el.value;});const notes={};document.querySelectorAll('[data-note]').forEach(function(el){notes[el.dataset.note]=el.value;});return {schema_version:'0.1',fixture_slug:data.manifest.fixture_slug,condition_ids:data.manifest.condition_ids,reviewed_at:new Date().toISOString(),scores:scores,notes:notes};}",
+            "function restore(){const saved=localStorage.getItem(storageKey);if(!saved)return;const parsed=JSON.parse(saved);Object.entries(parsed.scores||{}).forEach(function(entry){const el=document.querySelector('[data-score=\"'+entry[0]+'\"]');if(el)el.value=entry[1];});Object.entries(parsed.notes||{}).forEach(function(entry){const el=document.querySelector('[data-note=\"'+entry[0]+'\"]');if(el)el.value=entry[1];});status.textContent='Loaded saved review';}",
+            "function save(){localStorage.setItem(storageKey,JSON.stringify(collect(),null,2));status.textContent='Saved locally';}",
+            "document.getElementById('save-review').addEventListener('click',save);",
+            "document.getElementById('export-json').addEventListener('click',function(){const blob=new Blob([JSON.stringify(collect(),null,2)+'\\n'],{type:'application/json'});const link=document.createElement('a');link.href=URL.createObjectURL(blob);link.download='human_review.json';link.click();URL.revokeObjectURL(link.href);});",
+            "document.querySelectorAll('select,textarea').forEach(function(el){el.addEventListener('change',save);});",
+            "restore();",
+            "}());",
+            "</script>",
+            "</main>",
+            "</body>",
+            "</html>",
+            "",
+        ]
+    )
+
+
+def write_review_html(out_dir: str | Path) -> Path:
+    """Write the offline human review HTML file for a dry-run output directory."""
+    out_dir_path = Path(out_dir)
+    manifest = _read_json(out_dir_path / "manifest.json")
+    review_schema = _read_json(out_dir_path / "review_schema.json")
+    structured_brief = _read_json(out_dir_path / "structured_brief.json")
+    html_path = out_dir_path / "human_review.html"
+    html_path.write_text(
+        _html_document(manifest, review_schema, structured_brief),
+        encoding="utf-8",
+    )
+    return html_path

--- a/src/vulca/real_brief/review_html.py
+++ b/src/vulca/real_brief/review_html.py
@@ -33,6 +33,7 @@ def _condition_cards(manifest: dict[str, Any]) -> str:
     for condition in manifest.get("conditions", []):
         condition_id = _escape(condition.get("id", ""))
         label = _escape(condition.get("label", "Untitled condition"))
+        purpose = _escape(condition.get("purpose", ""))
         condition_path = _escape(condition.get("condition_path", ""))
         prompt_path = _escape(condition.get("prompt_path", ""))
         cards.append(
@@ -41,6 +42,7 @@ def _condition_cards(manifest: dict[str, Any]) -> str:
                     '<article class="card condition-card">',
                     f"<h2>Condition {condition_id}</h2>",
                     f"<p>{label}</p>",
+                    f'<p class="muted">{purpose}</p>',
                     '<div class="links">',
                     f'<a href="{condition_path}">{condition_path}</a>',
                     f'<a href="{prompt_path}">{prompt_path}</a>',
@@ -50,6 +52,22 @@ def _condition_cards(manifest: dict[str, Any]) -> str:
             )
         )
     return "\n".join(cards)
+
+
+def _package_links() -> str:
+    return "\n".join(
+        [
+            '<section class="card package-links">',
+            "<h2>Review Packages</h2>",
+            '<div class="links horizontal-links">',
+            '<a href="decision_package.md">Decision Package</a>',
+            '<a href="production_package.md">Production Package</a>',
+            '<a href="workflow_handoff.json">Workflow Handoff</a>',
+            '<a href="review_schema.json">Review Schema</a>',
+            "</div>",
+            "</section>",
+        ]
+    )
 
 
 def _dimension_rows(
@@ -145,6 +163,7 @@ def _html_document(
             ".grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:12px}",
             ".card{padding:14px}",
             ".links{display:flex;flex-direction:column;gap:6px}",
+            ".horizontal-links{flex-direction:row;flex-wrap:wrap}",
             "a{color:#154f7f}",
             "table{width:100%;border-collapse:collapse;margin-top:12px;overflow:hidden}",
             "th,td{padding:12px;border-top:1px solid #e6e0d5;text-align:left;vertical-align:top}",
@@ -166,6 +185,7 @@ def _html_document(
             '<button id="export-json" type="button">Export JSON</button>',
             "</header>",
             _brief_summary(structured_brief),
+            _package_links(),
             "<section>",
             "<h2>Conditions</h2>",
             f'<div class="grid">{_condition_cards(manifest)}</div>',

--- a/src/vulca/real_brief/review_html.py
+++ b/src/vulca/real_brief/review_html.py
@@ -52,7 +52,10 @@ def _condition_cards(manifest: dict[str, Any]) -> str:
     return "\n".join(cards)
 
 
-def _dimension_rows(review_schema: dict[str, Any]) -> str:
+def _dimension_rows(
+    manifest: dict[str, Any],
+    review_schema: dict[str, Any],
+) -> str:
     scale = review_schema.get("scale", {})
     min_score = int(scale.get("min", 0))
     max_score = int(scale.get("max", 2))
@@ -61,20 +64,31 @@ def _dimension_rows(review_schema: dict[str, Any]) -> str:
         for score in range(min_score, max_score + 1)
     )
     rows = []
-    for dimension in review_schema.get("dimensions", []):
-        dimension_id = _escape(dimension.get("id", ""))
-        label = _escape(dimension.get("label", dimension.get("id", "")))
-        rows.append(
-            "\n".join(
-                [
-                    "<tr>",
-                    f"<th scope=\"row\"><code>{dimension_id}</code><span>{label}</span></th>",
-                    f'<td><select data-score="{dimension_id}"><option value="">-</option>{options}</select></td>',
-                    f'<td><textarea data-note="{dimension_id}" rows="2"></textarea></td>',
-                    "</tr>",
-                ]
+    for condition in manifest.get("conditions", []):
+        condition_id = _escape(condition.get("id", ""))
+        condition_label = _escape(condition.get("label", "Untitled condition"))
+        for dimension in review_schema.get("dimensions", []):
+            dimension_id = _escape(dimension.get("id", ""))
+            label = _escape(dimension.get("label", dimension.get("id", "")))
+            rows.append(
+                "\n".join(
+                    [
+                        "<tr>",
+                        f"<th scope=\"row\"><code>{condition_id}</code><span>{condition_label}</span></th>",
+                        f"<td><code>{dimension_id}</code><span>{label}</span></td>",
+                        (
+                            f'<td><select data-score-condition="{condition_id}" '
+                            f'data-score-dimension="{dimension_id}">'
+                            f'<option value="">-</option>{options}</select></td>'
+                        ),
+                        (
+                            f'<td><textarea data-note-condition="{condition_id}" '
+                            f'data-note-dimension="{dimension_id}" rows="2"></textarea></td>'
+                        ),
+                        "</tr>",
+                    ]
+                )
             )
-        )
     return "\n".join(rows)
 
 
@@ -134,7 +148,7 @@ def _html_document(
             "a{color:#154f7f}",
             "table{width:100%;border-collapse:collapse;margin-top:12px;overflow:hidden}",
             "th,td{padding:12px;border-top:1px solid #e6e0d5;text-align:left;vertical-align:top}",
-            "th span{display:block;font-weight:400;color:#5c6670;margin-top:4px}",
+            "th span,td span{display:block;font-weight:400;color:#5c6670;margin-top:4px}",
             "select,textarea{width:100%;box-sizing:border-box;border:1px solid #b8c0c8;border-radius:6px;padding:8px;font:inherit}",
             "textarea{resize:vertical}",
             "button{border:1px solid #1d2329;background:#1d2329;color:#fff;border-radius:6px;padding:9px 12px;font:inherit;cursor:pointer}",
@@ -159,8 +173,8 @@ def _html_document(
             "<section>",
             "<h2>Review Dimensions</h2>",
             "<table>",
-            "<thead><tr><th>Dimension</th><th>Score</th><th>Notes</th></tr></thead>",
-            f"<tbody>{_dimension_rows(review_schema)}</tbody>",
+            "<thead><tr><th>Condition</th><th>Dimension</th><th>Score</th><th>Notes</th></tr></thead>",
+            f"<tbody>{_dimension_rows(manifest, review_schema)}</tbody>",
             "</table>",
             '<div class="actions"><button id="save-review" type="button">Save</button><span id="status" class="muted"></span></div>',
             "</section>",
@@ -170,8 +184,9 @@ def _html_document(
             f"const storageKey = {json.dumps(storage_key)};",
             "const data = JSON.parse(document.getElementById('review-data').textContent);",
             "const status = document.getElementById('status');",
-            "function collect(){const scores={};document.querySelectorAll('[data-score]').forEach(function(el){scores[el.dataset.score]=el.value;});const notes={};document.querySelectorAll('[data-note]').forEach(function(el){notes[el.dataset.note]=el.value;});return {schema_version:'0.1',fixture_slug:data.manifest.fixture_slug,condition_ids:data.manifest.condition_ids,reviewed_at:new Date().toISOString(),scores:scores,notes:notes};}",
-            "function restore(){const saved=localStorage.getItem(storageKey);if(!saved)return;const parsed=JSON.parse(saved);Object.entries(parsed.scores||{}).forEach(function(entry){const el=document.querySelector('[data-score=\"'+entry[0]+'\"]');if(el)el.value=entry[1];});Object.entries(parsed.notes||{}).forEach(function(entry){const el=document.querySelector('[data-note=\"'+entry[0]+'\"]');if(el)el.value=entry[1];});status.textContent='Loaded saved review';}",
+            "function ensureNested(root,conditionId){if(!root[conditionId])root[conditionId]={};return root[conditionId];}",
+            "function collect(){const scores={};document.querySelectorAll('[data-score-condition]').forEach(function(el){const conditionId=el.dataset.scoreCondition;const dimensionId=el.dataset.scoreDimension;ensureNested(scores,conditionId);scores[conditionId][dimensionId]=el.value;});const notes={};document.querySelectorAll('[data-note-condition]').forEach(function(el){const conditionId=el.dataset.noteCondition;const dimensionId=el.dataset.noteDimension;ensureNested(notes,conditionId);notes[conditionId][dimensionId]=el.value;});return {schema_version:'0.1',fixture_slug:data.manifest.fixture_slug,condition_ids:data.manifest.condition_ids,reviewed_at:new Date().toISOString(),scores:scores,notes:notes};}",
+            "function restore(){const saved=localStorage.getItem(storageKey);if(!saved)return;const parsed=JSON.parse(saved);(data.manifest.condition_ids||[]).forEach(function(conditionId){const scoreBucket=(parsed.scores&&parsed.scores[conditionId])||{};Object.entries(scoreBucket).forEach(function(entry){const el=document.querySelector('[data-score-condition=\"'+conditionId+'\"][data-score-dimension=\"'+entry[0]+'\"]');if(el)el.value=entry[1];});const noteBucket=(parsed.notes&&parsed.notes[conditionId])||{};Object.entries(noteBucket).forEach(function(entry){const el=document.querySelector('[data-note-condition=\"'+conditionId+'\"][data-note-dimension=\"'+entry[0]+'\"]');if(el)el.value=entry[1];});});status.textContent='Loaded saved review';}",
             "function save(){localStorage.setItem(storageKey,JSON.stringify(collect(),null,2));status.textContent='Saved locally';}",
             "document.getElementById('save-review').addEventListener('click',save);",
             "document.getElementById('export-json').addEventListener('click',function(){const blob=new Blob([JSON.stringify(collect(),null,2)+'\\n'],{type:'application/json'});const link=document.createElement('a');link.href=URL.createObjectURL(blob);link.download='human_review.json';link.click();URL.revokeObjectURL(link.href);});",

--- a/src/vulca/real_brief/types.py
+++ b/src/vulca/real_brief/types.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import re
 from dataclasses import asdict, dataclass, field
 from typing import Any
+from urllib.parse import urlparse
 
 
 _SAFE_SLUG_RE = re.compile(r"^[a-z0-9][a-z0-9._-]*$")
@@ -31,7 +32,7 @@ def safe_slug(slug: str) -> str:
         or "/" in slug
         or "\\" in slug
         or ".." in slug
-        or not _SAFE_SLUG_RE.match(slug)
+        or not _SAFE_SLUG_RE.fullmatch(slug)
     ):
         raise ValueError(
             "safe slug required: lowercase letters, digits, '.', '_' or '-' only"
@@ -87,7 +88,11 @@ class RealBriefFixture:
         safe_slug(self.slug)
         if not self.title.strip():
             raise ValueError(f"{self.slug}: title is required")
-        if not self.source.url.startswith(("https://", "http://")):
+        parsed_source_url = urlparse(self.source.url)
+        if (
+            parsed_source_url.scheme not in {"http", "https"}
+            or not parsed_source_url.netloc
+        ):
             raise ValueError(f"{self.slug}: source.url must be absolute http(s)")
         for field_name in (
             "client",

--- a/src/vulca/real_brief/types.py
+++ b/src/vulca/real_brief/types.py
@@ -94,6 +94,8 @@ class RealBriefFixture:
             or not parsed_source_url.netloc
         ):
             raise ValueError(f"{self.slug}: source.url must be absolute http(s)")
+        if not self.source.retrieved_on.strip():
+            raise ValueError(f"{self.slug}: source.retrieved_on is required")
         for field_name in (
             "client",
             "context",
@@ -106,6 +108,10 @@ class RealBriefFixture:
                 raise ValueError(f"{self.slug}: {field_name} is required")
         if self.ai_policy not in AI_POLICIES:
             raise ValueError(f"{self.slug}: unsupported ai_policy {self.ai_policy!r}")
+        if self.ai_policy == "prohibited_for_submission" and not self.simulation_only:
+            raise ValueError(
+                f"{self.slug}: simulation_only is required when AI is prohibited"
+            )
         list_fields = {
             "audience": self.audience,
             "deliverables": self.deliverables,
@@ -118,6 +124,15 @@ class RealBriefFixture:
         for field_name, value in list_fields.items():
             if not value:
                 raise ValueError(f"{self.slug}: {field_name} must not be empty")
+            if any(isinstance(item, str) and not item.strip() for item in value):
+                raise ValueError(f"{self.slug}: {field_name} must not contain blanks")
+        for deliverable in self.deliverables:
+            if not deliverable.name.strip():
+                raise ValueError(f"{self.slug}: deliverables.name is required")
+            if not deliverable.format.strip():
+                raise ValueError(f"{self.slug}: deliverables.format is required")
+            if not deliverable.channel.strip():
+                raise ValueError(f"{self.slug}: deliverables.channel is required")
         unknown_dimensions = [
             item for item in self.evaluation_dimensions if item not in REVIEW_DIMENSIONS
         ]

--- a/src/vulca/real_brief/types.py
+++ b/src/vulca/real_brief/types.py
@@ -1,0 +1,146 @@
+"""Structured real-brief benchmark data types."""
+from __future__ import annotations
+
+import re
+from dataclasses import asdict, dataclass, field
+from typing import Any
+
+
+_SAFE_SLUG_RE = re.compile(r"^[a-z0-9][a-z0-9._-]*$")
+
+AI_POLICIES = {"allowed", "prohibited_for_submission", "unspecified"}
+CONDITION_IDS = ("A", "B", "C", "D")
+REVIEW_DIMENSIONS = (
+    "brief_compliance",
+    "audience_fit",
+    "deliverable_fit",
+    "constraint_handling",
+    "cultural_taste_specificity",
+    "structural_control",
+    "editability_reusability",
+    "production_realism",
+    "risk_avoidance",
+    "decision_usefulness",
+)
+
+
+def safe_slug(slug: str) -> str:
+    if (
+        not slug
+        or slug in {".", ".."}
+        or "/" in slug
+        or "\\" in slug
+        or ".." in slug
+        or not _SAFE_SLUG_RE.match(slug)
+    ):
+        raise ValueError(
+            "safe slug required: lowercase letters, digits, '.', '_' or '-' only"
+        )
+    return slug
+
+
+@dataclass(frozen=True)
+class SourceInfo:
+    url: str
+    retrieved_on: str
+    usage_note: str = "Internal benchmark only"
+    deadline: str = ""
+
+    def to_dict(self) -> dict[str, str]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class Deliverable:
+    name: str
+    format: str
+    channel: str
+    required: bool = True
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class RealBriefFixture:
+    slug: str
+    title: str
+    source: SourceInfo
+    client: str
+    context: str
+    audience: list[str]
+    deliverables: list[Deliverable]
+    constraints: list[str]
+    budget: str
+    timeline: str
+    required_outputs: list[str]
+    ai_policy: str
+    simulation_only: bool
+    risks: list[str]
+    avoid: list[str]
+    evaluation_dimensions: list[str]
+    source_brief: str = ""
+    domain: str = "brand_visual"
+    tags: list[str] = field(default_factory=list)
+
+    def validate(self) -> None:
+        safe_slug(self.slug)
+        if not self.title.strip():
+            raise ValueError(f"{self.slug}: title is required")
+        if not self.source.url.startswith(("https://", "http://")):
+            raise ValueError(f"{self.slug}: source.url must be absolute http(s)")
+        for field_name in (
+            "client",
+            "context",
+            "budget",
+            "timeline",
+            "ai_policy",
+            "domain",
+        ):
+            if not str(getattr(self, field_name)).strip():
+                raise ValueError(f"{self.slug}: {field_name} is required")
+        if self.ai_policy not in AI_POLICIES:
+            raise ValueError(f"{self.slug}: unsupported ai_policy {self.ai_policy!r}")
+        list_fields = {
+            "audience": self.audience,
+            "deliverables": self.deliverables,
+            "constraints": self.constraints,
+            "required_outputs": self.required_outputs,
+            "risks": self.risks,
+            "avoid": self.avoid,
+            "evaluation_dimensions": self.evaluation_dimensions,
+        }
+        for field_name, value in list_fields.items():
+            if not value:
+                raise ValueError(f"{self.slug}: {field_name} must not be empty")
+        unknown_dimensions = [
+            item for item in self.evaluation_dimensions if item not in REVIEW_DIMENSIONS
+        ]
+        if unknown_dimensions:
+            joined = ", ".join(unknown_dimensions)
+            raise ValueError(f"{self.slug}: unknown evaluation dimensions: {joined}")
+
+    def to_dict(self) -> dict[str, Any]:
+        self.validate()
+        return {
+            "schema_version": "0.1",
+            "slug": self.slug,
+            "title": self.title,
+            "source": self.source.to_dict(),
+            "client": self.client,
+            "context": self.context,
+            "audience": list(self.audience),
+            "deliverables": [item.to_dict() for item in self.deliverables],
+            "constraints": list(self.constraints),
+            "budget": self.budget,
+            "timeline": self.timeline,
+            "required_outputs": list(self.required_outputs),
+            "ai_policy": self.ai_policy,
+            "simulation_only": self.simulation_only,
+            "risks": list(self.risks),
+            "avoid": list(self.avoid),
+            "evaluation_dimensions": list(self.evaluation_dimensions),
+            "source_brief": self.source_brief,
+            "domain": self.domain,
+            "tags": list(self.tags),
+        }

--- a/tests/test_real_brief_benchmark.py
+++ b/tests/test_real_brief_benchmark.py
@@ -208,6 +208,26 @@ def test_builtin_fixtures_are_valid_and_ordered():
         assert payload["simulation_only"] is True
 
 
+def test_builtin_fixtures_include_expected_source_deadlines():
+    from vulca.real_brief.fixtures import build_real_brief_fixtures
+
+    expected_deadlines = {
+        "gsm-community-market-campaign": "2026-03-13 17:00",
+        "seattle-polish-film-festival-poster": "2026-06-01 23:59",
+        "model-young-package-unpacking-taboo": "2026-04-17",
+        "erie-botanical-gardens-public-art": "2026-04-20 12:00",
+        "music-video-treatment-low-budget": "2026-01-31",
+    }
+    fixtures_by_slug = {
+        fixture.slug: fixture for fixture in build_real_brief_fixtures()
+    }
+
+    assert {
+        slug: fixtures_by_slug[slug].source.deadline
+        for slug in expected_deadlines
+    } == expected_deadlines
+
+
 def test_get_real_brief_fixture_rejects_unknown_slug():
     from vulca.real_brief.fixtures import get_real_brief_fixture
 
@@ -215,10 +235,10 @@ def test_get_real_brief_fixture_rejects_unknown_slug():
         get_real_brief_fixture("missing-brief")
 
 
-def test_ai_prohibited_fixture_is_marked_for_internal_simulation_only():
+def test_seattle_fixture_is_marked_for_internal_simulation_only():
     from vulca.real_brief.fixtures import get_real_brief_fixture
 
-    imageout_like = get_real_brief_fixture("seattle-polish-film-festival-poster")
+    seattle = get_real_brief_fixture("seattle-polish-film-festival-poster")
 
-    assert imageout_like.simulation_only is True
-    assert imageout_like.source.usage_note == "Internal benchmark only"
+    assert seattle.simulation_only is True
+    assert seattle.source.usage_note == "Internal benchmark only"

--- a/tests/test_real_brief_benchmark.py
+++ b/tests/test_real_brief_benchmark.py
@@ -716,6 +716,50 @@ def test_human_review_html_contains_conditions_dimensions_and_export(tmp_path):
     assert "globalai" not in html.lower()
 
 
+def test_human_review_html_scores_every_condition_dimension_pair(tmp_path):
+    import json
+    from pathlib import Path
+
+    from vulca.real_brief.artifacts import write_real_brief_dry_run
+
+    result = write_real_brief_dry_run(
+        output_root=tmp_path,
+        slug="model-young-package-unpacking-taboo",
+        date="2026-05-01",
+        write_html_review=True,
+    )
+
+    out_dir = Path(result["output_dir"])
+    html = (out_dir / "human_review.html").read_text(encoding="utf-8")
+    manifest = json.loads((out_dir / "manifest.json").read_text(encoding="utf-8"))
+    review_schema = json.loads(
+        (out_dir / "review_schema.json").read_text(encoding="utf-8")
+    )
+    condition_ids = manifest["condition_ids"]
+    dimension_ids = [
+        dimension["id"] for dimension in review_schema["dimensions"]
+    ]
+    expected_control_count = len(condition_ids) * len(dimension_ids)
+
+    assert html.count('<select data-score-condition="') == expected_control_count
+    assert html.count('<textarea data-note-condition="') == expected_control_count
+    for condition_id in condition_ids:
+        for dimension_id in dimension_ids:
+            assert (
+                f'<select data-score-condition="{condition_id}" '
+                f'data-score-dimension="{dimension_id}"'
+            ) in html
+            assert (
+                f'<textarea data-note-condition="{condition_id}" '
+                f'data-note-dimension="{dimension_id}"'
+            ) in html
+
+    assert "scores[conditionId][dimensionId]" in html
+    assert "notes[conditionId][dimensionId]" in html
+    assert "parsed.scores[conditionId]" in html
+    assert "parsed.notes[conditionId]" in html
+
+
 def test_write_real_brief_dry_run_writes_manifest_before_html_renderer(
     tmp_path,
     monkeypatch,

--- a/tests/test_real_brief_benchmark.py
+++ b/tests/test_real_brief_benchmark.py
@@ -649,8 +649,10 @@ def test_write_real_brief_dry_run_packages_are_reviewable(tmp_path):
 
 def test_real_brief_public_import_lazily_loads_heavy_exports():
     import json
+    import os
     import subprocess
     import sys
+    from pathlib import Path
 
     script = """
 import json
@@ -668,10 +670,18 @@ after_export = {
 }
 print(json.dumps({"after_import": after_import, "after_export": after_export}))
 """
+    env = dict(os.environ)
+    source_path = str(Path(__file__).resolve().parents[1] / "src")
+    env["PYTHONPATH"] = (
+        source_path
+        if not env.get("PYTHONPATH")
+        else f"{source_path}{os.pathsep}{env['PYTHONPATH']}"
+    )
     completed = subprocess.run(
         [sys.executable, "-c", script],
         check=True,
         capture_output=True,
+        env=env,
         text=True,
     )
 

--- a/tests/test_real_brief_benchmark.py
+++ b/tests/test_real_brief_benchmark.py
@@ -690,25 +690,30 @@ print(json.dumps({"after_import": after_import, "after_export": after_export}))
     assert payload["after_export"] == {"callable": True, "artifacts": True}
 
 
-def test_write_real_brief_dry_run_default_html_review_writes_placeholder(tmp_path):
+def test_human_review_html_contains_conditions_dimensions_and_export(tmp_path):
+    from pathlib import Path
+
     from vulca.real_brief.artifacts import write_real_brief_dry_run
 
     result = write_real_brief_dry_run(
         output_root=tmp_path,
-        slug="seattle-polish-film-festival-poster",
+        slug="model-young-package-unpacking-taboo",
         date="2026-05-01",
+        write_html_review=True,
     )
 
-    html = (
-        tmp_path
-        / "2026-05-01-seattle-polish-film-festival-poster"
-        / "human_review.html"
-    )
-    text = html.read_text(encoding="utf-8")
-    assert result["output_dir"] == str(html.parent)
-    assert "Full renderer pending" in text
-    assert "manifest.json" in text
-    assert "review_schema.json" in text
+    html = Path(result["output_dir"], "human_review.html").read_text(encoding="utf-8")
+    assert "Real Brief Benchmark Review" in html
+    assert "A-one-shot.md" in html
+    assert "D-vulca-preview-iterate.md" in html
+    assert "brief_compliance" in html
+    assert "decision_usefulness" in html
+    assert "Export JSON" in html
+    assert "Full renderer pending" not in html
+    assert "sk-" not in html
+    assert "VULCA_REAL_PROVIDER_API_KEY" not in html
+    assert "OPENAI_API_KEY" not in html
+    assert "globalai" not in html.lower()
 
 
 def test_write_real_brief_dry_run_writes_manifest_before_html_renderer(

--- a/tests/test_real_brief_benchmark.py
+++ b/tests/test_real_brief_benchmark.py
@@ -699,3 +699,33 @@ def test_write_real_brief_dry_run_default_html_review_writes_placeholder(tmp_pat
     assert "Full renderer pending" in text
     assert "manifest.json" in text
     assert "review_schema.json" in text
+
+
+def test_write_real_brief_dry_run_writes_manifest_before_html_renderer(
+    tmp_path,
+    monkeypatch,
+):
+    from pathlib import Path
+    import sys
+    import types
+
+    from vulca.real_brief.artifacts import write_real_brief_dry_run
+
+    module = types.ModuleType("vulca.real_brief.review_html")
+
+    def fake_write_review_html(out_dir):
+        assert (out_dir / "manifest.json").exists()
+        assert (out_dir / "review_schema.json").exists()
+        (out_dir / "human_review.html").write_text("fake review", encoding="utf-8")
+
+    module.write_review_html = fake_write_review_html
+    monkeypatch.setitem(sys.modules, "vulca.real_brief.review_html", module)
+
+    result = write_real_brief_dry_run(
+        output_root=tmp_path,
+        slug="seattle-polish-film-festival-poster",
+        date="2026-05-01",
+    )
+
+    out_dir = Path(result["output_dir"])
+    assert (out_dir / "human_review.html").read_text(encoding="utf-8") == "fake review"

--- a/tests/test_real_brief_benchmark.py
+++ b/tests/test_real_brief_benchmark.py
@@ -433,3 +433,79 @@ def test_preview_iterate_prompt_has_concrete_iteration_sections():
     assert "constraints" in prompt
     assert "risks" in prompt
     assert "Canva-editable" in prompt
+
+
+def test_write_real_brief_dry_run_artifacts(tmp_path):
+    import json
+    from pathlib import Path
+
+    from vulca.real_brief.artifacts import write_real_brief_dry_run
+
+    result = write_real_brief_dry_run(
+        output_root=tmp_path,
+        slug="seattle-polish-film-festival-poster",
+        date="2026-05-01",
+        write_html_review=False,
+    )
+
+    out_dir = Path(result["output_dir"])
+    assert out_dir == tmp_path / "2026-05-01-seattle-polish-film-festival-poster"
+    for rel in [
+        "source_brief.md",
+        "structured_brief.json",
+        "decision_package.md",
+        "production_package.md",
+        "workflow_handoff.json",
+        "review_schema.json",
+        "conditions/A-one-shot.md",
+        "conditions/B-structured-brief.md",
+        "conditions/C-vulca-planning.md",
+        "conditions/D-vulca-preview-iterate.md",
+        "prompts/A.txt",
+        "prompts/B.txt",
+        "prompts/C.txt",
+        "prompts/D.txt",
+        "images/README.md",
+        "evaluations/README.md",
+        "summary.md",
+        "manifest.json",
+    ]:
+        assert (out_dir / rel).exists(), rel
+
+    handoff = json.loads((out_dir / "workflow_handoff.json").read_text())
+    assert handoff["schema_version"] == "0.1"
+    assert handoff["human_gate_required"] is True
+    assert handoff["visual_discovery_seed"]["slug"] == (
+        "seattle-polish-film-festival-poster"
+    )
+    assert handoff["visual_brainstorm_seed"]["domain"] == "poster"
+
+    review = json.loads((out_dir / "review_schema.json").read_text())
+    assert review["scale"] == {"min": 0, "max": 2, "step": 1}
+    assert review["condition_ids"] == ["A", "B", "C", "D"]
+    assert "decision_usefulness" in [d["id"] for d in review["dimensions"]]
+
+    summary = (out_dir / "summary.md").read_text(encoding="utf-8")
+    assert "No image quality conclusion" in summary
+    assert "simulation_only: true" in summary
+
+
+def test_write_real_brief_dry_run_rejects_secret_like_output_root(tmp_path):
+    from vulca.real_brief.artifacts import write_real_brief_dry_run
+
+    out = tmp_path / "safe-output"
+    write_real_brief_dry_run(
+        output_root=out,
+        slug="gsm-community-market-campaign",
+        date="2026-05-01",
+        write_html_review=False,
+    )
+    generated = "\n".join(
+        path.read_text(encoding="utf-8", errors="ignore")
+        for path in out.rglob("*")
+        if path.is_file() and path.suffix in {".md", ".json", ".txt", ".html"}
+    )
+    assert "sk-" not in generated
+    assert "VULCA_REAL_PROVIDER_API_KEY" not in generated
+    assert "OPENAI_API_KEY" not in generated
+    assert "globalai" not in generated.lower()

--- a/tests/test_real_brief_benchmark.py
+++ b/tests/test_real_brief_benchmark.py
@@ -272,3 +272,107 @@ def test_condition_generation_preserves_fixture_constraints():
     assert "real photography" in joined
     assert "19-week" in joined
     assert "clip art" in joined
+
+
+def test_brief_digest_matches_task_three_field_contract():
+    from vulca.real_brief.conditions import brief_digest
+    from vulca.real_brief.fixtures import get_real_brief_fixture
+
+    fixture = get_real_brief_fixture("seattle-polish-film-festival-poster")
+    digest = brief_digest(fixture)
+
+    for label in [
+        "Client:",
+        "Context:",
+        "Audience:",
+        "Required deliverables:",
+        "Constraints:",
+        "Budget:",
+        "Timeline:",
+        "Risks:",
+        "Avoid:",
+        "AI policy:",
+        "Simulation only:",
+    ]:
+        assert label in digest
+
+    assert "poster concept (11 x 17 in vertical, print/digital)" in digest
+    assert "program cover adaptation (same key art, print)" in digest
+    assert "Brief:" not in digest
+    assert "Source brief:" not in digest
+    assert "Source deadline:" not in digest
+    assert "Required outputs:" not in digest
+    assert "simulation_only:" not in digest
+
+
+def test_condition_prompts_match_task_three_contract_phrases():
+    from vulca.real_brief.conditions import build_real_brief_conditions
+    from vulca.real_brief.fixtures import get_real_brief_fixture
+
+    fixture = get_real_brief_fixture("seattle-polish-film-festival-poster")
+    conditions = build_real_brief_conditions(fixture)
+
+    assert (
+        "Return a polished concept and any visual prompt needed to generate it."
+        in conditions[0]["prompt"]
+    )
+    assert "satisfy required deliverables" in conditions[1]["prompt"]
+    assert "respect every listed constraint" in conditions[1]["prompt"]
+    assert "identify the most production-relevant risk" in conditions[1]["prompt"]
+    assert conditions[2]["prompt"].startswith(
+        "Build a Vulca planning package before generating final pixels."
+    )
+    assert "Direction summary:" in conditions[2]["prompt"]
+    assert (
+        "produce 2-3 low-cost thumbnail directions before final comp"
+        in conditions[3]["prompt"]
+    )
+    assert (
+        "critique each direction against constraints and risks"
+        in conditions[3]["prompt"]
+    )
+    assert (
+        "refine the strongest direction into a final comp prompt"
+        in conditions[3]["prompt"]
+    )
+    assert (
+        "document editability, redraw, and reuse notes"
+        in conditions[3]["prompt"]
+    )
+
+
+def test_vulca_condition_prompts_include_generated_direction_set():
+    from vulca.real_brief.conditions import build_real_brief_conditions
+    from vulca.real_brief.fixtures import get_real_brief_fixture
+
+    fixture = get_real_brief_fixture("seattle-polish-film-festival-poster")
+    conditions = build_real_brief_conditions(fixture)
+    condition_c_prompt = conditions[2]["prompt"]
+    condition_d_prompt = conditions[3]["prompt"]
+
+    for prompt in [condition_c_prompt, condition_d_prompt]:
+        assert "Generated direction set:" in prompt
+        assert prompt.count("Direction ") >= 3
+        assert prompt.count(f"{fixture.slug}-") >= 3
+
+
+def test_preview_iterate_prompt_has_concrete_iteration_sections():
+    from vulca.real_brief.conditions import build_real_brief_conditions
+    from vulca.real_brief.fixtures import get_real_brief_fixture
+
+    fixture = get_real_brief_fixture("gsm-community-market-campaign")
+    prompt = build_real_brief_conditions(fixture)[3]["prompt"]
+
+    for section in [
+        "Preview prompts:",
+        "Critique criteria:",
+        "Refinement notes:",
+        "Editability, redraw, and reuse notes:",
+    ]:
+        assert section in prompt
+
+    assert "thumbnail" in prompt
+    assert "required deliverables" in prompt
+    assert "constraints" in prompt
+    assert "risks" in prompt
+    assert "Canva-editable" in prompt

--- a/tests/test_real_brief_benchmark.py
+++ b/tests/test_real_brief_benchmark.py
@@ -242,3 +242,33 @@ def test_seattle_fixture_is_marked_for_internal_simulation_only():
 
     assert seattle.simulation_only is True
     assert seattle.source.usage_note == "Internal benchmark only"
+
+
+def test_build_real_brief_conditions_a_through_d():
+    from vulca.real_brief.conditions import build_real_brief_conditions
+    from vulca.real_brief.fixtures import get_real_brief_fixture
+
+    fixture = get_real_brief_fixture("seattle-polish-film-festival-poster")
+    conditions = build_real_brief_conditions(fixture)
+
+    assert [condition["id"] for condition in conditions] == ["A", "B", "C", "D"]
+    assert conditions[0]["label"] == "One-shot model baseline"
+    assert "Raw real brief" in conditions[0]["purpose"]
+    assert "Required deliverables" in conditions[1]["prompt"]
+    assert "Missing questions" in conditions[2]["prompt"]
+    assert "Preview plan" in conditions[3]["prompt"]
+    assert conditions[3]["workflow_stage"] == "vulca-preview-iterate"
+
+
+def test_condition_generation_preserves_fixture_constraints():
+    from vulca.real_brief.conditions import build_real_brief_conditions
+    from vulca.real_brief.fixtures import get_real_brief_fixture
+
+    fixture = get_real_brief_fixture("gsm-community-market-campaign")
+    conditions = build_real_brief_conditions(fixture)
+    joined = "\n".join(condition["prompt"] for condition in conditions)
+
+    assert "Canva-editable" in joined
+    assert "real photography" in joined
+    assert "19-week" in joined
+    assert "clip art" in joined

--- a/tests/test_real_brief_benchmark.py
+++ b/tests/test_real_brief_benchmark.py
@@ -185,3 +185,40 @@ def test_fixture_validation_rejects_missing_required_field():
 
     with pytest.raises(ValueError, match="client"):
         fixture.validate()
+
+
+def test_builtin_fixtures_are_valid_and_ordered():
+    from vulca.real_brief.fixtures import build_real_brief_fixtures
+
+    fixtures = build_real_brief_fixtures()
+
+    assert [fixture.slug for fixture in fixtures] == [
+        "gsm-community-market-campaign",
+        "seattle-polish-film-festival-poster",
+        "model-young-package-unpacking-taboo",
+        "erie-botanical-gardens-public-art",
+        "music-video-treatment-low-budget",
+    ]
+    for fixture in fixtures:
+        fixture.validate()
+        payload = fixture.to_dict()
+        assert payload["schema_version"] == "0.1"
+        assert payload["source"]["retrieved_on"] == "2026-04-30"
+        assert payload["source"]["usage_note"] == "Internal benchmark only"
+        assert payload["simulation_only"] is True
+
+
+def test_get_real_brief_fixture_rejects_unknown_slug():
+    from vulca.real_brief.fixtures import get_real_brief_fixture
+
+    with pytest.raises(ValueError, match="unknown real brief slug"):
+        get_real_brief_fixture("missing-brief")
+
+
+def test_ai_prohibited_fixture_is_marked_for_internal_simulation_only():
+    from vulca.real_brief.fixtures import get_real_brief_fixture
+
+    imageout_like = get_real_brief_fixture("seattle-polish-film-festival-poster")
+
+    assert imageout_like.simulation_only is True
+    assert imageout_like.source.usage_note == "Internal benchmark only"

--- a/tests/test_real_brief_benchmark.py
+++ b/tests/test_real_brief_benchmark.py
@@ -509,3 +509,193 @@ def test_write_real_brief_dry_run_rejects_secret_like_output_root(tmp_path):
     assert "VULCA_REAL_PROVIDER_API_KEY" not in generated
     assert "OPENAI_API_KEY" not in generated
     assert "globalai" not in generated.lower()
+
+
+@pytest.mark.parametrize("date", ["../escape", "2026/05/01", "20260501"])
+def test_write_real_brief_dry_run_rejects_unsafe_dates(tmp_path, date):
+    from vulca.real_brief.artifacts import write_real_brief_dry_run
+
+    with pytest.raises(ValueError, match="YYYY-MM-DD"):
+        write_real_brief_dry_run(
+            output_root=tmp_path,
+            slug="seattle-polish-film-festival-poster",
+            date=date,
+            write_html_review=False,
+        )
+
+    assert not (tmp_path.parent / "escape-seattle-polish-film-festival-poster").exists()
+
+
+def test_write_real_brief_dry_run_writes_planned_handoff_and_manifest(tmp_path):
+    import json
+
+    from vulca.real_brief.artifacts import write_real_brief_dry_run
+
+    result = write_real_brief_dry_run(
+        output_root=tmp_path,
+        slug="seattle-polish-film-festival-poster",
+        date="2026-05-01",
+        write_html_review=False,
+    )
+    out_dir = tmp_path / "2026-05-01-seattle-polish-film-festival-poster"
+    assert result["manifest_json"] == str(out_dir / "manifest.json")
+
+    handoff = json.loads((out_dir / "workflow_handoff.json").read_text())
+    assert handoff["slug"] == "seattle-polish-film-festival-poster"
+    assert handoff["structured_brief_path"] == "structured_brief.json"
+    assert handoff["visual_discovery_seed"]["initial_intent"]
+    assert handoff["visual_discovery_seed"]["title"] == (
+        "Seattle Polish Film Festival Poster"
+    )
+    assert handoff["visual_brainstorm_seed"]["physical_form"] == "poster concept"
+    assert "required festival text must be present" in (
+        handoff["visual_brainstorm_seed"]["constraints"]
+    )
+    assert handoff["visual_spec_seed"]["provider_policy"] == "dry_run_default"
+    assert "decision_usefulness" in handoff["visual_spec_seed"][
+        "evaluation_dimensions"
+    ]
+    assert handoff["visual_plan_seed"]["condition_ids"] == ["A", "B", "C", "D"]
+    assert (
+        handoff["visual_plan_seed"]["requires_explicit_real_provider_opt_in"] is True
+    )
+    assert handoff["evaluate_seed"] == {
+        "review_schema_path": "review_schema.json",
+        "mode": "brief_compliance",
+    }
+    assert handoff["human_gate_required"] is True
+
+    manifest = json.loads((out_dir / "manifest.json").read_text())
+    assert manifest["schema_version"] == "0.1"
+    assert manifest["experiment"] == "real-brief-benchmark"
+    assert manifest["mode"] == "dry_run"
+    assert manifest["provider_execution"] == "disabled"
+    assert manifest["fixture"] == {
+        "slug": "seattle-polish-film-festival-poster",
+        "title": "Seattle Polish Film Festival Poster",
+    }
+    assert manifest["review_schema_path"] == "review_schema.json"
+    assert manifest["workflow_handoff_path"] == "workflow_handoff.json"
+    assert manifest["conditions"] == [
+        {
+            "id": "A",
+            "label": "One-shot model baseline",
+            "condition_path": "conditions/A-one-shot.md",
+            "prompt_path": "prompts/A.txt",
+        },
+        {
+            "id": "B",
+            "label": "Structured brief baseline",
+            "condition_path": "conditions/B-structured-brief.md",
+            "prompt_path": "prompts/B.txt",
+        },
+        {
+            "id": "C",
+            "label": "Vulca planning workflow",
+            "condition_path": "conditions/C-vulca-planning.md",
+            "prompt_path": "prompts/C.txt",
+        },
+        {
+            "id": "D",
+            "label": "Vulca preview-and-iterate workflow",
+            "condition_path": "conditions/D-vulca-preview-iterate.md",
+            "prompt_path": "prompts/D.txt",
+        },
+    ]
+
+
+def test_write_real_brief_dry_run_packages_are_reviewable(tmp_path):
+    from vulca.real_brief.artifacts import write_real_brief_dry_run
+
+    write_real_brief_dry_run(
+        output_root=tmp_path,
+        slug="gsm-community-market-campaign",
+        date="2026-05-01",
+        write_html_review=False,
+    )
+    out_dir = tmp_path / "2026-05-01-gsm-community-market-campaign"
+    decision_package = (out_dir / "decision_package.md").read_text()
+    production_package = (out_dir / "production_package.md").read_text()
+
+    for heading in [
+        "Brief Digest",
+        "Assumptions",
+        "Missing Questions",
+        "Creative Directions",
+        "Direction Rationale",
+        "Risks And Rejected Approaches",
+        "Recommended Direction",
+        "Decision Checklist",
+    ]:
+        assert f"## {heading}" in decision_package
+
+    for heading in [
+        "Selected Direction",
+        "Prompt Packet",
+        "Visual Operations",
+        "Layout And Structure Constraints",
+        "Channel And Deliverable Constraints",
+        "Preview Or Thumbnail Plan",
+        "Evaluation Checklist",
+        "Editability And Reusability Notes",
+        "Redraw And Layer Notes",
+        "Next Iteration Plan",
+    ]:
+        assert f"## {heading}" in production_package
+
+    for path in ["prompts/A.txt", "prompts/B.txt", "prompts/C.txt", "prompts/D.txt"]:
+        assert path in production_package
+
+
+def test_real_brief_public_import_lazily_loads_heavy_exports():
+    import json
+    import subprocess
+    import sys
+
+    script = """
+import json
+import sys
+import vulca.real_brief as rb
+
+after_import = {
+    "artifacts": "vulca.real_brief.artifacts" in sys.modules,
+    "conditions": "vulca.real_brief.conditions" in sys.modules,
+}
+from vulca.real_brief import write_real_brief_dry_run
+after_export = {
+    "callable": callable(write_real_brief_dry_run),
+    "artifacts": "vulca.real_brief.artifacts" in sys.modules,
+}
+print(json.dumps({"after_import": after_import, "after_export": after_export}))
+"""
+    completed = subprocess.run(
+        [sys.executable, "-c", script],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    payload = json.loads(completed.stdout)
+    assert payload["after_import"] == {"artifacts": False, "conditions": False}
+    assert payload["after_export"] == {"callable": True, "artifacts": True}
+
+
+def test_write_real_brief_dry_run_default_html_review_writes_placeholder(tmp_path):
+    from vulca.real_brief.artifacts import write_real_brief_dry_run
+
+    result = write_real_brief_dry_run(
+        output_root=tmp_path,
+        slug="seattle-polish-film-festival-poster",
+        date="2026-05-01",
+    )
+
+    html = (
+        tmp_path
+        / "2026-05-01-seattle-polish-film-festival-poster"
+        / "human_review.html"
+    )
+    text = html.read_text(encoding="utf-8")
+    assert result["output_dir"] == str(html.parent)
+    assert "Full renderer pending" in text
+    assert "manifest.json" in text
+    assert "review_schema.json" in text

--- a/tests/test_real_brief_benchmark.py
+++ b/tests/test_real_brief_benchmark.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+
+def test_safe_slug_accepts_fixture_style_ids():
+    from vulca.real_brief.types import safe_slug
+
+    assert safe_slug("seattle-polish-film-festival-poster") == (
+        "seattle-polish-film-festival-poster"
+    )
+    assert safe_slug("gsm-community-market-campaign") == (
+        "gsm-community-market-campaign"
+    )
+
+
+@pytest.mark.parametrize(
+    "slug",
+    ["", ".", "..", "../escape", "/abs/path", "has space", "UpperCase", "x/y"],
+)
+def test_safe_slug_rejects_unsafe_ids(slug):
+    from vulca.real_brief.types import safe_slug
+
+    with pytest.raises(ValueError, match="safe slug"):
+        safe_slug(slug)
+
+
+def test_fixture_validation_rejects_missing_required_field():
+    from vulca.real_brief.types import RealBriefFixture, SourceInfo
+
+    fixture = RealBriefFixture(
+        slug="broken-fixture",
+        title="Broken Fixture",
+        source=SourceInfo(
+            url="https://example.test/brief",
+            retrieved_on="2026-05-01",
+            usage_note="Internal benchmark only",
+        ),
+        client="",
+        context="Context exists",
+        audience=["audience"],
+        deliverables=[],
+        constraints=["constraint"],
+        budget="not specified by source",
+        timeline="source-specific deadline",
+        required_outputs=["decision_package", "production_package"],
+        ai_policy="unspecified",
+        simulation_only=True,
+        risks=["risk"],
+        avoid=["avoid"],
+        evaluation_dimensions=["brief_compliance"],
+    )
+
+    with pytest.raises(ValueError, match="client"):
+        fixture.validate()

--- a/tests/test_real_brief_benchmark.py
+++ b/tests/test_real_brief_benchmark.py
@@ -825,3 +825,89 @@ def test_real_brief_benchmark_cli_real_provider_fails_closed(tmp_path):
                 "--real-provider",
             ]
         )
+
+
+def test_real_brief_benchmark_cli_import_and_help_are_offline():
+    import json
+    import os
+    import subprocess
+    import sys
+    from pathlib import Path
+
+    source_path = str(Path(__file__).resolve().parents[1] / "src")
+    env = dict(os.environ)
+    env["PYTHONPATH"] = (
+        source_path
+        if not env.get("PYTHONPATH")
+        else f"{source_path}{os.pathsep}{env['PYTHONPATH']}"
+    )
+    import_probe = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            (
+                "import json, sys\n"
+                "import scripts.real_brief_benchmark\n"
+                "print(json.dumps({"
+                "'artifacts': 'vulca.real_brief.artifacts' in sys.modules,"
+                "'conditions': 'vulca.real_brief.conditions' in sys.modules"
+                "}))"
+            ),
+        ],
+        check=True,
+        capture_output=True,
+        env=env,
+        text=True,
+    )
+    help_probe = subprocess.run(
+        [sys.executable, "scripts/real_brief_benchmark.py", "--help"],
+        check=True,
+        capture_output=True,
+        env=env,
+        text=True,
+    )
+
+    assert json.loads(import_probe.stdout) == {
+        "artifacts": False,
+        "conditions": False,
+    }
+    assert "LiteLLM" not in import_probe.stderr
+    assert "model cost" not in import_probe.stderr.lower()
+    assert "LiteLLM" not in help_probe.stderr
+    assert "model cost" not in help_probe.stderr.lower()
+    assert "Write real-brief benchmark dry-run artifacts" in help_probe.stdout
+
+
+def test_real_brief_benchmark_script_errors_do_not_traceback(tmp_path):
+    import os
+    import subprocess
+    import sys
+    from pathlib import Path
+
+    source_path = str(Path(__file__).resolve().parents[1] / "src")
+    env = dict(os.environ)
+    env["PYTHONPATH"] = (
+        source_path
+        if not env.get("PYTHONPATH")
+        else f"{source_path}{os.pathsep}{env['PYTHONPATH']}"
+    )
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "scripts/real_brief_benchmark.py",
+            "--slug",
+            "gsm-community-market-campaign",
+            "--date",
+            "2026-05-01",
+            "--output-root",
+            str(tmp_path),
+            "--real-provider",
+        ],
+        capture_output=True,
+        env=env,
+        text=True,
+    )
+
+    assert completed.returncode != 0
+    assert "not implemented" in completed.stderr
+    assert "Traceback" not in completed.stderr

--- a/tests/test_real_brief_benchmark.py
+++ b/tests/test_real_brief_benchmark.py
@@ -1,9 +1,35 @@
 from __future__ import annotations
 
-import json
-from pathlib import Path
-
 import pytest
+
+
+def _valid_fixture(**overrides):
+    from vulca.real_brief.types import Deliverable, RealBriefFixture, SourceInfo
+
+    data = {
+        "slug": "valid-fixture",
+        "title": "Valid Fixture",
+        "source": SourceInfo(
+            url="https://example.test/brief",
+            retrieved_on="2026-05-01",
+            usage_note="Internal benchmark only",
+        ),
+        "client": "Client exists",
+        "context": "Context exists",
+        "audience": ["audience"],
+        "deliverables": [Deliverable("poster", "print", "campaign")],
+        "constraints": ["constraint"],
+        "budget": "not specified by source",
+        "timeline": "source-specific deadline",
+        "required_outputs": ["decision_package", "production_package"],
+        "ai_policy": "unspecified",
+        "simulation_only": True,
+        "risks": ["risk"],
+        "avoid": ["avoid"],
+        "evaluation_dimensions": ["brief_compliance"],
+    }
+    data.update(overrides)
+    return RealBriefFixture(**data)
 
 
 def test_safe_slug_accepts_fixture_style_ids():
@@ -65,6 +91,69 @@ def test_fixture_validation_rejects_url_without_netloc():
     )
 
     with pytest.raises(ValueError, match="source.url"):
+        fixture.validate()
+
+
+def test_fixture_validation_accepts_valid_fixture_and_serializes():
+    fixture = _valid_fixture()
+
+    fixture.validate()
+    payload = fixture.to_dict()
+
+    assert payload["schema_version"] == "0.1"
+    assert payload["source"]["retrieved_on"] == "2026-05-01"
+    assert payload["deliverables"][0]["name"] == "poster"
+
+
+def test_fixture_validation_rejects_ai_prohibited_non_simulation_fixture():
+    fixture = _valid_fixture(
+        ai_policy="prohibited_for_submission",
+        simulation_only=False,
+    )
+
+    with pytest.raises(ValueError, match="simulation_only"):
+        fixture.validate()
+
+
+@pytest.mark.parametrize(
+    ("field_name", "value"),
+    [
+        ("audience", [""]),
+        ("constraints", [" "]),
+        ("risks", [""]),
+        ("avoid", [""]),
+        ("required_outputs", [""]),
+        ("evaluation_dimensions", [""]),
+    ],
+)
+def test_fixture_validation_rejects_blank_string_list_entries(field_name, value):
+    fixture = _valid_fixture(**{field_name: value})
+
+    with pytest.raises(ValueError, match=field_name):
+        fixture.validate()
+
+
+def test_fixture_validation_rejects_blank_deliverable_fields():
+    from vulca.real_brief.types import Deliverable
+
+    fixture = _valid_fixture(deliverables=[Deliverable("", "", "")])
+
+    with pytest.raises(ValueError, match="deliverables"):
+        fixture.validate()
+
+
+def test_fixture_validation_rejects_blank_source_retrieved_on():
+    from vulca.real_brief.types import SourceInfo
+
+    fixture = _valid_fixture(
+        source=SourceInfo(
+            url="https://example.test/brief",
+            retrieved_on=" ",
+            usage_note="Internal benchmark only",
+        )
+    )
+
+    with pytest.raises(ValueError, match="retrieved_on"):
         fixture.validate()
 
 

--- a/tests/test_real_brief_benchmark.py
+++ b/tests/test_real_brief_benchmark.py
@@ -3,6 +3,14 @@ from __future__ import annotations
 import pytest
 
 
+def _assert_ordered(text, expected_parts):
+    cursor = -1
+    for part in expected_parts:
+        next_cursor = text.find(part, cursor + 1)
+        assert next_cursor != -1, f"missing or out of order: {part!r}"
+        cursor = next_cursor
+
+
 def _valid_fixture(**overrides):
     from vulca.real_brief.types import Deliverable, RealBriefFixture, SourceInfo
 
@@ -313,16 +321,65 @@ def test_condition_prompts_match_task_three_contract_phrases():
     conditions = build_real_brief_conditions(fixture)
 
     assert (
-        "Return a polished concept and any visual prompt needed to generate it."
-        in conditions[0]["prompt"]
+        conditions[0]["purpose"]
+        == "Raw real brief condensed into a single model ask."
     )
-    assert "satisfy required deliverables" in conditions[1]["prompt"]
-    assert "respect every listed constraint" in conditions[1]["prompt"]
-    assert "identify the most production-relevant risk" in conditions[1]["prompt"]
+    _assert_ordered(
+        conditions[0]["prompt"],
+        [
+            "Create the requested creative output for this real brief.",
+            "Client: Seattle Polish Film Festival",
+            "Return a polished concept and any visual prompt needed to generate it.",
+        ],
+    )
+
+    assert (
+        conditions[1]["purpose"]
+        == "Same brief normalized into structured client, deliverable, and constraint fields."
+    )
+    _assert_ordered(
+        conditions[1]["prompt"],
+        [
+            "Create a direction from the structured brief below.",
+            "Client: Seattle Polish Film Festival",
+            "Success criteria:",
+            "- satisfy required deliverables",
+            "- respect every listed constraint",
+            "- identify the most production-relevant risk",
+        ],
+    )
+
     assert conditions[2]["prompt"].startswith(
         "Build a Vulca planning package before generating final pixels."
     )
-    assert "Direction summary:" in conditions[2]["prompt"]
+    _assert_ordered(
+        conditions[2]["prompt"],
+        [
+            "Missing questions:",
+            "- Which stakeholder approves the final direction?",
+            "- Which deliverable must be most production-ready first?",
+            "- Which source assets already exist?",
+            "Selected direction card:",
+            "Direction summary:",
+            "Visual operations:",
+            "Evaluation focus:",
+            "Generated direction set for comparison:",
+        ],
+    )
+
+    assert conditions[3]["prompt"].startswith(
+        "Build a Vulca preview-and-iterate package for this brief."
+    )
+    _assert_ordered(
+        conditions[3]["prompt"],
+        [
+            "Preview plan:",
+            "- produce 2-3 low-cost thumbnail directions before final comp",
+            "- critique each direction against constraints and risks",
+            "- refine the strongest direction into a final comp prompt",
+            "- document editability, redraw, and reuse notes",
+        ],
+    )
     assert (
         "produce 2-3 low-cost thumbnail directions before final comp"
         in conditions[3]["prompt"]
@@ -351,7 +408,7 @@ def test_vulca_condition_prompts_include_generated_direction_set():
     condition_d_prompt = conditions[3]["prompt"]
 
     for prompt in [condition_c_prompt, condition_d_prompt]:
-        assert "Generated direction set:" in prompt
+        assert "Generated direction set for comparison:" in prompt
         assert prompt.count("Direction ") >= 3
         assert prompt.count(f"{fixture.slug}-") >= 3
 

--- a/tests/test_real_brief_benchmark.py
+++ b/tests/test_real_brief_benchmark.py
@@ -788,3 +788,40 @@ def test_write_real_brief_dry_run_writes_manifest_before_html_renderer(
 
     out_dir = Path(result["output_dir"])
     assert (out_dir / "human_review.html").read_text(encoding="utf-8") == "fake review"
+
+
+def test_real_brief_benchmark_cli_writes_all_slugs(tmp_path):
+    from scripts.real_brief_benchmark import main
+
+    rc = main(
+        [
+            "--slug",
+            "all",
+            "--date",
+            "2026-05-01",
+            "--output-root",
+            str(tmp_path),
+            "--no-html-review",
+        ]
+    )
+
+    assert rc == 0
+    assert (tmp_path / "2026-05-01-gsm-community-market-campaign").exists()
+    assert (tmp_path / "2026-05-01-music-video-treatment-low-budget").exists()
+
+
+def test_real_brief_benchmark_cli_real_provider_fails_closed(tmp_path):
+    from scripts.real_brief_benchmark import main
+
+    with pytest.raises(RuntimeError, match="not implemented"):
+        main(
+            [
+                "--slug",
+                "gsm-community-market-campaign",
+                "--date",
+                "2026-05-01",
+                "--output-root",
+                str(tmp_path),
+                "--real-provider",
+            ]
+        )

--- a/tests/test_real_brief_benchmark.py
+++ b/tests/test_real_brief_benchmark.py
@@ -580,24 +580,37 @@ def test_write_real_brief_dry_run_writes_planned_handoff_and_manifest(tmp_path):
         {
             "id": "A",
             "label": "One-shot model baseline",
+            "purpose": "Raw real brief condensed into a single model ask.",
             "condition_path": "conditions/A-one-shot.md",
             "prompt_path": "prompts/A.txt",
         },
         {
             "id": "B",
             "label": "Structured brief baseline",
+            "purpose": (
+                "Same brief normalized into structured client, deliverable, "
+                "and constraint fields."
+            ),
             "condition_path": "conditions/B-structured-brief.md",
             "prompt_path": "prompts/B.txt",
         },
         {
             "id": "C",
             "label": "Vulca planning workflow",
+            "purpose": (
+                "Ambiguity handling, direction cards, visual operations, and "
+                "evaluation focus before generation."
+            ),
             "condition_path": "conditions/C-vulca-planning.md",
             "prompt_path": "prompts/C.txt",
         },
         {
             "id": "D",
             "label": "Vulca preview-and-iterate workflow",
+            "purpose": (
+                "Preview prompts, critique, refinement, and editability checks "
+                "before final composition."
+            ),
             "condition_path": "conditions/D-vulca-preview-iterate.md",
             "prompt_path": "prompts/D.txt",
         },
@@ -714,6 +727,31 @@ def test_human_review_html_contains_conditions_dimensions_and_export(tmp_path):
     assert "VULCA_REAL_PROVIDER_API_KEY" not in html
     assert "OPENAI_API_KEY" not in html
     assert "globalai" not in html.lower()
+
+
+def test_human_review_html_links_review_packages_and_condition_purposes(tmp_path):
+    from pathlib import Path
+
+    from vulca.real_brief.artifacts import write_real_brief_dry_run
+
+    result = write_real_brief_dry_run(
+        output_root=tmp_path,
+        slug="seattle-polish-film-festival-poster",
+        date="2026-05-01",
+        write_html_review=True,
+    )
+
+    html = Path(result["output_dir"], "human_review.html").read_text(encoding="utf-8")
+
+    assert 'href="decision_package.md"' in html
+    assert 'href="production_package.md"' in html
+    assert "Decision Package" in html
+    assert "Production Package" in html
+    assert "Raw real brief condensed into a single model ask." in html
+    assert (
+        "Preview prompts, critique, refinement, and editability checks "
+        "before final composition."
+    ) in html
 
 
 def test_human_review_html_scores_every_condition_dimension_pair(tmp_path):

--- a/tests/test_real_brief_benchmark.py
+++ b/tests/test_real_brief_benchmark.py
@@ -911,3 +911,41 @@ def test_real_brief_benchmark_script_errors_do_not_traceback(tmp_path):
     assert completed.returncode != 0
     assert "not implemented" in completed.stderr
     assert "Traceback" not in completed.stderr
+
+
+def test_real_brief_benchmark_cli_dry_run_uses_local_cost_map(tmp_path):
+    import os
+    import subprocess
+    import sys
+    from pathlib import Path
+
+    source_path = str(Path(__file__).resolve().parents[1] / "src")
+    env = dict(os.environ)
+    env.pop("LITELLM_LOCAL_MODEL_COST_MAP", None)
+    env["PYTHONPATH"] = (
+        source_path
+        if not env.get("PYTHONPATH")
+        else f"{source_path}{os.pathsep}{env['PYTHONPATH']}"
+    )
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "scripts/real_brief_benchmark.py",
+            "--slug",
+            "gsm-community-market-campaign",
+            "--date",
+            "2026-05-01",
+            "--output-root",
+            str(tmp_path),
+            "--no-html-review",
+        ],
+        check=True,
+        capture_output=True,
+        env=env,
+        text=True,
+    )
+
+    assert completed.stderr == ""
+    assert "LiteLLM" not in completed.stderr
+    assert "model cost" not in completed.stderr.lower()
+    assert (tmp_path / "2026-05-01-gsm-community-market-campaign").exists()

--- a/tests/test_real_brief_benchmark.py
+++ b/tests/test_real_brief_benchmark.py
@@ -19,13 +19,53 @@ def test_safe_slug_accepts_fixture_style_ids():
 
 @pytest.mark.parametrize(
     "slug",
-    ["", ".", "..", "../escape", "/abs/path", "has space", "UpperCase", "x/y"],
+    [
+        "",
+        ".",
+        "..",
+        "../escape",
+        "/abs/path",
+        "has space",
+        "UpperCase",
+        "x/y",
+        "abc\n",
+    ],
 )
 def test_safe_slug_rejects_unsafe_ids(slug):
     from vulca.real_brief.types import safe_slug
 
     with pytest.raises(ValueError, match="safe slug"):
         safe_slug(slug)
+
+
+def test_fixture_validation_rejects_url_without_netloc():
+    from vulca.real_brief.types import Deliverable, RealBriefFixture, SourceInfo
+
+    fixture = RealBriefFixture(
+        slug="broken-fixture",
+        title="Broken Fixture",
+        source=SourceInfo(
+            url="https://",
+            retrieved_on="2026-05-01",
+            usage_note="Internal benchmark only",
+        ),
+        client="Client exists",
+        context="Context exists",
+        audience=["audience"],
+        deliverables=[Deliverable("deliverable", "format", "channel")],
+        constraints=["constraint"],
+        budget="not specified by source",
+        timeline="source-specific deadline",
+        required_outputs=["decision_package", "production_package"],
+        ai_policy="unspecified",
+        simulation_only=True,
+        risks=["risk"],
+        avoid=["avoid"],
+        evaluation_dimensions=["brief_compliance"],
+    )
+
+    with pytest.raises(ValueError, match="source.url"):
+        fixture.validate()
 
 
 def test_fixture_validation_rejects_missing_required_field():


### PR DESCRIPTION
## Summary

- Adds `vulca.real_brief`, a dry-run benchmark harness for public creative briefs with structured fixtures, validation, A/B/C/D condition generation, artifact writing, and workflow handoff data.
- Adds a local `human_review.html` surface that links the decision/production packages and supports A/B/C/D x review-dimension scoring with JSON export.
- Adds `scripts/real_brief_benchmark.py` as an offline, fail-closed CLI and links the older cultural-term prompt experiment to this real-brief successor benchmark.

## Safety / Scope

- Phase 1 remains dry-run only: no real provider execution, no image generation, and `--real-provider` fails closed.
- CLI import/help and dry-run execution avoid provider-adjacent remote cost-map fetches.
- Generated artifacts are scanned for secret-like strings; no live keys or endpoint details are written.
- Redraw/mask refinement files are intentionally untouched; redraw validation remains in its separate branch.

## Verification

- `PYTHONPATH=src python3 -m pytest tests/test_real_brief_benchmark.py -q` -> 49 passed
- `PYTHONPATH=src python3 -m pytest tests/test_visual_discovery_benchmark.py tests/test_visual_discovery_artifacts.py tests/test_visual_discovery_cards.py tests/test_visual_discovery_types.py -q` -> 22 passed
- `PYTHONPATH=src python3 scripts/real_brief_benchmark.py --date 2026-05-01 --slug all --output-root /private/tmp/vulca-real-brief-benchmark-check-final2`
- `grep -R -n -E "sk-|VULCA_REAL_PROVIDER_API_KEY|OPENAI_API_KEY|globalai" /private/tmp/vulca-real-brief-benchmark-check-final2` -> no matches

## Follow-up

- Phase 2 should connect the generated `workflow_handoff.json` into `/visual-discovery -> /visual-brainstorm -> /visual-spec -> /visual-plan -> /evaluate`.
- Real provider and redraw-based visual evaluation should wait until the redraw branch stabilizes and is merged.
