### PR TITLE
docs(platform): refresh post-v0.22 readiness

### DIFF
--- a/.agents/skills/evaluate/SKILL.md
+++ b/.agents/skills/evaluate/SKILL.md
@@ -83,7 +83,7 @@ Next action must be one of:
 - `accept`
 - `revise prompt`
 - `rerun /visual-plan`
-- `redraw target after v0.22 route is available`
+- `redraw target with dogfooded v0.22 route`
 - `run /visual-discovery`
 
 ## Artifact Contract

--- a/.claude/skills/evaluate/SKILL.md
+++ b/.claude/skills/evaluate/SKILL.md
@@ -83,7 +83,7 @@ Next action must be one of:
 - `accept`
 - `revise prompt`
 - `rerun /visual-plan`
-- `redraw target after v0.22 route is available`
+- `redraw target with dogfooded v0.22 route`
 - `run /visual-discovery`
 
 ## Artifact Contract

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ User intent ─▶ Claude Code (planning) ─▶ Vulca MCP tools ─▶ Image ar
 
 ### Roadmap — no promises, just honest order
 
-- **Next skill:** `/inpaint` (region-level edit), once v0.22 redraw routes are hardened
+- **Next skill:** `/inpaint` (region-level edit), after real-image dogfood validates the v0.22 redraw routes
 - **Then:** `/layered-create` (structured generation)
 - **Beyond:** community-driven — file an issue with your workflow
 

--- a/docs/platform/claude-plugin-marketplace-checklist.md
+++ b/docs/platform/claude-plugin-marketplace-checklist.md
@@ -1,7 +1,7 @@
 # Claude Plugin Marketplace Checklist
 
 **Status:** Pre-submission checklist
-**Last verified:** 2026-04-30
+**Last verified:** 2026-05-01
 
 ## Official Path
 
@@ -31,7 +31,7 @@ Lead with the workflows that are already product-ready:
 - `/visual-plan`
 - `/evaluate`
 
-Do not lead marketplace copy with redraw. Redraw and inpaint can be described as advanced MCP tools, but polished user-facing `/inpaint` or `/redraw-layer` promotion should wait for v0.22 target-aware mask refinement evidence.
+Do not lead marketplace copy with redraw. Redraw and inpaint can be described as advanced MCP tools, but polished user-facing `/inpaint` or `/redraw-layer` promotion should wait for real-image dogfood evidence from the v0.22 target-aware mask refinement route.
 
 ## Package Layout
 

--- a/docs/platform/claude-submission-packet/validation.md
+++ b/docs/platform/claude-submission-packet/validation.md
@@ -8,6 +8,8 @@ Run from the plugin package root after PR #28 is present.
 
 Observed on 2026-04-30: validation passed.
 
+Repeated on 2026-05-01 from `master`: validation passed.
+
 ```bash
 /Users/yhryzy/.local/bin/claude --plugin-dir . --print --max-budget-usd 0.20 --permission-mode dontAsk "Reply with only the Vulca plugin skill names you can see from loaded plugins; do not use tools."
 ```
@@ -30,4 +32,17 @@ PR #28 platform package validation also ran:
 
 Observed on 2026-04-30: 60 tests passed.
 
+Focused post-merge validation also ran on 2026-05-01:
+
+```bash
+python3 -m pytest tests/test_visual_discovery_docs_truth.py tests/test_prompting.py tests/test_mcp_remote_profile.py tests/test_redraw_review_contract.py tests/test_mask_refine.py -q
+```
+
+Observed: 32 tests passed.
+
 The public-doc forbidden phrase scan returned no matches for stale fixed MCP tool counts, unsupported platform-listing claims, or cultural-prompting overclaims.
+
+Standalone plugin repository sync:
+
+- `vulca-plugin` PR #9 synced the public Claude plugin repository to v0.19.0.
+- PR #9 merged on 2026-05-01 at `55b6bb371544cd199e43f493b763d34e9cb85f5e`.

--- a/docs/platform/manual-review-checklist.md
+++ b/docs/platform/manual-review-checklist.md
@@ -1,7 +1,7 @@
 # Platform Manual Review Checklist
 
 **Status:** Human review checklist
-**Last verified:** 2026-04-30
+**Last verified:** 2026-05-01
 
 Use this checklist before merging or submitting Vulca to a plugin directory.
 
@@ -82,7 +82,6 @@ Do not state that official Codex public publishing has opened until OpenAI's doc
 
 Before marketplace copy leads with redraw:
 
-- review and merge `codex/v0-22-mask-refinement`;
 - run its redraw-focused tests;
-- dogfood at least one real image where target-aware masks avoid editing unrelated pixels;
+- dogfood representative real images where target-aware masks avoid editing unrelated pixels;
 - confirm final user-facing image uses paste-back output, not sparse transparent layer output.

--- a/docs/platform/marketplace-copy-draft.md
+++ b/docs/platform/marketplace-copy-draft.md
@@ -1,7 +1,7 @@
 # Marketplace Copy Draft
 
 **Status:** Draft for human review
-**Last verified:** 2026-04-30
+**Last verified:** 2026-05-01
 
 ## One-Liner
 
@@ -22,7 +22,7 @@ The first marketplace release should emphasize:
 - `/decompose` for semantic layer extraction;
 - `/evaluate` for structured review against Vulca's L1-L5 framework.
 
-Redraw and inpaint tools are available for advanced workflows. Polished user-facing `/inpaint` or `/redraw-layer` skills will be promoted after v0.22 target-aware mask refinement evidence lands.
+Redraw and inpaint tools are available for advanced workflows. Polished user-facing `/inpaint` or `/redraw-layer` skills will be promoted after real-image dogfood validates the v0.22 target-aware mask refinement route.
 
 ## Claude Marketplace Notes
 

--- a/docs/platform/release-readiness-status.md
+++ b/docs/platform/release-readiness-status.md
@@ -1,7 +1,7 @@
 # Platform Release Readiness Status
 
 **Status:** Working release gate summary
-**Last updated:** 2026-04-30
+**Last updated:** 2026-05-01
 
 ## Current Claims We Can Make
 
@@ -10,19 +10,19 @@
 - Codex can be documented as a plugin plus MCP target; official public Codex plugin publishing should remain future-facing until OpenAI opens that flow.
 - ChatGPT can be documented as a remote MCP app/prototype target.
 - Google/Gemini can be documented as a provider path now, with ADK / Vertex Agent Engine later.
-- Redraw is an advanced workflow today; polished `/inpaint` or `/redraw-layer` promotion remains gated on v0.22 merge and real-image dogfood.
+- Redraw is an advanced workflow today. v0.22 target-aware mask refinement is merged, but polished `/inpaint` or `/redraw-layer` promotion remains gated on real-image dogfood evidence.
 
 ## Claims We Should Not Make Yet
 
 - Do not claim the public Codex listing has already launched.
 - Do not claim Google has a Vulca plugin marketplace path.
 - Do not claim cultural terminology guarantees better generation.
-- Do not lead marketplace copy with redraw quality until v0.22 lands and is dogfooded.
+- Do not lead marketplace copy with redraw quality until v0.22 is dogfooded on representative real images.
 - Do not present transparent layer assets as final after-images.
 
 ## Verification Evidence
 
-Run in `codex/platform-distribution-realtime-plan`:
+Run in `master` on 2026-05-01:
 
 ```bash
 /opt/homebrew/bin/codex marketplace add .
@@ -35,6 +35,15 @@ Observed: added marketplace `vulca-plugins` from this worktree.
 ```
 
 Observed: validation passed.
+
+Run in `/Users/yhryzy/dev/vulca-plugin` on 2026-05-01:
+
+```bash
+/Users/yhryzy/.local/bin/claude plugin validate .
+/Users/yhryzy/.local/bin/claude plugin validate .claude-plugin/plugin.json
+```
+
+Observed: marketplace and plugin manifest validation passed. `vulca-plugin` PR #9 synced the standalone plugin repository to v0.19.0 and was merged at commit `55b6bb371544cd199e43f493b763d34e9cb85f5e`.
 
 ```bash
 /Users/yhryzy/.local/bin/claude --plugin-dir . --print --max-budget-usd 0.20 --permission-mode dontAsk "Reply with only the Vulca plugin skill names you can see from loaded plugins; do not use tools."
@@ -68,7 +77,7 @@ grep -RIn "culture term[s] guarantee\|cultural term[s] guarantee\|always improve
 
 Observed: no matches.
 
-Run in `codex/v0-22-mask-refinement`:
+Run after v0.22 merge:
 
 ```bash
 /opt/homebrew/bin/python3 -m pytest tests/test_mask_refine.py tests/test_layers_redraw_refinement.py tests/test_redraw_review_contract.py -q
@@ -87,5 +96,5 @@ Observed: 44 passed.
 - Optional: run a full interactive `claude --plugin-dir .` session if you want UI-level confirmation beyond `plugin validate` and non-interactive skill discovery.
 - Optional: open Codex UI and confirm the newly added `vulca-plugins` marketplace source appears as expected.
 - Review marketplace copy and screenshots before submission.
-- Dogfood v0.22 redraw on at least one real image and confirm the user-facing after-image is `source_pasteback_path`.
+- Dogfood v0.22 redraw on representative real images and confirm the user-facing after-image is `source_pasteback_path`.
 - Decide what to do with main-worktree untracked generated artifacts before any broad cleanup.

--- a/docs/platform/worktree-cleanup-audit.md
+++ b/docs/platform/worktree-cleanup-audit.md
@@ -1,17 +1,15 @@
 # Worktree Cleanup Audit
 
 **Status:** Review notes
-**Last checked:** 2026-04-30
+**Last checked:** 2026-05-01
 
 ## Worktrees
 
 | Path | Branch | Status | Recommendation |
 |---|---|---|---|
-| `/Users/yhryzy/dev/vulca/.worktrees/platform-distribution-realtime-plan` | `codex/platform-distribution-realtime-plan` | Dirty by design | Keep for manual review, then stage/commit as the platform distribution package. |
-| `/Users/yhryzy/dev/vulca/.worktrees/v0-22-mask-refinement` | `codex/v0-22-mask-refinement` | Dirty with redraw code/test changes plus showcase artifacts | Keep separate. Review and commit code/test changes before merging; decide separately whether showcase artifacts should be tracked. |
-| `/Users/yhryzy/dev/vulca/.worktrees/cultural-term-benchmark-signal` | `codex/cultural-term-benchmark-signal` | Clean | No cleanup needed. |
+| `/Users/yhryzy/dev/vulca/.worktrees/real-brief-benchmark-design` | `codex/real-brief-benchmark-design` | Clean, ahead of its upstream by 5 commits | Keep separate from platform distribution. Review/push/PR when benchmark design is ready. |
 | `/Users/yhryzy/.codex/worktrees/9919/vulca` | detached | Clean | Archive/remove later if no longer needed; no code cleanup needed. |
-| `/Users/yhryzy/dev/vulca` | `master` | Dirty with local `.mcp.json` and many untracked demo/assets/log/model files | Do not auto-clean. Decide which generated artifacts matter, then either move to ignored local storage, track intentionally, or remove after backup. |
+| `/Users/yhryzy/dev/vulca` | `master` | No tracked edits; untracked demo/spec/research artifacts remain | Do not auto-clean. Decide which generated artifacts matter, then either move to ignored local storage, track intentionally, or remove after backup. |
 
 ## Platform Branch Dirty Set
 
@@ -34,20 +32,13 @@ These files are expected for the current platform distribution work:
 
 ## Main Worktree Notes
 
-Main has a local `.mcp.json` that loads `/Users/yhryzy/dev/vulca/.env.local` before starting `/opt/homebrew/bin/vulca-mcp`. That may be useful for local development, but it is user-machine-specific and should not be blindly committed into a public package.
+Main previously had a local `.mcp.json` that loaded `/Users/yhryzy/dev/vulca/.env.local` before starting `/opt/homebrew/bin/vulca-mcp`. That user-machine-specific version is preserved in `stash@{0}` as `codex-local-mcp-before-origin-master-ff`; the tracked package uses the portable `vulca-mcp` config.
 
 Main also has many untracked generated or local files, including demo assets, visual-spec outputs, screenshots, `error.log`, `mobileclip_blt.ts`, and `rf-detr-base.pth`. These should be treated as local artifacts until a human decides otherwise.
 
 ## v0.22 Notes
 
-The v0.22 worktree has dirty changes in:
-
-- `src/vulca/layers/redraw.py`
-- `tests/test_layers_redraw_refinement.py`
-- `.superpowers/`
-- `docs/visual-specs/2026-04-27-ipad-cartoon-roadside/v0_22_gpt_image_2/`
-
-The redraw test gates pass, but this branch should be reviewed independently from platform distribution. Do not mix these files into the platform branch.
+v0.22 target-aware mask refinement has merged to `master`. Keep redraw promotion gated on real-image dogfood and final paste-back review; do not market sparse transparent layer outputs as final after-images.
 
 ## Cleanup Policy
 

--- a/docs/product/platform-distribution-realtime-brief.md
+++ b/docs/product/platform-distribution-realtime-brief.md
@@ -1,7 +1,7 @@
 # Vulca Platform Distribution Realtime Brief
 
 **Status:** Working brief for platform distribution
-**Last verified:** 2026-04-30
+**Last verified:** 2026-05-01
 
 This brief records current public platform facts for distributing Vulca into Claude, OpenAI/Codex/ChatGPT, and Google/Gemini workflows. It should be refreshed before marketplace submission, remote MCP launch, or public claims about platform support.
 
@@ -37,7 +37,7 @@ Vulca implication:
 - The existing `.claude-plugin/plugin.json` should be treated as the packaging entry point, but it must not claim fixed MCP tool counts.
 - Claude marketplace packaging needs root-level `skills/` and `.mcp.json`; keep those synced from `.agents/skills/` with `scripts/sync_plugin_skills.py`.
 - Marketplace submission should wait until plugin install, skill invocation, MCP startup, and at least one no-cost workflow are tested in a fresh Claude Code session.
-- The first official submission should emphasize `/decompose`, `/visual-discovery`, `/visual-brainstorm`, `/visual-spec`, `/visual-plan`, and `/evaluate`; `/inpaint` or `/redraw-layer` should wait for v0.22 evidence.
+- The first official submission should emphasize `/decompose`, `/visual-discovery`, `/visual-brainstorm`, `/visual-spec`, `/visual-plan`, and `/evaluate`; `/inpaint` or `/redraw-layer` should wait for real-image v0.22 redraw dogfood evidence.
 
 ## OpenAI / Codex / ChatGPT
 
@@ -105,11 +105,11 @@ Vulca implication:
 
 ## Redraw Distribution Rule
 
-Redraw should not lead marketplace copy until v0.22 target-aware mask refinement passes a real-image dogfood gate.
+Redraw should not lead marketplace copy until the merged v0.22 target-aware mask refinement route passes a real-image dogfood gate.
 
 Use this public wording until then:
 
-> Redraw and inpaint tools are available for advanced workflows. Polished user-facing `/inpaint` or `/redraw-layer` skills will be promoted after v0.22 target-aware mask refinement evidence lands.
+> Redraw and inpaint tools are available for advanced workflows. Polished user-facing `/inpaint` or `/redraw-layer` skills will be promoted after real-image dogfood validates the v0.22 target-aware mask refinement route.
 
 The first public marketplace copy should lead with artifact control, decomposition, discovery, prompt composition, and evaluation.
 

--- a/docs/product/roadmap.md
+++ b/docs/product/roadmap.md
@@ -1,7 +1,7 @@
 # Vulca Product Roadmap
 
 **Status:** Public product roadmap
-**Last updated:** 2026-04-30
+**Last updated:** 2026-05-01
 
 Vulca is an agent-native visual control layer. The product turns fuzzy visual intent into controlled creative production through reviewable artifacts, provider-routed generation, semantic pixel editing, and cultural evaluation.
 
@@ -15,6 +15,7 @@ Vulca is an agent-native visual control layer. The product turns fuzzy visual in
 - `docs/product/provider-capabilities.md`: provider/platform capability matrix.
 - `plugins/vulca`: repo-local Codex plugin package for marketplace validation.
 - `.agents/plugins/marketplace.json`: repo marketplace entry for Codex plugin testing.
+- v0.22 target-aware mask refinement merged for redraw route hardening.
 - MCP tools for image generation, image viewing, evaluation, inpainting, layers, redraw, compositing, paste-back, and Tool Protocol analysis.
 - 13 cultural traditions and L1-L5 evaluation framework.
 
@@ -26,12 +27,12 @@ Vulca is an agent-native visual control layer. The product turns fuzzy visual in
 - ChatGPT remote MCP prototype scope.
 - ChatGPT remote MCP safe-profile prototype.
 - Cultural-term efficacy benchmark real-provider opt-in.
-- v0.22 target-aware mask refinement review and merge gate.
+- Real-image v0.22 redraw dogfood before promoting `/inpaint` or `/redraw-layer` as polished skills.
 
 ## In Parallel
 
-- v0.22 target-aware mask refinement in `.worktrees/v0-22-mask-refinement`.
-- This work owns redraw robustness and should land before `/inpaint` or `/redraw-layer` is marketed as a polished user-facing skill.
+- Real-brief benchmark design work in `.worktrees/real-brief-benchmark-design`.
+- Untracked generated demo/spec artifacts in the main worktree need an explicit keep/move/remove decision before broad cleanup.
 
 ## Later
 

--- a/docs/superpowers/plans/2026-04-30-evaluate-skill.md
+++ b/docs/superpowers/plans/2026-04-30-evaluate-skill.md
@@ -182,7 +182,7 @@ Next action must be one of:
 - `accept`
 - `revise prompt`
 - `rerun /visual-plan`
-- `redraw target after v0.22 route is available`
+- `redraw target with dogfooded v0.22 route`
 - `run /visual-discovery`
 
 ## Artifact Contract

--- a/docs/superpowers/plans/2026-04-30-platform-distribution-redraw-hardening.md
+++ b/docs/superpowers/plans/2026-04-30-platform-distribution-redraw-hardening.md
@@ -188,7 +188,7 @@ In `docs/product/roadmap.md`, set `## Next` to:
 - Codex plugin marketplace validation and MCP usage guide.
 - ChatGPT remote MCP prototype scope.
 - Cultural-term efficacy benchmark real-provider opt-in.
-- v0.22 target-aware mask refinement review and merge gate.
+- Real-image v0.22 redraw dogfood before promoting `/inpaint` or `/redraw-layer` as polished skills.
 ```
 
 - [ ] **Step 3: Run docs truth tests**
@@ -252,7 +252,7 @@ Create `docs/platform/claude-plugin-marketplace-checklist.md` with:
 
 - No fixed MCP tool count claims.
 - No promise that cultural terms improve output quality.
-- No public promotion of `/inpaint` or `/redraw-layer` until v0.22 evidence lands.
+- No public promotion of `/inpaint` or `/redraw-layer` until real-image v0.22 redraw dogfood evidence lands.
 - Real-provider generation is explicit opt-in.
 - README includes security notes for local file access and provider uploads.
 
@@ -495,7 +495,7 @@ Acceptance:
 Until real-image dogfood passes, public docs must use this wording:
 
 ```markdown
-Redraw and inpaint tools are available for advanced workflows. Polished user-facing `/inpaint` or `/redraw-layer` skills will be promoted after v0.22 target-aware mask refinement evidence lands.
+Redraw and inpaint tools are available for advanced workflows. Polished user-facing `/inpaint` or `/redraw-layer` skills will be promoted after real-image dogfood validates the v0.22 target-aware mask refinement route.
 ```
 
 ## Task 7: Final Verification

--- a/docs/superpowers/specs/2026-04-30-evaluate-skill-design.md
+++ b/docs/superpowers/specs/2026-04-30-evaluate-skill-design.md
@@ -141,7 +141,7 @@ The user-facing response must include:
   - `accept`
   - `revise prompt`
   - `rerun /visual-plan`
-  - `redraw target after v0.22 route is available`
+  - `redraw target with dogfooded v0.22 route`
   - `run /visual-discovery` if the brief is unclear
 
 Artifact markdown should include:

--- a/docs/superpowers/specs/2026-04-30-product-positioning-platform-design.md
+++ b/docs/superpowers/specs/2026-04-30-product-positioning-platform-design.md
@@ -298,7 +298,7 @@ Output:
 ### Phase 2: Skill Packaging
 
 - Ship `/evaluate`.
-- Productize `/inpaint` or `/redraw-layer` after v0.22 lands.
+- Productize `/inpaint` or `/redraw-layer` after real-image dogfood validates the v0.22 redraw route.
 - Update `using-vulca-skills` routing once these skills exist.
 
 ### Phase 3: Evidence and Distribution

--- a/plugins/vulca/skills/evaluate/SKILL.md
+++ b/plugins/vulca/skills/evaluate/SKILL.md
@@ -83,7 +83,7 @@ Next action must be one of:
 - `accept`
 - `revise prompt`
 - `rerun /visual-plan`
-- `redraw target after v0.22 route is available`
+- `redraw target with dogfooded v0.22 route`
 - `run /visual-discovery`
 
 ## Artifact Contract

--- a/skills/evaluate/SKILL.md
+++ b/skills/evaluate/SKILL.md
@@ -83,7 +83,7 @@ Next action must be one of:
 - `accept`
 - `revise prompt`
 - `rerun /visual-plan`
-- `redraw target after v0.22 route is available`
+- `redraw target with dogfooded v0.22 route`
 - `run /visual-discovery`
 
 ## Artifact Contract


### PR DESCRIPTION
## Summary
- update platform/readiness docs now that v0.22 target-aware mask refinement is merged
- keep redraw/inpaint promotion gated on real-image dogfood and paste-back review
- record 2026-05-01 validation and standalone vulca-plugin PR #9 merge
- sync evaluate skill next-action wording across packaged skill copies

## Verification
- python3 -m pytest tests/test_visual_discovery_docs_truth.py tests/test_prompting.py tests/test_mcp_remote_profile.py tests/test_redraw_review_contract.py tests/test_mask_refine.py -q
- /Users/yhryzy/.local/bin/claude plugin validate .
- python3 -m json.tool .claude-plugin/plugin.json
- python3 -m json.tool .agents/plugins/marketplace.json
- python3 -m json.tool plugins/vulca/.codex-plugin/plugin.json
- python3 -m json.tool plugins/vulca/.mcp.json
- python3 -m json.tool .mcp.json
- git diff --check