### PR TITLE
feat(mcp): add remote-safe ChatGPT server

### DIFF
--- a/docs/platform/chatgpt-remote-mcp-prototype.md
+++ b/docs/platform/chatgpt-remote-mcp-prototype.md
@@ -1,11 +1,13 @@
-# ChatGPT Remote MCP Prototype
+# ChatGPT Remote MCP
 
-**Status:** Prototype profile
-**Last verified:** 2026-04-30
+**Status:** Initial remote-safe server
+**Last verified:** 2026-05-01
 
 ## Purpose
 
 Expose a conservative Vulca MCP profile for ChatGPT developer mode and OpenAI API remote MCP experiments.
+
+This profile now has a dedicated FastMCP server entry point. It is still a deployment prototype: production hosting, TLS, authentication, audit logging, and account-level ChatGPT app setup remain separate gates.
 
 ## Allowed Tools
 
@@ -15,9 +17,9 @@ Expose a conservative Vulca MCP profile for ChatGPT developer mode and OpenAI AP
 - `compose_prompt_from_design`
 - `evaluate_artwork`
 
-`evaluate_artwork` defaults to `mock=True` and `mode="rubric_only"` for the remote profile.
+`evaluate_artwork` defaults to `mock=True` and `mode="rubric_only"` for the remote profile. In this mode Vulca returns the resolved L1-L5 rubric payload and does not read image pixels or call a VLM. Pixel-reading evaluation is intentionally not exposed by this first remote server.
 
-`compose_prompt_from_design` reads a user-supplied `design.md` path. Remote deployments must require approval before calling it and should constrain approved paths to the configured workspace.
+`compose_prompt_from_design` reads a user-supplied `design.md` path. The remote server constrains that path to `VULCA_REMOTE_WORKSPACE_ROOT`; relative paths resolve inside that root and absolute paths outside that root are rejected.
 
 ## Not Exposed By Default
 
@@ -43,10 +45,30 @@ tools = [
 ]
 ```
 
+## Run Locally
+
+Install with the MCP extra, then start the remote-safe profile:
+
+```bash
+VULCA_REMOTE_WORKSPACE_ROOT=/absolute/path/to/workspace \
+VULCA_REMOTE_MCP_HOST=127.0.0.1 \
+VULCA_REMOTE_MCP_PORT=8765 \
+VULCA_REMOTE_MCP_PATH=/mcp \
+vulca-mcp-remote
+```
+
+Default transport is `streamable-http`. For local stdio debugging only:
+
+```bash
+VULCA_REMOTE_MCP_TRANSPORT=stdio vulca-mcp-remote
+```
+
+Use `http://127.0.0.1:8765/mcp` for local API experiments. ChatGPT developer mode requires a remotely reachable server URL; use HTTPS, auth, and logging before connecting a public endpoint.
+
 ## Privacy Rules
 
 - Do not pass private images to a remote server without explicit user approval.
-- Do not pass private project paths to a remote server unless the path is in the approved workspace.
-- Do not enable provider-backed VLM evaluation by default.
+- Do not pass private project paths to a remote server unless the path is inside `VULCA_REMOTE_WORKSPACE_ROOT`.
+- Do not enable pixel-reading or provider-backed VLM evaluation by default.
 - Do not expose filesystem-writing tools in the first prototype.
 - Keep all cost-incurring tools behind explicit opt-in.

--- a/docs/platform/openai-codex-mcp-guide.md
+++ b/docs/platform/openai-codex-mcp-guide.md
@@ -54,7 +54,7 @@ codex mcp list
 
 Use this path for developer workflows that only need tools and do not need bundled skills or plugin UI metadata.
 
-## ChatGPT Remote MCP Prototype
+## ChatGPT Remote MCP
 
 Start with a conservative remote MCP allowlist:
 
@@ -65,6 +65,14 @@ Start with a conservative remote MCP allowlist:
 - `evaluate_artwork`
 
 Do not expose generation, redraw, inpaint, paste-back, or filesystem-writing layer tools by default. Add those only behind explicit approval, clear cost labeling, and image/file privacy review.
+
+Vulca now includes a remote-safe FastMCP entry point:
+
+```bash
+VULCA_REMOTE_WORKSPACE_ROOT=/absolute/path/to/workspace vulca-mcp-remote
+```
+
+By default this serves streamable HTTP on `http://127.0.0.1:8765/mcp`. Use this for local OpenAI Responses API experiments. ChatGPT developer mode requires a remotely reachable HTTPS endpoint and should not be connected to a public server until auth, logging, and deployment review are complete.
 
 Responses API remote MCP tests should use an allowlist and approval requirement:
 
@@ -91,6 +99,7 @@ Before public install instructions:
 
 - validate the repo marketplace in a clean Codex Desktop session;
 - verify `vulca-mcp` is available in the target environment;
+- verify `vulca-mcp-remote` starts with `VULCA_REMOTE_WORKSPACE_ROOT` set before ChatGPT remote MCP experiments;
 - run one no-cost `/visual-discovery` or prompt-composition workflow;
 - confirm generated artifacts stay in the workspace;
 - confirm public copy says official Codex public publishing is still pending unless OpenAI has opened it.

--- a/docs/platform/release-readiness-status.md
+++ b/docs/platform/release-readiness-status.md
@@ -8,7 +8,7 @@
 - Vulca has a Claude plugin package shape at the repository root: `.claude-plugin/plugin.json`, `.mcp.json`, and `skills/`.
 - Vulca has a repo-local Codex plugin package for validation: `plugins/vulca/.codex-plugin/plugin.json`, `plugins/vulca/.mcp.json`, and `plugins/vulca/skills/`.
 - Codex can be documented as a plugin plus MCP target; official public Codex plugin publishing should remain future-facing until OpenAI opens that flow.
-- ChatGPT can be documented as a remote MCP app/prototype target.
+- ChatGPT can be documented as a remote MCP app/prototype target with a remote-safe streamable HTTP entry point, `vulca-mcp-remote`.
 - Google/Gemini can be documented as a provider path now, with ADK / Vertex Agent Engine later.
 - Redraw is an advanced workflow today. v0.22 target-aware mask refinement is merged, but polished `/inpaint` or `/redraw-layer` promotion remains gated on real-image dogfood evidence.
 
@@ -91,10 +91,19 @@ Observed: 14 passed.
 
 Observed: 44 passed.
 
+Run after adding the ChatGPT remote-safe MCP entry point:
+
+```bash
+/opt/homebrew/bin/python3 -m pytest tests/test_mcp_remote_profile.py -q
+```
+
+Observed: 14 passed.
+
 ## Manual Gates Remaining
 
 - Optional: run a full interactive `claude --plugin-dir .` session if you want UI-level confirmation beyond `plugin validate` and non-interactive skill discovery.
 - Optional: open Codex UI and confirm the newly added `vulca-plugins` marketplace source appears as expected.
+- Deploy `vulca-mcp-remote` behind HTTPS/auth/logging before connecting it to ChatGPT developer mode from a public URL.
 - Review marketplace copy and screenshots before submission.
 - Dogfood v0.22 redraw on representative real images and confirm the user-facing after-image is `source_pasteback_path`.
 - Decide what to do with main-worktree untracked generated artifacts before any broad cleanup.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,6 +134,7 @@ Issues = "https://github.com/vulca-org/vulca/issues"
 [project.scripts]
 vulca = "vulca.cli:main"
 vulca-mcp = "vulca.mcp_server:mcp.run"
+vulca-mcp-remote = "vulca.mcp_remote:main"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/vulca"]

--- a/src/vulca/mcp_remote.py
+++ b/src/vulca/mcp_remote.py
@@ -1,6 +1,15 @@
 from __future__ import annotations
 
+import os
+from pathlib import Path
+
+from fastmcp import FastMCP
+
 from vulca.mcp_profiles import get_remote_tool_policy, list_remote_safe_tools
+
+
+class RemoteMCPAccessError(ValueError):
+    """Raised when a remote-safe MCP tool would read outside its workspace."""
 
 
 def _policy_to_dict(tool_name: str) -> dict[str, object]:
@@ -19,10 +28,129 @@ def build_remote_mcp_server_summary() -> dict[str, object]:
     allowed_tools = list_remote_safe_tools()
     return {
         "profile": "chatgpt_remote_safe",
-        "transport_status": "profile_only",
+        "transport_status": "streamable_http_ready",
         "allowed_tools": allowed_tools,
         "policies": {
             tool_name: _policy_to_dict(tool_name)
             for tool_name in allowed_tools
         },
     }
+
+
+def resolve_remote_workspace_path(
+    requested_path: str,
+    *,
+    workspace_root: str | os.PathLike[str] | None,
+) -> Path:
+    if not workspace_root:
+        raise RemoteMCPAccessError(
+            "VULCA_REMOTE_WORKSPACE_ROOT is required before remote file reads."
+        )
+
+    root = Path(workspace_root).expanduser().resolve()
+    requested = Path(requested_path).expanduser()
+    candidate = requested if requested.is_absolute() else root / requested
+    resolved = candidate.resolve()
+
+    if not resolved.is_relative_to(root):
+        raise RemoteMCPAccessError(
+            f"Remote path {resolved} is outside workspace root {root}."
+        )
+    if not resolved.exists():
+        raise RemoteMCPAccessError(f"Remote path {resolved} does not exist.")
+    if not resolved.is_file():
+        raise RemoteMCPAccessError(f"Remote path {resolved} is not a file.")
+    return resolved
+
+
+async def _remote_compose_prompt_from_design(design_path: str) -> dict:
+    """Use this when composing a provider-ready prompt from an approved design.md path inside the remote workspace."""
+    safe_path = resolve_remote_workspace_path(
+        design_path,
+        workspace_root=os.environ.get("VULCA_REMOTE_WORKSPACE_ROOT", ""),
+    )
+    from vulca.mcp_server import compose_prompt_from_design
+
+    return await compose_prompt_from_design(str(safe_path))
+
+
+async def _evaluate_artwork(**kwargs) -> dict:
+    from vulca.mcp_server import evaluate_artwork
+
+    return await evaluate_artwork(**kwargs)
+
+
+async def _remote_evaluate_artwork(
+    image_path: str,
+    tradition: str = "",
+    intent: str = "",
+) -> dict:
+    """Use this when returning Vulca's L1-L5 rubric without reading pixels or calling a VLM."""
+    return await _evaluate_artwork(
+        image_path=image_path,
+        tradition=tradition,
+        intent=intent,
+        mock=True,
+        mode="rubric_only",
+        vlm_model="",
+    )
+
+
+remote_mcp = FastMCP(
+    "VULCA Remote",
+    instructions=(
+        "Remote-safe Vulca profile for ChatGPT and OpenAI Responses MCP. "
+        "Only discovery, tradition lookup, prompt composition, and mock "
+        "rubric evaluation tools are exposed."
+    ),
+)
+
+
+async def _remote_list_traditions() -> dict:
+    """Use this when selecting from Vulca's traditions before prompt or evaluation work."""
+    from vulca.mcp_server import list_traditions
+
+    return await list_traditions()
+
+
+async def _remote_get_tradition_guide(tradition: str) -> dict:
+    """Use this when loading detailed weights, terminology, taboos, and layer guidance for one tradition."""
+    from vulca.mcp_server import get_tradition_guide
+
+    return await get_tradition_guide(tradition=tradition)
+
+
+async def _remote_search_traditions(tags: list[str], limit: int = 5) -> dict:
+    """Use this when fuzzy visual or cultural keywords need to be matched to Vulca traditions."""
+    from vulca.mcp_server import search_traditions
+
+    return await search_traditions(tags=tags, limit=limit)
+
+
+remote_mcp.tool(name="list_traditions")(_remote_list_traditions)
+remote_mcp.tool(name="get_tradition_guide")(_remote_get_tradition_guide)
+remote_mcp.tool(name="search_traditions")(_remote_search_traditions)
+remote_mcp.tool(name="compose_prompt_from_design")(_remote_compose_prompt_from_design)
+remote_mcp.tool(name="evaluate_artwork")(_remote_evaluate_artwork)
+
+
+def main() -> None:
+    transport = os.environ.get("VULCA_REMOTE_MCP_TRANSPORT", "streamable-http")
+    host = os.environ.get("VULCA_REMOTE_MCP_HOST", "127.0.0.1")
+    port = int(os.environ.get("VULCA_REMOTE_MCP_PORT", "8765"))
+    path = os.environ.get("VULCA_REMOTE_MCP_PATH", "/mcp")
+
+    if transport == "stdio":
+        remote_mcp.run(transport="stdio")
+        return
+
+    remote_mcp.run(
+        transport=transport,
+        host=host,
+        port=port,
+        path=path,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_mcp_remote_profile.py
+++ b/tests/test_mcp_remote_profile.py
@@ -1,11 +1,22 @@
 from __future__ import annotations
 
+import asyncio
+import os
+from pathlib import Path
+import subprocess
+import sys
+
+import pytest
+
 from vulca.mcp_profiles import (
     REMOTE_DENIED_TOOLS,
     REMOTE_SAFE_TOOLS,
     get_remote_tool_policy,
     list_remote_safe_tools,
 )
+
+
+ROOT = Path(__file__).resolve().parent.parent
 
 
 def test_remote_profile_exposes_only_safe_tools():
@@ -85,8 +96,123 @@ def test_remote_mcp_summary_uses_allowlist_and_policy():
 
     assert summary["profile"] == "chatgpt_remote_safe"
     assert summary["allowed_tools"] == list_remote_safe_tools()
-    assert summary["transport_status"] == "profile_only"
+    assert summary["transport_status"] == "streamable_http_ready"
     assert summary["policies"]["evaluate_artwork"]["default_kwargs"] == {
         "mock": True,
         "mode": "rubric_only",
     }
+
+
+def test_remote_fastmcp_server_exposes_allowlist_only():
+    from vulca.mcp_remote import remote_mcp
+
+    tools = asyncio.run(remote_mcp.list_tools())
+    tool_names = sorted(tool.name for tool in tools)
+
+    assert tool_names == list_remote_safe_tools()
+
+
+def test_remote_fastmcp_tools_have_descriptions():
+    from vulca.mcp_remote import remote_mcp
+
+    tools = asyncio.run(remote_mcp.list_tools())
+
+    assert all(tool.description for tool in tools)
+    assert {
+        tool.name for tool in tools if "Use this when" in (tool.description or "")
+    } == set(list_remote_safe_tools())
+
+
+def test_remote_mcp_listing_does_not_import_full_local_mcp_server():
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            (
+                "import asyncio, sys; "
+                "from vulca.mcp_remote import remote_mcp; "
+                "asyncio.run(remote_mcp.list_tools()); "
+                "print('vulca.mcp_server' in sys.modules)"
+            ),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+        env={**os.environ, "PYTHONPATH": str(ROOT / "src")},
+    )
+
+    assert result.stdout.strip() == "False"
+
+
+def test_remote_workspace_path_requires_configured_root(tmp_path):
+    from vulca.mcp_remote import RemoteMCPAccessError, resolve_remote_workspace_path
+
+    design_path = tmp_path / "design.md"
+    design_path.write_text("# Design\n", encoding="utf-8")
+
+    with pytest.raises(RemoteMCPAccessError, match="VULCA_REMOTE_WORKSPACE_ROOT"):
+        resolve_remote_workspace_path(str(design_path), workspace_root="")
+
+
+def test_remote_workspace_path_blocks_escape(tmp_path):
+    from vulca.mcp_remote import RemoteMCPAccessError, resolve_remote_workspace_path
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    secret = tmp_path / "secret-design.md"
+    secret.write_text("# Secret\n", encoding="utf-8")
+
+    with pytest.raises(RemoteMCPAccessError, match="outside"):
+        resolve_remote_workspace_path(str(secret), workspace_root=str(workspace))
+
+
+def test_remote_workspace_path_allows_relative_file_inside_root(tmp_path):
+    from vulca.mcp_remote import resolve_remote_workspace_path
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    design_path = workspace / "design.md"
+    design_path.write_text("# Design\n", encoding="utf-8")
+
+    assert resolve_remote_workspace_path(
+        "design.md",
+        workspace_root=str(workspace),
+    ) == design_path.resolve()
+
+
+def test_remote_evaluate_artwork_forces_mock_rubric_only(monkeypatch):
+    from vulca import mcp_remote
+
+    captured: dict[str, object] = {}
+
+    async def fake_evaluate_artwork(**kwargs):
+        captured.update(kwargs)
+        return {"ok": True}
+
+    monkeypatch.setattr(mcp_remote, "_evaluate_artwork", fake_evaluate_artwork)
+
+    result = asyncio.run(
+        mcp_remote._remote_evaluate_artwork(
+            image_path="artwork.png",
+            tradition="chinese_xieyi",
+            intent="misty mountain",
+        )
+    )
+
+    assert result == {"ok": True}
+    assert captured == {
+        "image_path": "artwork.png",
+        "tradition": "chinese_xieyi",
+        "intent": "misty mountain",
+        "mock": True,
+        "mode": "rubric_only",
+        "vlm_model": "",
+    }
+
+
+def test_pyproject_exposes_remote_mcp_console_script():
+    pyproject = (ROOT / "pyproject.toml").read_text(
+        encoding="utf-8"
+    )
+
+    assert 'vulca-mcp-remote = "vulca.mcp_remote:main"' in pyproject


### PR DESCRIPTION
## Summary
- add a remote-safe FastMCP server entry point for ChatGPT/OpenAI remote MCP experiments
- expose only the conservative allowlist: traditions lookup/search, prompt composition, and rubric-only evaluation
- require VULCA_REMOTE_WORKSPACE_ROOT for design file reads and keep generation/redraw/inpaint/filesystem-writing tools out of the remote profile
- document local streamable HTTP usage and remaining production deployment/auth gates

## Verification
- /opt/homebrew/bin/python3 -m pytest tests/test_mcp_remote_profile.py tests/test_visual_discovery_docs_truth.py -q
- /opt/homebrew/bin/python3.11 -m pytest tests/test_mcp_remote_profile.py tests/test_visual_discovery_docs_truth.py -q
- git diff --check