### PR TITLE
docs(platform): refresh Google Gemini posture

### DIFF
--- a/docs/platform/google-gemini-provider-guide.md
+++ b/docs/platform/google-gemini-provider-guide.md
@@ -1,26 +1,29 @@
 # Google Gemini Provider Guide
 
 **Status:** Draft provider guide
-**Last verified:** 2026-04-30
+**Last verified:** 2026-05-01
 
 ## Official Path
 
-Google's immediate Vulca role is provider infrastructure. Gemini API and Vertex AI expose image generation and image editing models, while Google ADK and Vertex AI Agent Engine are future agent integration targets.
+Google's immediate Vulca role is provider infrastructure plus future MCP-compatible agent wiring. Gemini API and Vertex AI expose image generation and image editing models, Gemini CLI can consume local or remote MCP servers, and Google ADK / Gemini Enterprise Agent Platform are future agent integration targets.
 
 Sources:
 
 - [Gemini image generation](https://ai.google.dev/gemini-api/docs/image-generation)
 - [Vertex AI Gemini image generation and editing](https://docs.cloud.google.com/vertex-ai/generative-ai/docs/multimodal/image-generation)
+- [Gemini CLI](https://docs.cloud.google.com/gemini/docs/codeassist/gemini-cli)
 - [Gemini function calling](https://ai.google.dev/gemini-api/docs/function-calling)
-- [Vertex AI Agent Engine overview](https://docs.cloud.google.com/vertex-ai/generative-ai/docs/agent-engine/overview)
+- [Gemini Enterprise Agent Platform scale guide](https://docs.cloud.google.com/gemini-enterprise-agent-platform/scale)
 - [Google ADK MCP](https://google.github.io/adk-docs/mcp/)
+
+As of 2026-05-01, the Gemini API image-generation docs describe Nano Banana as the public name for Gemini native image generation. They list Nano Banana 2 (`gemini-3.1-flash-image-preview`), Nano Banana Pro (`gemini-3-pro-image-preview`), and Nano Banana (`gemini-2.5-flash-image`) as distinct model families. Keep public Vulca docs at the capability level unless a provider capability test pins an exact model ID.
 
 ## Vulca Position
 
 Treat Google as:
 
 - a current image provider path for generation, editing, reference-heavy exploration, and provider comparisons;
-- a function-calling and MCP-compatible agent path to research later;
+- a function-calling, Gemini CLI, ADK, and Agent Platform path to research later;
 - not a direct public plugin listing path for Vulca today.
 
 Model names and limits change quickly. Public docs should say "Gemini image models" or "Vertex AI image generation/editing" unless a specific benchmark or provider capability test pins an exact model ID.

--- a/docs/product/platform-distribution-realtime-brief.md
+++ b/docs/product/platform-distribution-realtime-brief.md
@@ -78,29 +78,32 @@ Vulca implication:
 
 ## Google / Gemini
 
-Google's immediate value for Vulca is provider infrastructure, not a direct equivalent of the Claude plugin marketplace. Gemini API and Vertex AI support image generation and editing, and Google ADK supports MCP tools for agents.
+Google's immediate value for Vulca is provider infrastructure and MCP-compatible agent wiring, not a direct equivalent of the Claude plugin marketplace. Gemini API and Vertex AI support image generation and editing, Gemini CLI / Gemini Code Assist can consume MCP servers, and Google ADK supports consuming and exposing MCP tools for agents.
 
 Current official facts:
 
-- Gemini image generation and editing supports Gemini 2.5 Flash Image and Gemini 3 Pro Image preview on Vertex AI.
-- Gemini 2.5 Flash Image supports 1024px output; Gemini 3 Pro Image preview supports up to 4096px.
+- Nano Banana is Google's public name for Gemini native image generation capabilities in the Gemini API.
+- The Gemini API image-generation docs currently identify three Nano Banana model families: Nano Banana 2 / `gemini-3.1-flash-image-preview`, Nano Banana Pro / `gemini-3-pro-image-preview`, and Nano Banana / `gemini-2.5-flash-image`.
+- Gemini 3 image models add higher-resolution output, reference-image mixing, improved text rendering, and optional grounding features, with model-specific limits.
 - Gemini image models support text-to-image, text rendering, interleaved text/image output, and image-plus-text editing.
-- Vertex AI Agent Engine supports deploying and managing production agents.
+- Gemini CLI is an open-source terminal agent and can use local or remote MCP servers; Gemini Code Assist agent mode exposes a subset of Gemini CLI functionality in VS Code.
+- Gemini Enterprise Agent Platform / Agent Platform Runtime supports deploying and managing production agents.
 - Gemini API supports function calling with typed function declarations and modes such as AUTO, ANY, NONE, and VALIDATED.
-- Google ADK documents MCP as a way to consume or expose tools to agents.
+- Google ADK documents MCP as a way to consume external MCP servers from agents and expose ADK tools through MCP servers.
 
 Sources:
 
 - [Gemini image generation](https://ai.google.dev/gemini-api/docs/image-generation)
 - [Vertex AI Gemini image generation and editing](https://docs.cloud.google.com/vertex-ai/generative-ai/docs/multimodal/image-generation)
+- [Gemini CLI](https://docs.cloud.google.com/gemini/docs/codeassist/gemini-cli)
 - [Gemini function calling](https://ai.google.dev/gemini-api/docs/function-calling)
-- [Vertex AI Agent Engine overview](https://docs.cloud.google.com/vertex-ai/generative-ai/docs/agent-engine/overview)
+- [Gemini Enterprise Agent Platform scale guide](https://docs.cloud.google.com/gemini-enterprise-agent-platform/scale)
 - [Google ADK MCP](https://google.github.io/adk-docs/mcp/)
 
 Vulca implication:
 
 - Keep Gemini as a first-class provider for sketching, reference-heavy exploration, and provider comparisons.
-- Document Google as "provider current, agent distribution planned" until an ADK or Vertex Agent Engine integration is implemented and tested.
+- Document Google as "provider current, MCP/agent integration planned" until a Gemini CLI, ADK, or Agent Platform Runtime integration is implemented and tested.
 - Do not claim Google has a Vulca marketplace-listing path for plugins.
 
 ## Redraw Distribution Rule

--- a/docs/product/provider-capabilities.md
+++ b/docs/product/provider-capabilities.md
@@ -1,7 +1,7 @@
 # Vulca Provider and Platform Capability Matrix
 
 **Status:** Public product guide
-**Last updated:** 2026-04-30
+**Last updated:** 2026-05-01
 
 Vulca separates agent surfaces from image providers.
 
@@ -12,7 +12,8 @@ Vulca separates agent surfaces from image providers.
 | Claude Code | Primary agent surface for MCP tools, skills, and marketplace distribution | Current, marketplace packaging next |
 | OpenAI Codex | Plugin marketplace surface plus local MCP consumer for developer workflows | Repo-local Codex plugin package current, official public listing later |
 | ChatGPT developer mode | Remote MCP app surface for interactive workflows | Remote MCP prototype planned |
-| Gemini API / Vertex AI | Image provider and future agent runtime target | Provider current, ADK/Agent Engine planned |
+| Gemini API / Vertex AI | Image provider path for generation, editing, and provider comparisons | Provider current |
+| Gemini CLI / Google ADK / Agent Platform | MCP-capable Google agent path | Planned integration; not a plugin marketplace listing |
 | Python SDK / CLI | Power-user and test harness path | Current |
 | Vulca Studio UI | Review surface for cards, sketches, layers, and evaluations | Later |
 
@@ -22,7 +23,7 @@ Vulca separates agent surfaces from image providers.
 |---|---|---|---|
 | `mock` | Cost-free artifact validation | tests, discovery sketch records, workflow dry-runs | quality claims |
 | `openai` | High-quality generation/editing backend | final candidates, image edits, text-heavy visuals when model supports it | assuming every model supports every edit knob |
-| `gemini` / `nb2` | Gemini image backend | sketching, reference-heavy exploration, alternative provider comparisons | treating marketing names as implementation IDs |
+| `gemini` / `nb2` | Gemini image backend | sketching, reference-heavy exploration, alternative provider comparisons | treating marketing names as stable implementation IDs |
 | `comfyui` | Local generation/editing backend | local-first workflows, inspectable pipelines, advanced users | assuming cloud-model prompt behavior |
 
 ## Documentation Rules


### PR DESCRIPTION
## Summary
- refresh Google/Gemini platform posture with current Gemini CLI, ADK MCP, and Gemini Enterprise Agent Platform wording
- update Nano Banana / Gemini image model naming from the current official Gemini API docs
- keep Google positioned as provider plus planned MCP/agent integration, not a plugin marketplace listing path

## Verification
- python3 -m pytest tests/test_visual_discovery_docs_truth.py -q
- git diff --check
- subagent source-backed review: no findings