### PR TITLE
feat: add real brief workflow adapter

### DIFF
--- a/docs/product/experiments/cultural-term-efficacy.md
+++ b/docs/product/experiments/cultural-term-efficacy.md
@@ -37,8 +37,8 @@ The default harness writes prompts, manifests, empty result records, and summari
 Real provider execution requires explicit opt-in:
 
 ```bash
+# Export the provider API key in your local shell before running this command.
 VULCA_REAL_PROVIDER_BASE_URL=https://example.openai-compatible-gateway.test \
-VULCA_REAL_PROVIDER_API_KEY=... \
 VULCA_REAL_PROVIDER_MODEL=gpt-image-2 \
 PYTHONPATH=src python3 scripts/visual_discovery_benchmark.py \
   --real-provider \
@@ -99,3 +99,9 @@ Use `scripts/real_brief_benchmark.py` for the successor dry-run harness:
 ```bash
 PYTHONPATH=src python3 scripts/real_brief_benchmark.py --date 2026-05-01
 ```
+
+Phase 2 real-brief workflow adapter: `scripts/real_brief_workflow_adapter.py`
+imports a Phase 1 real-brief package into `docs/visual-specs/<slug>/` as
+`discovery/`, `real_brief/`, and `workflow_seed.md` artifacts. It preserves
+`/visual-brainstorm`, `/visual-spec`, and `/visual-plan` human gates and does
+not call image providers.

--- a/docs/superpowers/plans/2026-05-01-real-brief-workflow-adapter.md
+++ b/docs/superpowers/plans/2026-05-01-real-brief-workflow-adapter.md
@@ -1,0 +1,1282 @@
+# Real Brief Workflow Adapter Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a Phase 2 adapter that imports Phase 1 real-brief benchmark packages into `docs/visual-specs/<slug>/` as official Vulca workflow seed artifacts without bypassing human gates.
+
+**Architecture:** Add a focused `vulca.real_brief.workflow_adapter` module that validates a Phase 1 package, copies source package artifacts into `real_brief/`, writes `discovery/` artifacts through existing `vulca.discovery` helpers for supported static 2D domains, and writes `workflow_seed.md` plus `adapter_manifest.json`. Keep `scripts/real_brief_workflow_adapter.py` as a thin CLI wrapper. No provider, redraw, mask, decompose, or layer execution happens in this phase.
+
+**Tech Stack:** Python `pathlib`, `json`, `shutil`, dataclasses-free helper functions, existing `vulca.real_brief` schemas, existing `vulca.discovery` artifact writer, pytest, argparse.
+
+---
+
+## File Structure
+
+- Create `src/vulca/real_brief/workflow_adapter.py`: source-package validation, domain mapping, safe copy, discovery artifact generation, adapter manifest, workflow seed writing, and public `adapt_real_brief_package`.
+- Create `scripts/real_brief_workflow_adapter.py`: CLI wrapper for the Python API.
+- Create `tests/test_real_brief_workflow_adapter.py`: TDD coverage for supported adaptation, unsupported domains, collision policy, validation failures, dry-run, CLI, and secret scanning.
+- Modify `src/vulca/real_brief/__init__.py`: lazy-export `adapt_real_brief_package`.
+- Optional documentation change only if implementation exposes a user-facing entry point that needs a link from `docs/product/experiments/cultural-term-efficacy.md`.
+
+Implementation boundaries:
+
+- Do not modify redraw, mask, decompose, layer, provider, MCP registration, or existing `/visual-*` skill files.
+- Do not call network APIs or real image providers in tests.
+- Do not write provider keys, endpoint URLs, or environment variable names into generated adapter artifacts.
+- Do not mutate the Phase 1 source package.
+- Keep `public_art` and `video_treatment` as `unsupported_for_visual_chain` in Phase 2 v1.
+
+---
+
+### Task 1: Supported Package Adapter Core
+
+**Files:**
+- Create: `tests/test_real_brief_workflow_adapter.py`
+- Create: `src/vulca/real_brief/workflow_adapter.py`
+
+- [ ] **Step 1: Write the failing supported-flow tests**
+
+Create `tests/test_real_brief_workflow_adapter.py` with:
+
+```python
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+
+def _source_package(tmp_path: Path, slug: str) -> Path:
+    from vulca.real_brief.artifacts import write_real_brief_dry_run
+
+    result = write_real_brief_dry_run(
+        output_root=tmp_path / "source",
+        slug=slug,
+        date="2026-05-01",
+        write_html_review=False,
+    )
+    return Path(result["output_dir"])
+
+
+def _read_json(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def test_adapt_real_brief_package_writes_supported_visual_workflow(tmp_path):
+    from vulca.real_brief.workflow_adapter import adapt_real_brief_package
+
+    source_package = _source_package(
+        tmp_path,
+        "seattle-polish-film-festival-poster",
+    )
+    original_manifest = (source_package / "manifest.json").read_text(encoding="utf-8")
+
+    result = adapt_real_brief_package(
+        source_package=source_package,
+        root=tmp_path / "repo",
+        date="2026-05-01",
+    )
+
+    project_dir = tmp_path / "repo" / "docs" / "visual-specs" / (
+        "seattle-polish-film-festival-poster"
+    )
+    real_brief_dir = project_dir / "real_brief"
+    discovery_dir = project_dir / "discovery"
+
+    assert result["slug"] == "seattle-polish-film-festival-poster"
+    assert result["status"] == "ready_for_visual_brainstorm"
+    assert Path(result["project_dir"]) == project_dir
+    assert Path(result["workflow_seed_md"]) == project_dir / "workflow_seed.md"
+    assert Path(result["adapter_manifest_json"]) == (
+        real_brief_dir / "adapter_manifest.json"
+    )
+    assert Path(result["discovery_md"]) == discovery_dir / "discovery.md"
+
+    for rel in [
+        "discovery/discovery.md",
+        "discovery/taste_profile.json",
+        "discovery/direction_cards.json",
+        "discovery/sketch_prompts.json",
+        "real_brief/adapter_manifest.json",
+        "real_brief/source_package_manifest.json",
+        "real_brief/structured_brief.json",
+        "real_brief/workflow_handoff.json",
+        "real_brief/decision_package.md",
+        "real_brief/production_package.md",
+        "real_brief/review_schema.json",
+        "real_brief/source_brief.md",
+        "real_brief/summary.md",
+        "real_brief/conditions/A-one-shot.md",
+        "real_brief/prompts/D.txt",
+        "workflow_seed.md",
+    ]:
+        assert (project_dir / rel).exists(), rel
+
+    manifest = _read_json(real_brief_dir / "adapter_manifest.json")
+    assert manifest["schema_version"] == "0.1"
+    assert manifest["adapter"] == "real-brief-workflow-adapter"
+    assert manifest["source_experiment"] == "real-brief-benchmark"
+    assert manifest["slug"] == "seattle-polish-film-festival-poster"
+    assert manifest["workflow_status"] == "ready_for_visual_brainstorm"
+    assert manifest["human_gate_required"] is True
+    assert manifest["simulation_only"] is True
+    assert manifest["domain"] == "poster"
+    assert manifest["visual_workflow_domain"] == "poster"
+    assert manifest["created"] == "2026-05-01"
+    assert manifest["workflow_artifacts"]["discovery_md"] == (
+        "../discovery/discovery.md"
+    )
+    assert manifest["next_steps"] == [
+        "/visual-brainstorm seattle-polish-film-festival-poster",
+        "/visual-spec seattle-polish-film-festival-poster",
+        "/visual-plan seattle-polish-film-festival-poster",
+        "/evaluate seattle-polish-film-festival-poster",
+    ]
+
+    discovery_md = (discovery_dir / "discovery.md").read_text(encoding="utf-8")
+    assert "ready_for_brainstorm" in discovery_md
+    assert "Ready for /visual-brainstorm" in discovery_md
+    assert "Seattle Polish Film Festival Poster" in discovery_md
+
+    workflow_seed = (project_dir / "workflow_seed.md").read_text(encoding="utf-8")
+    assert "ready_for_visual_brainstorm" in workflow_seed
+    assert "/visual-brainstorm seattle-polish-film-festival-poster" in workflow_seed
+    assert "/visual-spec must resolve design.md" in workflow_seed
+    assert "not a substitute for `proposal.md`" in workflow_seed
+
+    assert (source_package / "manifest.json").read_text(encoding="utf-8") == (
+        original_manifest
+    )
+
+
+def test_adapt_real_brief_package_dry_run_writes_nothing(tmp_path):
+    from vulca.real_brief.workflow_adapter import adapt_real_brief_package
+
+    source_package = _source_package(tmp_path, "gsm-community-market-campaign")
+    root = tmp_path / "repo"
+
+    result = adapt_real_brief_package(
+        source_package=source_package,
+        root=root,
+        date="2026-05-01",
+        dry_run=True,
+    )
+
+    assert result["slug"] == "gsm-community-market-campaign"
+    assert result["status"] == "ready_for_visual_brainstorm"
+    assert result["dry_run"] == "true"
+    assert not (root / "docs").exists()
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+PYTHONPATH=src python3 -m pytest tests/test_real_brief_workflow_adapter.py -q
+```
+
+Expected: FAIL with `ModuleNotFoundError: No module named 'vulca.real_brief.workflow_adapter'`.
+
+- [ ] **Step 3: Implement the first supported adapter path**
+
+Create `src/vulca/real_brief/workflow_adapter.py`:
+
+```python
+"""Adapt real-brief benchmark packages into Vulca visual workflow seeds."""
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+from typing import Any
+
+from vulca.discovery.artifacts import build_brainstorm_handoff, write_discovery_artifacts
+from vulca.discovery.cards import generate_direction_cards
+from vulca.discovery.profile import infer_taste_profile
+from vulca.discovery.prompting import compose_prompt_from_direction_card
+from vulca.discovery.types import SketchPrompt
+from vulca.real_brief.types import safe_slug
+
+
+REQUIRED_SOURCE_FILES = (
+    "manifest.json",
+    "workflow_handoff.json",
+    "structured_brief.json",
+    "decision_package.md",
+    "production_package.md",
+    "review_schema.json",
+)
+
+OPTIONAL_SOURCE_FILES = (
+    "source_brief.md",
+    "summary.md",
+)
+
+SUPPORTED_VISUAL_DOMAINS = {
+    "poster",
+    "packaging",
+    "brand_visual",
+    "illustration",
+    "editorial_cover",
+    "photography_brief",
+    "hero_visual_for_ui",
+}
+
+UNSUPPORTED_DOMAIN_REASONS = {
+    "public_art": "source domain is outside /visual-brainstorm static 2D scope",
+    "video_treatment": "source domain is outside /visual-brainstorm static 2D scope",
+}
+
+SECRET_MARKERS = (
+    "sk-",
+    "VULCA_REAL_PROVIDER_API_KEY",
+    "OPENAI_API_KEY",
+    "globalai",
+)
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _write_text(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def _project_dir(root: Path, slug: str) -> Path:
+    return root / "docs" / "visual-specs" / safe_slug(slug)
+
+
+def _source_rel(path: Path, source_package: Path) -> str:
+    return str(path.resolve().relative_to(source_package.resolve()))
+
+
+def _copy_file(source_package: Path, rel: str, dest_dir: Path, dest_name: str = "") -> None:
+    source = (source_package / rel).resolve()
+    source_package_resolved = source_package.resolve()
+    if source_package_resolved not in source.parents and source != source_package_resolved:
+        raise ValueError(f"unsafe source path outside package: {rel}")
+    if not source.exists():
+        return
+    target = dest_dir / (dest_name or rel)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(source, target)
+
+
+def _copy_tree_if_exists(source_package: Path, rel: str, dest_dir: Path) -> None:
+    source = (source_package / rel).resolve()
+    source_package_resolved = source_package.resolve()
+    if not source.exists():
+        return
+    if source_package_resolved not in source.parents and source != source_package_resolved:
+        raise ValueError(f"unsafe source path outside package: {rel}")
+    target = dest_dir / rel
+    if target.exists():
+        shutil.rmtree(target)
+    shutil.copytree(source, target)
+
+
+def _intent_from_structured_brief(
+    structured_brief: dict[str, Any],
+    handoff: dict[str, Any],
+) -> str:
+    seed = handoff.get("visual_discovery_seed", {})
+    initial_intent = str(seed.get("initial_intent") or structured_brief.get("source_brief") or "")
+    parts = [
+        initial_intent,
+        f"Client: {structured_brief.get('client', '')}",
+        f"Context: {structured_brief.get('context', '')}",
+        "Audience: " + ", ".join(str(item) for item in structured_brief.get("audience", [])),
+        "Constraints: " + ", ".join(str(item) for item in structured_brief.get("constraints", [])),
+        "Risks: " + ", ".join(str(item) for item in structured_brief.get("risks", [])),
+        "Avoid: " + ", ".join(str(item) for item in structured_brief.get("avoid", [])),
+    ]
+    return "\n".join(part for part in parts if part.strip())
+
+
+def _sketch_prompts_from_cards(cards: list[Any]) -> list[SketchPrompt]:
+    sketches: list[SketchPrompt] = []
+    for card in cards:
+        prompt = compose_prompt_from_direction_card(card, target="sketch")
+        payload = prompt.to_dict()
+        sketches.append(
+            SketchPrompt(
+                card_id=card.id,
+                provider="mock",
+                model="",
+                prompt=payload["prompt"],
+                negative_prompt=payload["negative_prompt"],
+                size="1024x1024",
+                purpose="adapter text sketch prompt for real-brief workflow handoff",
+            )
+        )
+    return sketches
+
+
+def _load_package(source_package: Path) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any]]:
+    if not source_package.is_dir():
+        raise ValueError(f"source package not found: {source_package}")
+    missing = [rel for rel in REQUIRED_SOURCE_FILES if not (source_package / rel).exists()]
+    if missing:
+        raise ValueError(f"source package missing required files: {', '.join(missing)}")
+
+    manifest = _read_json(source_package / "manifest.json")
+    handoff = _read_json(source_package / "workflow_handoff.json")
+    structured = _read_json(source_package / "structured_brief.json")
+
+    slug = safe_slug(str(structured.get("slug", "")))
+    if manifest.get("schema_version") != "0.1":
+        raise ValueError("manifest.schema_version must be 0.1")
+    if manifest.get("experiment") != "real-brief-benchmark":
+        raise ValueError("source package must be a real-brief-benchmark package")
+    if manifest.get("provider_execution") != "disabled":
+        raise ValueError("Phase 2 adapter only accepts disabled provider execution")
+    if handoff.get("schema_version") != "0.1":
+        raise ValueError("workflow_handoff.schema_version must be 0.1")
+    if handoff.get("human_gate_required") is not True:
+        raise ValueError("workflow_handoff.human_gate_required must be true")
+
+    fixture_slug = manifest.get("fixture", {}).get("slug")
+    if fixture_slug != slug or handoff.get("slug") != slug:
+        raise ValueError("slug mismatch across manifest, workflow_handoff, and structured_brief")
+
+    return manifest, handoff, structured
+
+
+def _workflow_status(structured: dict[str, Any]) -> tuple[str, str, str]:
+    domain = str(structured.get("domain", "")).strip()
+    if domain in SUPPORTED_VISUAL_DOMAINS:
+        return "ready_for_visual_brainstorm", domain, ""
+    reason = UNSUPPORTED_DOMAIN_REASONS.get(
+        domain,
+        "source domain is outside /visual-brainstorm static 2D scope",
+    )
+    return "unsupported_for_visual_chain", "", reason
+
+
+def _write_real_brief_package(
+    *,
+    source_package: Path,
+    real_brief_dir: Path,
+    manifest: dict[str, Any],
+) -> None:
+    _copy_file(source_package, "manifest.json", real_brief_dir, "source_package_manifest.json")
+    for rel in REQUIRED_SOURCE_FILES:
+        if rel == "manifest.json":
+            continue
+        _copy_file(source_package, rel, real_brief_dir)
+    for rel in OPTIONAL_SOURCE_FILES:
+        _copy_file(source_package, rel, real_brief_dir)
+    for rel in ("conditions", "prompts", "images", "evaluations"):
+        _copy_tree_if_exists(source_package, rel, real_brief_dir)
+
+
+def _adapter_manifest(
+    *,
+    source_package: Path,
+    slug: str,
+    status: str,
+    reason: str,
+    date: str,
+    structured: dict[str, Any],
+    manifest: dict[str, Any],
+    visual_domain: str,
+) -> dict[str, Any]:
+    payload = {
+        "schema_version": "0.1",
+        "adapter": "real-brief-workflow-adapter",
+        "source_experiment": "real-brief-benchmark",
+        "source_package_path": str(source_package),
+        "slug": slug,
+        "workflow_status": status,
+        "human_gate_required": True,
+        "simulation_only": bool(structured.get("simulation_only", True)),
+        "ai_policy": str(structured.get("ai_policy", "")),
+        "domain": str(structured.get("domain", "")),
+        "visual_workflow_domain": visual_domain or None,
+        "created": date,
+        "source_files": {
+            "manifest": "source_package_manifest.json",
+            "structured_brief": "structured_brief.json",
+            "workflow_handoff": "workflow_handoff.json",
+            "decision_package": "decision_package.md",
+            "production_package": "production_package.md",
+            "review_schema": "review_schema.json",
+        },
+        "workflow_artifacts": {},
+        "next_steps": [],
+    }
+    if reason:
+        payload["unsupported_reason"] = reason
+    if status == "ready_for_visual_brainstorm":
+        payload["workflow_artifacts"] = {
+            "discovery_md": "../discovery/discovery.md",
+            "taste_profile_json": "../discovery/taste_profile.json",
+            "direction_cards_json": "../discovery/direction_cards.json",
+            "workflow_seed_md": "../workflow_seed.md",
+        }
+        payload["next_steps"] = [
+            f"/visual-brainstorm {slug}",
+            f"/visual-spec {slug}",
+            f"/visual-plan {slug}",
+            f"/evaluate {slug}",
+        ]
+    return payload
+
+
+def _workflow_seed_text(
+    *,
+    title: str,
+    slug: str,
+    status: str,
+    source_package: Path,
+    handoff_text: str,
+    unsupported_reason: str,
+) -> str:
+    if status == "ready_for_visual_brainstorm":
+        next_step = f"Run /visual-brainstorm {slug} using the discovery handoff below."
+        deferred = "none"
+        imported_artifacts = [
+            "- discovery/discovery.md",
+            "- discovery/taste_profile.json",
+            "- discovery/direction_cards.json",
+            "- real_brief/structured_brief.json",
+            "- real_brief/decision_package.md",
+            "- real_brief/production_package.md",
+        ]
+    else:
+        next_step = "Do not run /visual-brainstorm for this package in Phase 2 v1."
+        deferred = unsupported_reason
+        imported_artifacts = [
+            "- real_brief/structured_brief.json",
+            "- real_brief/decision_package.md",
+            "- real_brief/production_package.md",
+            "- real_brief/adapter_manifest.json",
+        ]
+    return "\n".join(
+        [
+            f"# Real Brief Workflow Seed: {title}",
+            "",
+            "## Status",
+            status,
+            "",
+            "## Source Package",
+            str(source_package),
+            "",
+            "## Imported Artifacts",
+            *imported_artifacts,
+            "",
+            "## Recommended Next Step",
+            next_step,
+            "",
+            "## Discovery Handoff",
+            handoff_text or "none",
+            "",
+            "## Human Gates Preserved",
+            "- /visual-brainstorm must finalize proposal.md",
+            "- /visual-spec must resolve design.md",
+            "- /visual-plan must review plan.md before generation",
+            "",
+            "## Unsupported Or Deferred Items",
+            deferred,
+            "",
+            "This workflow seed is not a substitute for `proposal.md`.",
+            "",
+        ]
+    )
+
+
+def _assert_no_secret_markers(project_dir: Path) -> None:
+    for path in project_dir.rglob("*"):
+        if not path.is_file() or path.suffix.lower() not in {".md", ".json", ".txt"}:
+            continue
+        text = path.read_text(encoding="utf-8", errors="ignore")
+        lowered = text.lower()
+        for marker in SECRET_MARKERS:
+            haystack = lowered if marker == "globalai" else text
+            if marker in haystack:
+                raise ValueError(f"secret-like marker found in generated artifact: {path}")
+
+
+def adapt_real_brief_package(
+    *,
+    source_package: str | Path,
+    root: str | Path,
+    date: str,
+    force_discovery: bool = False,
+    force_real_brief: bool = False,
+    dry_run: bool = False,
+) -> dict[str, str]:
+    """Import a Phase 1 real-brief package into the visual workflow tree."""
+    source_package_path = Path(source_package)
+    root_path = Path(root)
+    manifest, handoff, structured = _load_package(source_package_path)
+    slug = safe_slug(str(structured["slug"]))
+    status, visual_domain, unsupported_reason = _workflow_status(structured)
+    project_dir = _project_dir(root_path, slug)
+    discovery_dir = project_dir / "discovery"
+    real_brief_dir = project_dir / "real_brief"
+
+    result = {
+        "slug": slug,
+        "status": status,
+        "project_dir": str(project_dir),
+        "adapter_manifest_json": str(real_brief_dir / "adapter_manifest.json"),
+    }
+    if status == "ready_for_visual_brainstorm":
+        result["workflow_seed_md"] = str(project_dir / "workflow_seed.md")
+        result["discovery_md"] = str(discovery_dir / "discovery.md")
+    if dry_run:
+        result["dry_run"] = "true"
+        return result
+
+    _write_real_brief_package(
+        source_package=source_package_path,
+        real_brief_dir=real_brief_dir,
+        manifest=manifest,
+    )
+
+    handoff_text = ""
+    if status == "ready_for_visual_brainstorm":
+        intent = _intent_from_structured_brief(structured, handoff)
+        profile = infer_taste_profile(slug, intent)
+        cards = generate_direction_cards(profile, count=3)
+        recommended_card = cards[0]
+        write_discovery_artifacts(
+            root=root_path,
+            slug=slug,
+            title=str(structured.get("title", slug)),
+            original_intent=intent,
+            profile=profile,
+            cards=cards,
+            recommended_card_id=recommended_card.id,
+            sketch_prompts=_sketch_prompts_from_cards(cards),
+        )
+        handoff_text = build_brainstorm_handoff(profile, recommended_card)
+
+    adapter_manifest = _adapter_manifest(
+        source_package=source_package_path,
+        slug=slug,
+        status=status,
+        reason=unsupported_reason,
+        date=date,
+        structured=structured,
+        manifest=manifest,
+        visual_domain=visual_domain,
+    )
+    _write_json(real_brief_dir / "adapter_manifest.json", adapter_manifest)
+    _write_text(
+        project_dir / "workflow_seed.md",
+        _workflow_seed_text(
+            title=str(structured.get("title", slug)),
+            slug=slug,
+            status=status,
+            source_package=source_package_path,
+            handoff_text=handoff_text,
+            unsupported_reason=unsupported_reason,
+        ),
+    )
+    _assert_no_secret_markers(project_dir)
+    return result
+```
+
+- [ ] **Step 4: Run supported-flow tests**
+
+Run:
+
+```bash
+PYTHONPATH=src python3 -m pytest tests/test_real_brief_workflow_adapter.py::test_adapt_real_brief_package_writes_supported_visual_workflow tests/test_real_brief_workflow_adapter.py::test_adapt_real_brief_package_dry_run_writes_nothing -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit Task 1**
+
+Run:
+
+```bash
+git add src/vulca/real_brief/workflow_adapter.py tests/test_real_brief_workflow_adapter.py
+git commit -m "feat: add real brief workflow adapter core"
+```
+
+---
+
+### Task 2: Validation, Collision Policy, And Unsupported Domains
+
+**Files:**
+- Modify: `tests/test_real_brief_workflow_adapter.py`
+- Modify: `src/vulca/real_brief/workflow_adapter.py`
+
+- [ ] **Step 1: Add failing tests for hardening behavior**
+
+Append to `tests/test_real_brief_workflow_adapter.py`:
+
+```python
+def test_adapt_real_brief_package_rejects_missing_required_file(tmp_path):
+    from vulca.real_brief.workflow_adapter import adapt_real_brief_package
+
+    source_package = _source_package(tmp_path, "seattle-polish-film-festival-poster")
+    (source_package / "workflow_handoff.json").unlink()
+
+    with pytest.raises(ValueError, match="missing required files"):
+        adapt_real_brief_package(
+            source_package=source_package,
+            root=tmp_path / "repo",
+            date="2026-05-01",
+        )
+
+    assert not (tmp_path / "repo" / "docs").exists()
+
+
+def test_adapt_real_brief_package_rejects_slug_mismatch(tmp_path):
+    from vulca.real_brief.workflow_adapter import adapt_real_brief_package
+
+    source_package = _source_package(tmp_path, "seattle-polish-film-festival-poster")
+    handoff_path = source_package / "workflow_handoff.json"
+    handoff = _read_json(handoff_path)
+    handoff["slug"] = "different-slug"
+    handoff_path.write_text(json.dumps(handoff), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="slug mismatch"):
+        adapt_real_brief_package(
+            source_package=source_package,
+            root=tmp_path / "repo",
+            date="2026-05-01",
+        )
+
+
+@pytest.mark.parametrize(
+    "filename",
+    ["proposal.md", "design.md", "plan.md"],
+)
+def test_adapt_real_brief_package_rejects_finalized_workflow_collisions(
+    tmp_path,
+    filename,
+):
+    from vulca.real_brief.workflow_adapter import adapt_real_brief_package
+
+    source_package = _source_package(tmp_path, "seattle-polish-film-festival-poster")
+    project_dir = tmp_path / "repo" / "docs" / "visual-specs" / (
+        "seattle-polish-film-festival-poster"
+    )
+    project_dir.mkdir(parents=True)
+    statuses = {
+        "proposal.md": "ready",
+        "design.md": "resolved",
+        "plan.md": "completed",
+    }
+    (project_dir / filename).write_text(
+        f"---\nstatus: {statuses[filename]}\n---\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(RuntimeError, match="refuse to overwrite finalized workflow"):
+        adapt_real_brief_package(
+            source_package=source_package,
+            root=tmp_path / "repo",
+            date="2026-05-01",
+        )
+
+
+def test_adapt_real_brief_package_requires_force_for_adapter_owned_dirs(tmp_path):
+    from vulca.real_brief.workflow_adapter import adapt_real_brief_package
+
+    source_package = _source_package(tmp_path, "gsm-community-market-campaign")
+    root = tmp_path / "repo"
+    adapt_real_brief_package(
+        source_package=source_package,
+        root=root,
+        date="2026-05-01",
+    )
+
+    with pytest.raises(RuntimeError, match="discovery already exists"):
+        adapt_real_brief_package(
+            source_package=source_package,
+            root=root,
+            date="2026-05-01",
+        )
+
+    result = adapt_real_brief_package(
+        source_package=source_package,
+        root=root,
+        date="2026-05-01",
+        force_discovery=True,
+        force_real_brief=True,
+    )
+
+    assert result["status"] == "ready_for_visual_brainstorm"
+
+
+@pytest.mark.parametrize(
+    "slug",
+    ["erie-botanical-gardens-public-art", "music-video-treatment-low-budget"],
+)
+def test_adapt_real_brief_package_marks_unsupported_domains(tmp_path, slug):
+    from vulca.real_brief.workflow_adapter import adapt_real_brief_package
+
+    source_package = _source_package(tmp_path, slug)
+
+    result = adapt_real_brief_package(
+        source_package=source_package,
+        root=tmp_path / "repo",
+        date="2026-05-01",
+    )
+
+    project_dir = tmp_path / "repo" / "docs" / "visual-specs" / slug
+    manifest = _read_json(project_dir / "real_brief" / "adapter_manifest.json")
+
+    assert result["status"] == "unsupported_for_visual_chain"
+    assert manifest["workflow_status"] == "unsupported_for_visual_chain"
+    assert manifest["visual_workflow_domain"] is None
+    assert manifest["unsupported_reason"] == (
+        "source domain is outside /visual-brainstorm static 2D scope"
+    )
+    assert not (project_dir / "discovery").exists()
+    assert (project_dir / "workflow_seed.md").exists()
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+PYTHONPATH=src python3 -m pytest tests/test_real_brief_workflow_adapter.py -q
+```
+
+Expected: FAIL on collision behavior because Task 1 implementation has not enforced destination policy.
+
+- [ ] **Step 3: Add destination collision helpers**
+
+Add these helpers to `src/vulca/real_brief/workflow_adapter.py` above `adapt_real_brief_package`:
+
+```python
+def _frontmatter_status(path: Path) -> str:
+    if not path.exists():
+        return ""
+    text = path.read_text(encoding="utf-8", errors="ignore")
+    if not text.startswith("---"):
+        return ""
+    for line in text.splitlines()[1:20]:
+        if line.strip() == "---":
+            break
+        if line.startswith("status:"):
+            return line.split(":", 1)[1].strip().strip("'\"")
+    return ""
+
+
+def _check_destination_policy(
+    *,
+    project_dir: Path,
+    force_discovery: bool,
+    force_real_brief: bool,
+) -> None:
+    terminal_files = {
+        "proposal.md": {"ready"},
+        "design.md": {"resolved"},
+        "plan.md": {"completed", "partial", "aborted"},
+    }
+    for filename, terminal_statuses in terminal_files.items():
+        status = _frontmatter_status(project_dir / filename)
+        if status in terminal_statuses:
+            raise RuntimeError(
+                f"refuse to overwrite finalized workflow: {project_dir / filename}"
+            )
+    if (project_dir / "discovery").exists() and not force_discovery:
+        raise RuntimeError("discovery already exists; pass --force-discovery")
+    if (project_dir / "real_brief").exists() and not force_real_brief:
+        raise RuntimeError("real_brief already exists; pass --force-real-brief")
+
+
+def _replace_adapter_owned_dir(target: Path, force: bool) -> None:
+    if target.exists():
+        if not force:
+            raise RuntimeError(f"{target.name} already exists")
+        shutil.rmtree(target)
+```
+
+- [ ] **Step 4: Apply destination policy in `adapt_real_brief_package`**
+
+In `adapt_real_brief_package`, after computing `project_dir`, `discovery_dir`, and `real_brief_dir`, insert:
+
+```python
+    _check_destination_policy(
+        project_dir=project_dir,
+        force_discovery=force_discovery,
+        force_real_brief=force_real_brief,
+    )
+```
+
+Before `_write_real_brief_package(...)`, insert:
+
+```python
+    _replace_adapter_owned_dir(discovery_dir, force_discovery)
+    _replace_adapter_owned_dir(real_brief_dir, force_real_brief)
+```
+
+- [ ] **Step 5: Run hardening tests**
+
+Run:
+
+```bash
+PYTHONPATH=src python3 -m pytest tests/test_real_brief_workflow_adapter.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit Task 2**
+
+Run:
+
+```bash
+git add src/vulca/real_brief/workflow_adapter.py tests/test_real_brief_workflow_adapter.py
+git commit -m "fix: harden real brief workflow adapter"
+```
+
+---
+
+### Task 3: CLI And Public Export
+
+**Files:**
+- Modify: `tests/test_real_brief_workflow_adapter.py`
+- Create: `scripts/real_brief_workflow_adapter.py`
+- Modify: `src/vulca/real_brief/__init__.py`
+
+- [ ] **Step 1: Add failing CLI and export tests**
+
+Append to `tests/test_real_brief_workflow_adapter.py`:
+
+```python
+def test_real_brief_workflow_adapter_cli_dry_run(tmp_path, capsys):
+    from scripts.real_brief_workflow_adapter import main
+
+    source_package = _source_package(tmp_path, "seattle-polish-film-festival-poster")
+
+    rc = main(
+        [
+            "--source-package",
+            str(source_package),
+            "--root",
+            str(tmp_path / "repo"),
+            "--date",
+            "2026-05-01",
+            "--dry-run",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+
+    assert rc == 0
+    assert payload["slug"] == "seattle-polish-film-festival-poster"
+    assert payload["status"] == "ready_for_visual_brainstorm"
+    assert payload["dry_run"] == "true"
+    assert not (tmp_path / "repo" / "docs").exists()
+
+
+def test_real_brief_workflow_adapter_cli_writes_files(tmp_path, capsys):
+    from scripts.real_brief_workflow_adapter import main
+
+    source_package = _source_package(tmp_path, "gsm-community-market-campaign")
+
+    rc = main(
+        [
+            "--source-package",
+            str(source_package),
+            "--root",
+            str(tmp_path / "repo"),
+            "--date",
+            "2026-05-01",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    project_dir = tmp_path / "repo" / "docs" / "visual-specs" / (
+        "gsm-community-market-campaign"
+    )
+
+    assert rc == 0
+    assert payload["status"] == "ready_for_visual_brainstorm"
+    assert (project_dir / "workflow_seed.md").exists()
+
+
+def test_real_brief_workflow_adapter_can_resolve_source_root_slug_date(tmp_path):
+    from scripts.real_brief_workflow_adapter import main
+
+    _source_package(tmp_path, "gsm-community-market-campaign")
+
+    rc = main(
+        [
+            "--source-root",
+            str(tmp_path / "source"),
+            "--slug",
+            "gsm-community-market-campaign",
+            "--root",
+            str(tmp_path / "repo"),
+            "--date",
+            "2026-05-01",
+            "--dry-run",
+        ]
+    )
+
+    assert rc == 0
+
+
+def test_real_brief_workflow_adapter_public_export_is_lazy():
+    from vulca.real_brief import adapt_real_brief_package
+
+    assert callable(adapt_real_brief_package)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+PYTHONPATH=src python3 -m pytest tests/test_real_brief_workflow_adapter.py -q
+```
+
+Expected: FAIL with `ModuleNotFoundError` for `scripts.real_brief_workflow_adapter` and missing export from `vulca.real_brief`.
+
+- [ ] **Step 3: Implement the CLI wrapper**
+
+Create `scripts/real_brief_workflow_adapter.py`:
+
+```python
+"""CLI wrapper for importing real-brief packages into visual workflow seeds."""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+def _resolve_source_package(args: argparse.Namespace) -> Path:
+    if args.source_package:
+        return Path(args.source_package)
+    if not args.source_root or not args.slug or not args.date:
+        raise RuntimeError(
+            "--source-package or all of --source-root, --slug, and --date is required"
+        )
+    return Path(args.source_root) / f"{args.date}-{args.slug}"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Import a real-brief benchmark package into Vulca visual workflow seeds."
+    )
+    parser.add_argument("--source-package")
+    parser.add_argument("--source-root")
+    parser.add_argument("--slug")
+    parser.add_argument("--root", default=".")
+    parser.add_argument("--date", required=True)
+    parser.add_argument("--force-discovery", action="store_true")
+    parser.add_argument("--force-real-brief", action="store_true")
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args(argv)
+
+    from vulca.real_brief.workflow_adapter import adapt_real_brief_package
+
+    result = adapt_real_brief_package(
+        source_package=_resolve_source_package(args),
+        root=args.root,
+        date=args.date,
+        force_discovery=args.force_discovery,
+        force_real_brief=args.force_real_brief,
+        dry_run=args.dry_run,
+    )
+    print(json.dumps(result, ensure_ascii=False, indent=2, sort_keys=True))
+    return 0
+
+
+def _cli() -> int:
+    try:
+        return main()
+    except (RuntimeError, ValueError) as exc:
+        raise SystemExit(f"error: {exc}") from None
+
+
+if __name__ == "__main__":
+    raise SystemExit(_cli())
+```
+
+- [ ] **Step 4: Add lazy export**
+
+Modify `src/vulca/real_brief/__init__.py`:
+
+Add `"adapt_real_brief_package"` to `__all__`.
+
+Add this entry to `_LAZY_EXPORTS`:
+
+```python
+    "adapt_real_brief_package": (
+        "vulca.real_brief.workflow_adapter",
+        "adapt_real_brief_package",
+    ),
+```
+
+- [ ] **Step 5: Run CLI/export tests**
+
+Run:
+
+```bash
+PYTHONPATH=src python3 -m pytest tests/test_real_brief_workflow_adapter.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit Task 3**
+
+Run:
+
+```bash
+git add scripts/real_brief_workflow_adapter.py src/vulca/real_brief/__init__.py tests/test_real_brief_workflow_adapter.py
+git commit -m "feat: add real brief workflow adapter cli"
+```
+
+---
+
+### Task 4: Secret Scan, Regression Tests, And Documentation Link
+
+**Files:**
+- Modify: `tests/test_real_brief_workflow_adapter.py`
+- Optionally modify: `docs/product/experiments/cultural-term-efficacy.md`
+
+- [ ] **Step 1: Add generated-artifact secret scan test**
+
+Append to `tests/test_real_brief_workflow_adapter.py`:
+
+```python
+def test_adapt_real_brief_package_generated_artifacts_do_not_contain_secret_markers(
+    tmp_path,
+):
+    from vulca.real_brief.workflow_adapter import adapt_real_brief_package
+
+    source_package = _source_package(tmp_path, "seattle-polish-film-festival-poster")
+    root = tmp_path / "repo"
+
+    adapt_real_brief_package(
+        source_package=source_package,
+        root=root,
+        date="2026-05-01",
+    )
+
+    project_dir = root / "docs" / "visual-specs" / (
+        "seattle-polish-film-festival-poster"
+    )
+    generated = "\n".join(
+        path.read_text(encoding="utf-8", errors="ignore")
+        for path in project_dir.rglob("*")
+        if path.is_file() and path.suffix in {".md", ".json", ".txt"}
+    )
+
+    assert "sk-" not in generated
+    assert "VULCA_REAL_PROVIDER_API_KEY" not in generated
+    assert "OPENAI_API_KEY" not in generated
+    assert "globalai" not in generated.lower()
+```
+
+- [ ] **Step 2: Run adapter tests**
+
+Run:
+
+```bash
+PYTHONPATH=src python3 -m pytest tests/test_real_brief_workflow_adapter.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run Phase 1 and visual-discovery regressions**
+
+Run:
+
+```bash
+PYTHONPATH=src python3 -m pytest tests/test_real_brief_benchmark.py tests/test_real_brief_workflow_adapter.py -q
+```
+
+Expected: PASS.
+
+Run:
+
+```bash
+PYTHONPATH=src python3 -m pytest tests/test_visual_discovery_benchmark.py tests/test_visual_discovery_artifacts.py tests/test_visual_discovery_cards.py tests/test_visual_discovery_types.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Add a short documentation link only if missing**
+
+Check:
+
+```bash
+grep -n "real-brief workflow adapter" docs/product/experiments/cultural-term-efficacy.md
+```
+
+If there is no Phase 2 link, add this short paragraph near the existing real-brief benchmark section:
+
+```markdown
+Phase 2 workflow adapter: `scripts/real_brief_workflow_adapter.py` imports a Phase 1 real-brief package into `docs/visual-specs/<slug>/` as `discovery/`, `real_brief/`, and `workflow_seed.md` artifacts. It preserves `/visual-brainstorm`, `/visual-spec`, and `/visual-plan` human gates and does not call image providers.
+```
+
+- [ ] **Step 5: Run docs grep to verify no secret marker was introduced**
+
+Run:
+
+```bash
+grep -R -nE 'sk-|VULCA_REAL_PROVIDER_API_KEY|OPENAI_API_KEY|globalai' src/vulca/real_brief scripts/real_brief_workflow_adapter.py tests/test_real_brief_workflow_adapter.py docs/product/experiments/cultural-term-efficacy.md
+```
+
+Expected: no output, except the intentional string literals inside the secret scan test. If grep shows only the four assertion strings inside `tests/test_real_brief_workflow_adapter.py`, that is acceptable because they are test sentinels and not credentials.
+
+- [ ] **Step 6: Commit Task 4**
+
+Run:
+
+```bash
+git add tests/test_real_brief_workflow_adapter.py docs/product/experiments/cultural-term-efficacy.md
+git commit -m "test: cover real brief workflow adapter artifacts"
+```
+
+If the documentation file was unchanged, omit it from `git add`.
+
+---
+
+### Task 5: End-To-End Dry Run And Branch Completion
+
+**Files:**
+- No planned code changes.
+
+- [ ] **Step 1: Run a CLI dry-run from a generated Phase 1 package**
+
+Run:
+
+```bash
+PYTHONPATH=src python3 scripts/real_brief_benchmark.py --slug seattle-polish-film-festival-poster --date 2026-05-01 --output-root /private/tmp/vulca-real-brief-phase2-source --no-html-review
+```
+
+Expected: exit 0 and source package at:
+
+```text
+/private/tmp/vulca-real-brief-phase2-source/2026-05-01-seattle-polish-film-festival-poster
+```
+
+Run:
+
+```bash
+PYTHONPATH=src python3 scripts/real_brief_workflow_adapter.py --source-package /private/tmp/vulca-real-brief-phase2-source/2026-05-01-seattle-polish-film-festival-poster --root /private/tmp/vulca-real-brief-phase2-target --date 2026-05-01
+```
+
+Expected JSON includes:
+
+```json
+{
+  "slug": "seattle-polish-film-festival-poster",
+  "status": "ready_for_visual_brainstorm"
+}
+```
+
+- [ ] **Step 2: Inspect generated files**
+
+Run:
+
+```bash
+find /private/tmp/vulca-real-brief-phase2-target/docs/visual-specs/seattle-polish-film-festival-poster -maxdepth 3 -type f | sort
+```
+
+Expected includes:
+
+```text
+discovery/discovery.md
+discovery/taste_profile.json
+discovery/direction_cards.json
+discovery/sketch_prompts.json
+real_brief/adapter_manifest.json
+real_brief/structured_brief.json
+real_brief/workflow_handoff.json
+workflow_seed.md
+```
+
+- [ ] **Step 3: Run final regression suite**
+
+Run:
+
+```bash
+PYTHONPATH=src python3 -m pytest tests/test_real_brief_benchmark.py tests/test_real_brief_workflow_adapter.py -q
+```
+
+Expected: PASS.
+
+Run:
+
+```bash
+PYTHONPATH=src python3 -m pytest tests/test_visual_discovery_benchmark.py tests/test_visual_discovery_artifacts.py tests/test_visual_discovery_cards.py tests/test_visual_discovery_types.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Check git status and commit any final docs-only adjustment**
+
+Run:
+
+```bash
+git status --short --branch
+```
+
+Expected: clean branch ahead of `origin/master` by the Phase 2 commits. If a small docs-only adjustment remains, commit it with:
+
+```bash
+git add <changed-doc-file>
+git commit -m "docs: link real brief workflow adapter"
+```
+
+- [ ] **Step 5: Prepare PR**
+
+Run:
+
+```bash
+git push -u origin codex/real-brief-workflow-adapter
+```
+
+Then create a PR titled:
+
+```text
+feat: add real brief workflow adapter
+```
+
+PR summary:
+
+```markdown
+## Summary
+- add Phase 2 adapter from real-brief benchmark packages to `docs/visual-specs/<slug>/`
+- write `discovery/`, `real_brief/`, and `workflow_seed.md` artifacts without provider execution
+- preserve `/visual-brainstorm`, `/visual-spec`, and `/visual-plan` human gates
+- mark `public_art` and `video_treatment` as unsupported for static visual workflow v1
+
+## Tests
+- `PYTHONPATH=src python3 -m pytest tests/test_real_brief_benchmark.py tests/test_real_brief_workflow_adapter.py -q`
+- `PYTHONPATH=src python3 -m pytest tests/test_visual_discovery_benchmark.py tests/test_visual_discovery_artifacts.py tests/test_visual_discovery_cards.py tests/test_visual_discovery_types.py -q`
+```
+
+---
+
+## Review Checklist
+
+- Adapter writes no generated pixels.
+- Adapter never calls real providers.
+- Adapter preserves human gates and never finalizes proposal/design/plan.
+- Adapter marks `public_art` and `video_treatment` unsupported.
+- Phase 1 benchmark tests still pass.
+- Visual discovery regression tests still pass.
+- Source packages are copied, not mutated.
+- Generated artifacts do not contain provider keys or live endpoint strings.

--- a/docs/superpowers/specs/2026-05-01-real-brief-workflow-adapter-design.md
+++ b/docs/superpowers/specs/2026-05-01-real-brief-workflow-adapter-design.md
@@ -1,0 +1,434 @@
+# Real Brief Workflow Adapter Design
+
+**Date:** 2026-05-01
+**Status:** Approved design for implementation planning
+**Branch:** `codex/real-brief-workflow-adapter`
+**Scope:** Phase 2 adapter that imports Phase 1 real-brief packages into the official Vulca visual workflow artifact tree.
+
+## Decision
+
+Build Phase 2 as an **artifact-first workflow adapter**.
+
+The adapter consumes a Phase 1 real-brief dry-run package and writes official workflow entry artifacts under `docs/visual-specs/<slug>/`. It must make the real brief usable by the existing chain:
+
+```text
+/visual-discovery -> /visual-brainstorm -> /visual-spec -> /visual-plan -> /evaluate
+```
+
+It must not silently bypass the human gates already required by those skills. In Phase 2, the adapter prepares seeds, review context, and discovery artifacts. It does not auto-finalize `proposal.md`, `design.md`, or `plan.md`.
+
+## Product Goal
+
+The product direction is no longer "a visual-discovery tool only." The product direction is:
+
+```text
+real creative work -> structured intent -> direction discovery -> reviewable plan -> controlled generation -> evaluation
+```
+
+The Phase 1 benchmark proved that one-shot model output is hard to judge when briefs are vague. Phase 2 turns the benchmark into a reusable workflow so Vulca can show where it adds value:
+
+- clarifying ambiguous client intent;
+- turning cultural and taste language into concrete visual operations;
+- preserving source constraints and production risks;
+- giving the user direction cards before final pixels;
+- making handoff packages reviewable by designers, directors, artists, and clients;
+- preparing future review/studio surfaces without coupling them to a specific HTML prototype.
+
+## Current Inputs
+
+Phase 1 writes packages like:
+
+```text
+docs/product/experiments/real-brief-results/<date>-<slug>/
+  source_brief.md
+  structured_brief.json
+  decision_package.md
+  production_package.md
+  workflow_handoff.json
+  review_schema.json
+  manifest.json
+  conditions/
+  prompts/
+  images/
+  evaluations/
+  human_review.html
+  summary.md
+```
+
+The Phase 2 adapter must treat these files as the source package. The required input files are:
+
+- `manifest.json`
+- `workflow_handoff.json`
+- `structured_brief.json`
+- `decision_package.md`
+- `production_package.md`
+- `review_schema.json`
+
+Optional but preserved when present:
+
+- `source_brief.md`
+- `human_review.html`
+- `conditions/*.md`
+- `prompts/*.txt`
+- `images/*`
+- `evaluations/*`
+- `summary.md`
+
+## Output Artifact Tree
+
+For a source package with `slug = seattle-polish-film-festival-poster`, the adapter writes:
+
+```text
+docs/visual-specs/seattle-polish-film-festival-poster/
+  discovery/
+    discovery.md
+    taste_profile.json
+    direction_cards.json
+    sketch_prompts.json
+  real_brief/
+    adapter_manifest.json
+    source_package_manifest.json
+    structured_brief.json
+    workflow_handoff.json
+    decision_package.md
+    production_package.md
+    review_schema.json
+    source_brief.md
+    summary.md
+    conditions/
+    prompts/
+    images/
+    evaluations/
+  workflow_seed.md
+```
+
+`discovery/` is the official upstream artifact location consumed by `/visual-discovery` and handed to `/visual-brainstorm`.
+
+`real_brief/` is a lossless package copy with adapter metadata. It preserves benchmark and review context without polluting the canonical proposal/design/plan files.
+
+`workflow_seed.md` is a human-readable handoff guide. It tells the user what the adapter imported and what to run next.
+
+## Non-Goals
+
+Phase 2 must not:
+
+- generate or edit images;
+- call real providers;
+- call redraw, mask, decompose, or layer tools;
+- finalize `proposal.md`;
+- finalize `design.md`;
+- finalize or execute `plan.md`;
+- mutate Phase 1 result packages in place;
+- depend on the redraw replacement branch;
+- write provider keys, endpoints, or secrets into artifacts;
+- submit or imply submission-readiness for AI-prohibited source briefs.
+
+## Adapter Contract
+
+### Input Validation
+
+The adapter validates:
+
+- source package path exists and is a directory;
+- required files exist;
+- `manifest.schema_version == "0.1"`;
+- `manifest.experiment == "real-brief-benchmark"`;
+- `manifest.provider_execution == "disabled"` for Phase 2 v1;
+- `workflow_handoff.schema_version == "0.1"`;
+- `workflow_handoff.human_gate_required is true`;
+- `workflow_handoff.slug == structured_brief.slug == manifest.fixture.slug`;
+- slug passes the same safe-slug rules used by `vulca.real_brief.types.safe_slug`;
+- every copied path stays inside the source package and destination project directory;
+- generated text contains no known secret markers.
+
+If validation fails, no partial destination tree should be left behind. Use a temp directory plus atomic rename where practical.
+
+### Collision Policy
+
+The adapter must not overwrite an existing finalized workflow.
+
+Rules:
+
+- If `docs/visual-specs/<slug>/proposal.md` exists with `status: ready`, abort.
+- If `docs/visual-specs/<slug>/design.md` exists with `status: resolved`, abort.
+- If `docs/visual-specs/<slug>/plan.md` exists with terminal status, abort.
+- If `discovery/` already exists, require `--force-discovery` to replace only adapter-owned discovery files.
+- If `real_brief/` already exists, require `--force-real-brief` to replace only adapter-owned real-brief files.
+
+The first implementation should keep this conservative. Re-import and merge behavior is explicitly out of scope for Phase 2.
+
+### Domain Mapping
+
+The adapter maps `structured_brief.domain` to the existing visual workflow domain enum when possible:
+
+| source domain | visual workflow domain | status |
+|---|---|---|
+| `poster` | `poster` | supported |
+| `packaging` | `packaging` | supported |
+| `brand_visual` | `brand_visual` | supported |
+| `illustration` | `illustration` | supported |
+| `editorial_cover` | `editorial_cover` | supported |
+| `photography_brief` | `photography_brief` | supported |
+| `hero_visual_for_ui` | `hero_visual_for_ui` | supported |
+| video or treatment-only domains | none | unsupported for visual chain v1 |
+
+The existing `music-video-treatment-low-budget` fixture remains useful for Phase 1 benchmarking, but Phase 2 v1 must not force it into the static 2D visual chain. It should produce a real-brief import package and mark:
+
+```json
+{
+  "workflow_status": "unsupported_for_visual_chain",
+  "reason": "video treatment is outside /visual-brainstorm static 2D scope"
+}
+```
+
+## Discovery Artifact Generation
+
+For supported static 2D briefs, the adapter uses existing discovery internals rather than inventing a second artifact shape:
+
+- `vulca.discovery.profile.infer_taste_profile`
+- `vulca.discovery.cards.generate_direction_cards`
+- `vulca.discovery.prompting.compose_prompt_from_direction_card`
+- `vulca.discovery.artifacts.write_discovery_artifacts`
+
+Input intent should combine:
+
+- `workflow_handoff.visual_discovery_seed.initial_intent`;
+- source client/context/audience from `structured_brief.json`;
+- constraints, risks, and avoid lists;
+- selected direction/card data already present in Phase 1 condition C/D when available.
+
+The output `discovery.md` must end in `ready_for_brainstorm`, not `proposal_ready` or `ready_for_spec`. `/visual-brainstorm` remains the next human gate.
+
+## Workflow Seed
+
+`workflow_seed.md` is a concise operator-facing handoff:
+
+```markdown
+# Real Brief Workflow Seed: <title>
+
+## Status
+ready_for_visual_brainstorm
+
+## Source Package
+<relative path>
+
+## Imported Artifacts
+- discovery/discovery.md
+- discovery/taste_profile.json
+- discovery/direction_cards.json
+- real_brief/structured_brief.json
+- real_brief/decision_package.md
+- real_brief/production_package.md
+
+## Recommended Next Step
+Run /visual-brainstorm <slug> using the discovery handoff below.
+
+## Discovery Handoff
+<handoff string from discovery artifacts>
+
+## Human Gates Preserved
+- /visual-brainstorm must finalize proposal.md
+- /visual-spec must resolve design.md
+- /visual-plan must review plan.md before generation
+
+## Unsupported Or Deferred Items
+<none or reason>
+```
+
+This file is not a substitute for `proposal.md`. It is a bridge for humans and agents.
+
+## Adapter Manifest
+
+`real_brief/adapter_manifest.json` is the machine contract for future Review Surface / Studio work:
+
+```json
+{
+  "schema_version": "0.1",
+  "adapter": "real-brief-workflow-adapter",
+  "source_experiment": "real-brief-benchmark",
+  "source_package_path": "docs/product/experiments/real-brief-results/2026-05-01-seattle-polish-film-festival-poster",
+  "slug": "seattle-polish-film-festival-poster",
+  "workflow_status": "ready_for_visual_brainstorm",
+  "human_gate_required": true,
+  "simulation_only": true,
+  "ai_policy": "unspecified",
+  "domain": "poster",
+  "visual_workflow_domain": "poster",
+  "created": "2026-05-01",
+  "source_files": {
+    "manifest": "source_package_manifest.json",
+    "structured_brief": "structured_brief.json",
+    "workflow_handoff": "workflow_handoff.json",
+    "decision_package": "decision_package.md",
+    "production_package": "production_package.md",
+    "review_schema": "review_schema.json"
+  },
+  "workflow_artifacts": {
+    "discovery_md": "../discovery/discovery.md",
+    "taste_profile_json": "../discovery/taste_profile.json",
+    "direction_cards_json": "../discovery/direction_cards.json",
+    "workflow_seed_md": "../workflow_seed.md"
+  },
+  "next_steps": [
+    "/visual-brainstorm seattle-polish-film-festival-poster",
+    "/visual-spec seattle-polish-film-festival-poster",
+    "/visual-plan seattle-polish-film-festival-poster",
+    "/evaluate seattle-polish-film-festival-poster"
+  ]
+}
+```
+
+The manifest should store relative paths from `real_brief/` where possible, so review tools can move or archive packages without rewriting absolute paths.
+
+## CLI
+
+Add a new script instead of overloading Phase 1:
+
+```bash
+PYTHONPATH=src python3 scripts/real_brief_workflow_adapter.py \
+  --source-package docs/product/experiments/real-brief-results/2026-05-01-seattle-polish-film-festival-poster \
+  --root . \
+  --date 2026-05-01
+```
+
+Flags:
+
+- `--source-package <path>` required unless `--source-root --slug --date` is supplied.
+- `--source-root <path>` optional convenience root for Phase 1 results.
+- `--slug <slug>` optional when resolving from `--source-root`.
+- `--date YYYY-MM-DD` required for deterministic metadata in tests.
+- `--root <repo-root>` default `.`.
+- `--force-discovery` opt-in replacement for adapter-owned `discovery/` files.
+- `--force-real-brief` opt-in replacement for adapter-owned `real_brief/` files.
+- `--dry-run` validate and print planned writes without writing files.
+
+Default execution writes artifacts. It never calls a provider.
+
+## Python API
+
+Add a focused module:
+
+```text
+src/vulca/real_brief/workflow_adapter.py
+```
+
+Public API:
+
+```python
+def adapt_real_brief_package(
+    *,
+    source_package: str | Path,
+    root: str | Path,
+    date: str,
+    force_discovery: bool = False,
+    force_real_brief: bool = False,
+    dry_run: bool = False,
+) -> dict[str, str]:
+    ...
+```
+
+Return shape:
+
+```json
+{
+  "slug": "seattle-polish-film-festival-poster",
+  "status": "ready_for_visual_brainstorm",
+  "project_dir": "docs/visual-specs/seattle-polish-film-festival-poster",
+  "workflow_seed_md": ".../workflow_seed.md",
+  "adapter_manifest_json": ".../real_brief/adapter_manifest.json",
+  "discovery_md": ".../discovery/discovery.md"
+}
+```
+
+For unsupported visual-chain inputs:
+
+```json
+{
+  "slug": "music-video-treatment-low-budget",
+  "status": "unsupported_for_visual_chain",
+  "project_dir": "docs/visual-specs/music-video-treatment-low-budget",
+  "adapter_manifest_json": ".../real_brief/adapter_manifest.json"
+}
+```
+
+## Error Handling
+
+Use clear `ValueError` or `RuntimeError` messages for:
+
+- unknown or unsafe slug;
+- missing required source package files;
+- schema version mismatch;
+- source package not created by real-brief benchmark;
+- `human_gate_required` false;
+- slug mismatch across files;
+- destination collision with finalized proposal/design/plan;
+- unsupported domain for visual workflow;
+- unsafe copy path;
+- secret-like content in generated adapter files.
+
+Unsupported static workflow domain is not a crash if the source package is otherwise valid. It writes a real-brief import package and adapter manifest, but it does not write discovery artifacts that claim `/visual-brainstorm` readiness.
+
+## Review Surface Readiness
+
+Phase 3 Review Surface / Studio should be able to load:
+
+- `real_brief/adapter_manifest.json`;
+- `real_brief/source_package_manifest.json`;
+- `real_brief/structured_brief.json`;
+- `real_brief/workflow_handoff.json`;
+- `real_brief/review_schema.json`;
+- `discovery/direction_cards.json`;
+- future `proposal.md`, `design.md`, `plan.md`, and `evaluation.json`.
+
+That means Phase 2 must preserve source metadata and not flatten the benchmark package into prose only.
+
+## Tests
+
+Add focused tests in `tests/test_real_brief_workflow_adapter.py`:
+
+- fixture-generated Phase 1 package adapts into `docs/visual-specs/<slug>/`;
+- adapter writes `discovery/discovery.md`, `taste_profile.json`, and `direction_cards.json`;
+- adapter writes `real_brief/adapter_manifest.json` with correct next steps and relative paths;
+- adapter copies required source files without modifying the Phase 1 source package;
+- adapter writes `workflow_seed.md` and preserves human gate language;
+- unsafe slugs and path traversal are rejected;
+- missing required files fail before partial writes;
+- existing ready `proposal.md` collision aborts;
+- `music-video-treatment-low-budget` is marked unsupported for visual chain instead of forced into `/visual-brainstorm`;
+- generated artifacts contain no provider keys, live endpoints, or secret-like markers;
+- CLI `--dry-run` reports planned writes and writes nothing;
+- CLI normal mode writes the same files as the Python API.
+
+Keep these existing tests green:
+
+- `tests/test_real_brief_benchmark.py`
+- `tests/test_visual_discovery_artifacts.py`
+- `tests/test_visual_discovery_benchmark.py`
+- `tests/test_visual_discovery_cards.py`
+- `tests/test_visual_discovery_types.py`
+
+## Implementation Boundaries
+
+Files expected in Phase 2 implementation:
+
+- Create `src/vulca/real_brief/workflow_adapter.py`
+- Create `scripts/real_brief_workflow_adapter.py`
+- Create `tests/test_real_brief_workflow_adapter.py`
+- Modify `src/vulca/real_brief/__init__.py` to lazy-export `adapt_real_brief_package`
+- Optionally update `docs/product/experiments/cultural-term-efficacy.md` with a short Phase 2 link
+
+Do not modify:
+
+- redraw, mask, decompose, or layer internals;
+- provider implementations;
+- MCP tool registration;
+- existing `/visual-*` skill contracts unless a failing test proves the adapter cannot use them as written.
+
+## Open Questions For Later Phases
+
+- Whether `/visual-brainstorm` should eventually accept `--from-real-brief <path>` and prefill `proposal.md` as `draft`.
+- Whether Review Surface should render `workflow_seed.md` or read only `adapter_manifest.json`.
+- Whether video/director-treatment briefs should get a separate `/video-treatment` workflow instead of remaining benchmark-only.
+- Whether Phase 3 should compare adapter-seeded discovery against manual `/visual-discovery` sessions.
+
+These are intentionally deferred. Phase 2 should only make real briefs enter the existing visual workflow safely and repeatably.

--- a/docs/superpowers/specs/2026-05-01-real-brief-workflow-adapter-design.md
+++ b/docs/superpowers/specs/2026-05-01-real-brief-workflow-adapter-design.md
@@ -170,14 +170,16 @@ The adapter maps `structured_brief.domain` to the existing visual workflow domai
 | `editorial_cover` | `editorial_cover` | supported |
 | `photography_brief` | `photography_brief` | supported |
 | `hero_visual_for_ui` | `hero_visual_for_ui` | supported |
-| video or treatment-only domains | none | unsupported for visual chain v1 |
+| `public_art` | none | unsupported for visual chain v1 |
+| `video_treatment` | none | unsupported for visual chain v1 |
+| other video or treatment-only domains | none | unsupported for visual chain v1 |
 
-The existing `music-video-treatment-low-budget` fixture remains useful for Phase 1 benchmarking, but Phase 2 v1 must not force it into the static 2D visual chain. It should produce a real-brief import package and mark:
+The existing `erie-botanical-gardens-public-art` and `music-video-treatment-low-budget` fixtures remain useful for Phase 1 benchmarking, but Phase 2 v1 must not force them into the static 2D visual chain. They should produce real-brief import packages and mark:
 
 ```json
 {
   "workflow_status": "unsupported_for_visual_chain",
-  "reason": "video treatment is outside /visual-brainstorm static 2D scope"
+  "reason": "source domain is outside /visual-brainstorm static 2D scope"
 }
 ```
 
@@ -394,7 +396,7 @@ Add focused tests in `tests/test_real_brief_workflow_adapter.py`:
 - unsafe slugs and path traversal are rejected;
 - missing required files fail before partial writes;
 - existing ready `proposal.md` collision aborts;
-- `music-video-treatment-low-budget` is marked unsupported for visual chain instead of forced into `/visual-brainstorm`;
+- `erie-botanical-gardens-public-art` and `music-video-treatment-low-budget` are marked unsupported for visual chain instead of forced into `/visual-brainstorm`;
 - generated artifacts contain no provider keys, live endpoints, or secret-like markers;
 - CLI `--dry-run` reports planned writes and writes nothing;
 - CLI normal mode writes the same files as the Python API.

--- a/scripts/real_brief_workflow_adapter.py
+++ b/scripts/real_brief_workflow_adapter.py
@@ -1,0 +1,58 @@
+"""CLI wrapper for importing real-brief packages into visual workflow seeds."""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+def _resolve_source_package(args: argparse.Namespace) -> Path:
+    if args.source_package:
+        return Path(args.source_package)
+    if not args.source_root or not args.slug or not args.date:
+        raise RuntimeError(
+            "--source-package or all of --source-root, --slug, and --date is required"
+        )
+    return Path(args.source_root) / f"{args.date}-{args.slug}"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Import a real-brief benchmark package into Vulca visual workflow seeds."
+        )
+    )
+    parser.add_argument("--source-package")
+    parser.add_argument("--source-root")
+    parser.add_argument("--slug")
+    parser.add_argument("--root", default=".")
+    parser.add_argument("--date", required=True)
+    parser.add_argument("--force-discovery", action="store_true")
+    parser.add_argument("--force-real-brief", action="store_true")
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args(argv)
+    source_package = _resolve_source_package(args)
+
+    from vulca.real_brief.workflow_adapter import adapt_real_brief_package
+
+    result = adapt_real_brief_package(
+        source_package=source_package,
+        root=args.root,
+        date=args.date,
+        force_discovery=args.force_discovery,
+        force_real_brief=args.force_real_brief,
+        dry_run=args.dry_run,
+    )
+    print(json.dumps(result, ensure_ascii=False, indent=2, sort_keys=True))
+    return 0
+
+
+def _cli() -> int:
+    try:
+        return main()
+    except (RuntimeError, ValueError) as exc:
+        raise SystemExit(f"error: {exc}") from None
+
+
+if __name__ == "__main__":
+    raise SystemExit(_cli())

--- a/scripts/real_brief_workflow_adapter.py
+++ b/scripts/real_brief_workflow_adapter.py
@@ -50,7 +50,7 @@ def main(argv: list[str] | None = None) -> int:
 def _cli() -> int:
     try:
         return main()
-    except (RuntimeError, ValueError) as exc:
+    except (FileNotFoundError, RuntimeError, ValueError) as exc:
         raise SystemExit(f"error: {exc}") from None
 
 

--- a/src/vulca/__init__.py
+++ b/src/vulca/__init__.py
@@ -31,6 +31,12 @@ Usage::
     session = StudioSession(brief=brief)
 """
 
+import os
+
+# Importing provider-facing modules can touch LiteLLM. Keep default imports
+# offline unless the caller has explicitly chosen another cost-map behavior.
+os.environ.setdefault("LITELLM_LOCAL_MODEL_COST_MAP", "true")
+
 from vulca._version import __version__
 from vulca.create import acreate, create
 from vulca.evaluate import aevaluate, evaluate

--- a/src/vulca/real_brief/__init__.py
+++ b/src/vulca/real_brief/__init__.py
@@ -15,6 +15,7 @@ from vulca.real_brief.types import (
 )
 
 __all__ = [
+    "adapt_real_brief_package",
     "CONDITION_IDS",
     "REVIEW_DIMENSIONS",
     "brief_digest",
@@ -29,6 +30,10 @@ __all__ = [
 ]
 
 _LAZY_EXPORTS = {
+    "adapt_real_brief_package": (
+        "vulca.real_brief.workflow_adapter",
+        "adapt_real_brief_package",
+    ),
     "brief_digest": ("vulca.real_brief.conditions", "brief_digest"),
     "build_real_brief_conditions": (
         "vulca.real_brief.conditions",

--- a/src/vulca/real_brief/workflow_adapter.py
+++ b/src/vulca/real_brief/workflow_adapter.py
@@ -1,0 +1,411 @@
+"""Adapter from real-brief dry-run packages into visual workflow seeds."""
+from __future__ import annotations
+
+import json
+import re
+import shutil
+from pathlib import Path
+from typing import Any
+
+from vulca.discovery.artifacts import write_discovery_artifacts
+from vulca.discovery.cards import generate_direction_cards
+from vulca.discovery.profile import infer_taste_profile
+from vulca.discovery.prompting import compose_prompt_from_direction_card
+from vulca.discovery.types import SketchPrompt
+from vulca.real_brief.types import safe_slug
+
+
+SUPPORTED_STATIC_VISUAL_DOMAINS = {
+    "poster",
+    "packaging",
+    "brand_visual",
+    "illustration",
+    "editorial_cover",
+    "photography_brief",
+    "hero_visual_for_ui",
+}
+
+_RUN_DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+_SOURCE_FILES = [
+    "structured_brief.json",
+    "workflow_handoff.json",
+    "decision_package.md",
+    "production_package.md",
+    "review_schema.json",
+    "source_brief.md",
+    "summary.md",
+]
+_SOURCE_DIRS = ["conditions", "prompts", "images", "evaluations"]
+_REQUIRED_SOURCE_FILES = [
+    "manifest.json",
+    "workflow_handoff.json",
+    "structured_brief.json",
+    "decision_package.md",
+    "production_package.md",
+    "review_schema.json",
+]
+_FINALIZED_STATUSES = {
+    "proposal.md": {"ready"},
+    "design.md": {"resolved"},
+    "plan.md": {"completed", "partial", "aborted"},
+}
+_STATUS_RE = re.compile(r"(?im)^\s*status\s*:\s*([a-z0-9_-]+)\s*$")
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _safe_date(date: str) -> str:
+    if not _RUN_DATE_RE.fullmatch(date):
+        raise ValueError("date must use YYYY-MM-DD")
+    return date
+
+
+def _project_dir(root: Path, slug: str) -> Path:
+    return root / "docs" / "visual-specs" / slug
+
+
+def _status_from_markdown(path: Path) -> str:
+    match = _STATUS_RE.search(path.read_text(encoding="utf-8"))
+    return match.group(1).lower() if match else ""
+
+
+def _load_source_package(
+    source_package: Path,
+) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any]]:
+    for filename in _REQUIRED_SOURCE_FILES:
+        path = source_package / filename
+        if not path.exists():
+            raise FileNotFoundError(f"required source package file missing: {path}")
+
+    manifest_path = source_package / "manifest.json"
+    structured_path = source_package / "structured_brief.json"
+    handoff_path = source_package / "workflow_handoff.json"
+    manifest = _read_json(manifest_path)
+    structured = _read_json(structured_path)
+    handoff = _read_json(handoff_path)
+    if manifest.get("schema_version") != "0.1":
+        raise ValueError("manifest.schema_version must be 0.1")
+    if manifest.get("experiment") != "real-brief-benchmark":
+        raise ValueError("source package is not a real-brief benchmark package")
+    if manifest.get("mode") != "dry_run":
+        raise ValueError("source package must be a dry-run package")
+    if manifest.get("provider_execution") != "disabled":
+        raise ValueError("manifest.provider_execution must be disabled")
+    if handoff.get("schema_version") != "0.1":
+        raise ValueError("workflow_handoff.schema_version must be 0.1")
+    if handoff.get("human_gate_required") is not True:
+        raise ValueError("workflow_handoff.human_gate_required must be true")
+
+    slugs = {
+        "manifest.fixture.slug": manifest.get("fixture", {}).get("slug"),
+        "workflow_handoff.slug": handoff.get("slug"),
+        "structured_brief.slug": structured.get("slug"),
+    }
+    normalized = {key: safe_slug(str(value)) for key, value in slugs.items()}
+    if len(set(normalized.values())) != 1:
+        raise ValueError(f"source package slug mismatch: {normalized}")
+    return manifest, structured, handoff
+
+
+def _initial_intent(structured: dict[str, Any], handoff: dict[str, Any]) -> str:
+    discovery_seed = handoff.get("visual_discovery_seed", {})
+    return str(
+        discovery_seed.get("initial_intent")
+        or structured.get("source_brief")
+        or structured.get("context")
+        or structured.get("title")
+        or ""
+    )
+
+
+def _build_sketch_prompts(cards: list[Any]) -> list[SketchPrompt]:
+    prompts: list[SketchPrompt] = []
+    for card in cards:
+        prompt = compose_prompt_from_direction_card(card, target="sketch")
+        prompts.append(
+            SketchPrompt(
+                card_id=card.id,
+                provider=prompt.provider,
+                model=prompt.model,
+                prompt=prompt.prompt,
+                negative_prompt=prompt.negative_prompt,
+                size="1024x1024",
+                purpose="visual workflow adapter discovery thumbnail seed",
+            )
+        )
+    return prompts
+
+
+def _next_steps(slug: str) -> list[str]:
+    return [
+        f"/visual-brainstorm {slug}",
+        f"/visual-spec {slug}",
+        f"/visual-plan {slug}",
+        f"/evaluate {slug}",
+    ]
+
+
+def _adapter_manifest(
+    *,
+    slug: str,
+    domain: str,
+    date: str,
+    source_manifest: dict[str, Any],
+    status: str,
+) -> dict[str, Any]:
+    discovery_path = (
+        "../discovery/discovery.md" if status == "ready_for_visual_brainstorm" else None
+    )
+    supported = status == "ready_for_visual_brainstorm"
+    manifest = {
+        "schema_version": "0.1",
+        "adapter": "real-brief-workflow-adapter",
+        "source_experiment": source_manifest.get("experiment"),
+        "source_mode": source_manifest.get("mode"),
+        "slug": slug,
+        "workflow_status": status,
+        "human_gate_required": True,
+        "simulation_only": True,
+        "domain": domain,
+        "visual_workflow_domain": domain if supported else None,
+        "created": date,
+        "workflow_artifacts": {
+            "discovery_md": discovery_path,
+            "workflow_seed_md": "../workflow_seed.md",
+        },
+        "source_package_manifest": "source_package_manifest.json",
+        "next_steps": _next_steps(slug) if supported else [],
+    }
+    if not supported:
+        manifest["unsupported_reason"] = (
+            "source domain is outside /visual-brainstorm static 2D scope"
+        )
+    return manifest
+
+
+def _workflow_seed_md(
+    *,
+    slug: str,
+    title: str,
+    domain: str,
+    source_package: Path,
+    status: str,
+) -> str:
+    next_step_lines = [f"- {step}" for step in _next_steps(slug)]
+    if status == "ready_for_visual_brainstorm":
+        status_section = [
+            "This file preserves the real-brief handoff context for the visual workflow.",
+            "It is not a substitute for `proposal.md`; /visual-brainstorm must still "
+            "create and resolve the human-reviewed proposal.",
+            "",
+            "## Human Gates",
+            "- Review the copied real_brief source package before using any production workflow.",
+            "- /visual-brainstorm must produce `proposal.md` and wait for human approval.",
+            "- /visual-spec must resolve design.md before planning or generation.",
+            "- /visual-plan must not execute production work without explicit human approval.",
+            "",
+            "## Suggested Next Steps",
+            *next_step_lines,
+        ]
+    else:
+        status_section = [
+            "This file preserves the real-brief source context, but this domain is "
+            "unsupported_for_visual_chain.",
+            "The adapter stops here and does not start `/visual-brainstorm`.",
+            "It is not a substitute for `proposal.md`.",
+            "",
+            "## Human Gates",
+            "- Review the copied real_brief source package before choosing another workflow.",
+            "- Choose a domain-specific workflow manually before any production work.",
+        ]
+    return "\n".join(
+        [
+            f"# Real Brief Workflow Seed: {title}",
+            "",
+            f"status: {status}",
+            "human_gate_required: true",
+            "simulation_only: true",
+            f"slug: {slug}",
+            f"domain: {domain}",
+            f"source_package: {source_package}",
+            "",
+            *status_section,
+            "",
+        ]
+    )
+
+
+def _copy_source_package(source_package: Path, real_brief_dir: Path) -> None:
+    real_brief_dir.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(
+        source_package / "manifest.json",
+        real_brief_dir / "source_package_manifest.json",
+    )
+    for filename in _SOURCE_FILES:
+        source = source_package / filename
+        if source.exists():
+            shutil.copy2(source, real_brief_dir / filename)
+    for dirname in _SOURCE_DIRS:
+        source_dir = source_package / dirname
+        if source_dir.exists():
+            target_dir = real_brief_dir / dirname
+            if target_dir.exists():
+                shutil.rmtree(target_dir)
+            shutil.copytree(source_dir, target_dir)
+
+
+def _assert_destination_can_write(
+    *,
+    project_dir: Path,
+    status: str,
+    force_discovery: bool,
+    force_real_brief: bool,
+) -> None:
+    for filename, terminal_statuses in _FINALIZED_STATUSES.items():
+        path = project_dir / filename
+        if path.exists() and _status_from_markdown(path) in terminal_statuses:
+            raise RuntimeError(
+                f"refusing finalized workflow overwrite: {path} has terminal status"
+            )
+
+    if status == "ready_for_visual_brainstorm":
+        discovery_dir = project_dir / "discovery"
+        if discovery_dir.exists() and not force_discovery:
+            raise RuntimeError(
+                f"{discovery_dir} already exists; pass force_discovery=True to overwrite"
+            )
+
+    real_brief_dir = project_dir / "real_brief"
+    if real_brief_dir.exists() and not force_real_brief:
+        raise RuntimeError(
+            f"{real_brief_dir} already exists; pass force_real_brief=True to overwrite"
+        )
+
+
+def adapt_real_brief_package(
+    *,
+    source_package: str | Path,
+    root: str | Path,
+    date: str,
+    dry_run: bool = False,
+    force_discovery: bool = False,
+    force_real_brief: bool = False,
+) -> dict[str, str]:
+    """Adapt a real-brief dry-run package into visual workflow seed artifacts."""
+    source_package_path = Path(source_package)
+    root_path = Path(root)
+    safe_date = _safe_date(date)
+    source_manifest, structured, handoff = _load_source_package(source_package_path)
+    slug = safe_slug(str(structured.get("slug") or source_manifest.get("fixture_slug")))
+    domain = str(
+        structured.get("domain")
+        or handoff.get("visual_discovery_seed", {}).get("domain")
+        or ""
+    )
+    project_dir = _project_dir(root_path, slug)
+    real_brief_dir = project_dir / "real_brief"
+    discovery_md = project_dir / "discovery" / "discovery.md"
+    workflow_seed_md = project_dir / "workflow_seed.md"
+    adapter_manifest_json = real_brief_dir / "adapter_manifest.json"
+    status = (
+        "ready_for_visual_brainstorm"
+        if domain in SUPPORTED_STATIC_VISUAL_DOMAINS
+        else "unsupported_for_visual_chain"
+    )
+
+    result = {
+        "slug": slug,
+        "status": status,
+        "project_dir": str(project_dir),
+        "adapter_manifest_json": str(adapter_manifest_json),
+        "workflow_seed_md": str(workflow_seed_md),
+    }
+    if status == "ready_for_visual_brainstorm":
+        result.update(
+            {
+                "discovery_md": str(discovery_md),
+            }
+        )
+    if dry_run:
+        result["dry_run"] = "true"
+        return result
+
+    title = str(structured.get("title") or slug)
+    _assert_destination_can_write(
+        project_dir=project_dir,
+        status=status,
+        force_discovery=force_discovery,
+        force_real_brief=force_real_brief,
+    )
+    if status != "ready_for_visual_brainstorm":
+        _copy_source_package(source_package_path, real_brief_dir)
+        _write_json(
+            adapter_manifest_json,
+            _adapter_manifest(
+                slug=slug,
+                domain=domain,
+                date=safe_date,
+                source_manifest=source_manifest,
+                status=status,
+            ),
+        )
+        workflow_seed_md.write_text(
+            _workflow_seed_md(
+                slug=slug,
+                title=title,
+                domain=domain,
+                source_package=source_package_path,
+                status=status,
+            ),
+            encoding="utf-8",
+        )
+        return result
+
+    intent = _initial_intent(structured, handoff)
+    profile = infer_taste_profile(slug, intent)
+    cards = generate_direction_cards(profile)
+    recommended_card_id = cards[0].id
+    sketch_prompts = _build_sketch_prompts(cards)
+
+    write_discovery_artifacts(
+        root=root_path,
+        slug=slug,
+        title=title,
+        original_intent=intent,
+        profile=profile,
+        cards=cards,
+        recommended_card_id=recommended_card_id,
+        sketch_prompts=sketch_prompts,
+    )
+    _copy_source_package(source_package_path, real_brief_dir)
+    _write_json(
+        adapter_manifest_json,
+        _adapter_manifest(
+            slug=slug,
+            domain=domain,
+            date=safe_date,
+            source_manifest=source_manifest,
+            status=status,
+        ),
+    )
+    workflow_seed_md.write_text(
+        _workflow_seed_md(
+            slug=slug,
+            title=title,
+            domain=domain,
+            source_package=source_package_path,
+            status=status,
+        ),
+        encoding="utf-8",
+    )
+    return result

--- a/src/vulca/real_brief/workflow_adapter.py
+++ b/src/vulca/real_brief/workflow_adapter.py
@@ -34,6 +34,7 @@ _SOURCE_FILES = [
     "review_schema.json",
     "source_brief.md",
     "summary.md",
+    "human_review.html",
 ]
 _SOURCE_DIRS = ["conditions", "prompts", "images", "evaluations"]
 _REQUIRED_SOURCE_FILES = [
@@ -264,6 +265,31 @@ def _copy_source_package(source_package: Path, real_brief_dir: Path) -> None:
             shutil.copytree(source_dir, target_dir)
 
 
+def _assert_source_path_safe(source_package: Path, path: Path) -> None:
+    if path.is_symlink():
+        raise ValueError(f"source package path must not be a symlink: {path}")
+    source_root = source_package.resolve()
+    resolved = path.resolve(strict=True)
+    if source_root != resolved and source_root not in resolved.parents:
+        raise ValueError(f"source package path escapes package: {path}")
+
+
+def _validate_copy_sources(source_package: Path) -> None:
+    source_package_root = source_package.resolve()
+    _assert_source_path_safe(source_package, source_package)
+    for filename in ["manifest.json", *_SOURCE_FILES]:
+        source = source_package / filename
+        if source.exists() or source.is_symlink():
+            _assert_source_path_safe(source_package_root, source)
+    for dirname in _SOURCE_DIRS:
+        source_dir = source_package / dirname
+        if not source_dir.exists() and not source_dir.is_symlink():
+            continue
+        _assert_source_path_safe(source_package_root, source_dir)
+        for child in source_dir.rglob("*"):
+            _assert_source_path_safe(source_package_root, child)
+
+
 def _assert_destination_can_write(
     *,
     project_dir: Path,
@@ -305,6 +331,7 @@ def adapt_real_brief_package(
     source_package_path = Path(source_package)
     root_path = Path(root)
     safe_date = _safe_date(date)
+    _validate_copy_sources(source_package_path)
     source_manifest, structured, handoff = _load_source_package(source_package_path)
     slug = safe_slug(str(structured.get("slug") or source_manifest.get("fixture_slug")))
     domain = str(

--- a/src/vulca/real_brief/workflow_adapter.py
+++ b/src/vulca/real_brief/workflow_adapter.py
@@ -331,6 +331,8 @@ def adapt_real_brief_package(
     source_package_path = Path(source_package)
     root_path = Path(root)
     safe_date = _safe_date(date)
+    if not source_package_path.exists():
+        raise FileNotFoundError(f"source package not found: {source_package_path}")
     _validate_copy_sources(source_package_path)
     source_manifest, structured, handoff = _load_source_package(source_package_path)
     slug = safe_slug(str(structured.get("slug") or source_manifest.get("fixture_slug")))

--- a/tests/test_real_brief_workflow_adapter.py
+++ b/tests/test_real_brief_workflow_adapter.py
@@ -1,0 +1,309 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+
+def _source_package(tmp_path: Path, slug: str) -> Path:
+    from vulca.real_brief.artifacts import write_real_brief_dry_run
+
+    result = write_real_brief_dry_run(
+        output_root=tmp_path / "source",
+        slug=slug,
+        date="2026-05-01",
+        write_html_review=False,
+    )
+    return Path(result["output_dir"])
+
+
+def _read_json(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _write_json(path: Path, payload: dict) -> None:
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def test_adapt_real_brief_package_writes_supported_visual_workflow(tmp_path):
+    from vulca.real_brief.workflow_adapter import adapt_real_brief_package
+
+    source_package = _source_package(
+        tmp_path,
+        "seattle-polish-film-festival-poster",
+    )
+    original_manifest = (source_package / "manifest.json").read_text(encoding="utf-8")
+
+    result = adapt_real_brief_package(
+        source_package=source_package,
+        root=tmp_path / "repo",
+        date="2026-05-01",
+    )
+
+    project_dir = (
+        tmp_path
+        / "repo"
+        / "docs"
+        / "visual-specs"
+        / "seattle-polish-film-festival-poster"
+    )
+    real_brief_dir = project_dir / "real_brief"
+    discovery_dir = project_dir / "discovery"
+
+    assert result["slug"] == "seattle-polish-film-festival-poster"
+    assert result["status"] == "ready_for_visual_brainstorm"
+    assert Path(result["project_dir"]) == project_dir
+    assert Path(result["workflow_seed_md"]) == project_dir / "workflow_seed.md"
+    assert Path(result["adapter_manifest_json"]) == (
+        real_brief_dir / "adapter_manifest.json"
+    )
+    assert Path(result["discovery_md"]) == discovery_dir / "discovery.md"
+
+    for rel in [
+        "discovery/discovery.md",
+        "discovery/taste_profile.json",
+        "discovery/direction_cards.json",
+        "discovery/sketch_prompts.json",
+        "real_brief/adapter_manifest.json",
+        "real_brief/source_package_manifest.json",
+        "real_brief/structured_brief.json",
+        "real_brief/workflow_handoff.json",
+        "real_brief/decision_package.md",
+        "real_brief/production_package.md",
+        "real_brief/review_schema.json",
+        "real_brief/source_brief.md",
+        "real_brief/summary.md",
+        "real_brief/conditions/A-one-shot.md",
+        "real_brief/prompts/D.txt",
+        "workflow_seed.md",
+    ]:
+        assert (project_dir / rel).exists(), rel
+
+    manifest = _read_json(real_brief_dir / "adapter_manifest.json")
+    assert manifest["schema_version"] == "0.1"
+    assert manifest["adapter"] == "real-brief-workflow-adapter"
+    assert manifest["source_experiment"] == "real-brief-benchmark"
+    assert manifest["slug"] == "seattle-polish-film-festival-poster"
+    assert manifest["workflow_status"] == "ready_for_visual_brainstorm"
+    assert manifest["human_gate_required"] is True
+    assert manifest["simulation_only"] is True
+    assert manifest["domain"] == "poster"
+    assert manifest["visual_workflow_domain"] == "poster"
+    assert manifest["created"] == "2026-05-01"
+    assert manifest["workflow_artifacts"]["discovery_md"] == (
+        "../discovery/discovery.md"
+    )
+    assert manifest["next_steps"] == [
+        "/visual-brainstorm seattle-polish-film-festival-poster",
+        "/visual-spec seattle-polish-film-festival-poster",
+        "/visual-plan seattle-polish-film-festival-poster",
+        "/evaluate seattle-polish-film-festival-poster",
+    ]
+
+    discovery_md = (discovery_dir / "discovery.md").read_text(encoding="utf-8")
+    assert "ready_for_brainstorm" in discovery_md
+    assert "Ready for /visual-brainstorm" in discovery_md
+    assert "Seattle Polish Film Festival Poster" in discovery_md
+
+    workflow_seed = (project_dir / "workflow_seed.md").read_text(encoding="utf-8")
+    assert "ready_for_visual_brainstorm" in workflow_seed
+    assert "/visual-brainstorm seattle-polish-film-festival-poster" in workflow_seed
+    assert "/visual-spec must resolve design.md" in workflow_seed
+    assert "not a substitute for `proposal.md`" in workflow_seed
+
+    assert (source_package / "manifest.json").read_text(encoding="utf-8") == (
+        original_manifest
+    )
+
+
+def test_adapt_real_brief_package_dry_run_writes_nothing(tmp_path):
+    from vulca.real_brief.workflow_adapter import adapt_real_brief_package
+
+    source_package = _source_package(tmp_path, "gsm-community-market-campaign")
+    root = tmp_path / "repo"
+
+    result = adapt_real_brief_package(
+        source_package=source_package,
+        root=root,
+        date="2026-05-01",
+        dry_run=True,
+    )
+
+    assert result["slug"] == "gsm-community-market-campaign"
+    assert result["status"] == "ready_for_visual_brainstorm"
+    assert result["dry_run"] == "true"
+    assert not (root / "docs").exists()
+
+
+@pytest.mark.parametrize(
+    ("filename", "status"),
+    [
+        ("proposal.md", "ready"),
+        ("design.md", "resolved"),
+        ("plan.md", "completed"),
+        ("plan.md", "partial"),
+        ("plan.md", "aborted"),
+    ],
+)
+def test_adapt_real_brief_package_refuses_finalized_workflow_files(
+    tmp_path,
+    filename,
+    status,
+):
+    from vulca.real_brief.workflow_adapter import adapt_real_brief_package
+
+    source_package = _source_package(tmp_path, "seattle-polish-film-festival-poster")
+    project_dir = (
+        tmp_path
+        / "repo"
+        / "docs"
+        / "visual-specs"
+        / "seattle-polish-film-festival-poster"
+    )
+    project_dir.mkdir(parents=True)
+    (project_dir / filename).write_text(f"status: {status}\n", encoding="utf-8")
+
+    with pytest.raises(RuntimeError, match="refusing finalized workflow overwrite"):
+        adapt_real_brief_package(
+            source_package=source_package,
+            root=tmp_path / "repo",
+            date="2026-05-01",
+        )
+
+
+def test_adapt_real_brief_package_requires_force_for_existing_generated_dirs(tmp_path):
+    from vulca.real_brief.workflow_adapter import adapt_real_brief_package
+
+    source_package = _source_package(tmp_path, "seattle-polish-film-festival-poster")
+    project_dir = (
+        tmp_path
+        / "repo"
+        / "docs"
+        / "visual-specs"
+        / "seattle-polish-film-festival-poster"
+    )
+    (project_dir / "discovery").mkdir(parents=True)
+
+    with pytest.raises(RuntimeError, match="force_discovery=True"):
+        adapt_real_brief_package(
+            source_package=source_package,
+            root=tmp_path / "repo",
+            date="2026-05-01",
+        )
+
+    (project_dir / "discovery").rmdir()
+    (project_dir / "real_brief").mkdir()
+
+    with pytest.raises(RuntimeError, match="force_real_brief=True"):
+        adapt_real_brief_package(
+            source_package=source_package,
+            root=tmp_path / "repo",
+            date="2026-05-01",
+        )
+
+    result = adapt_real_brief_package(
+        source_package=source_package,
+        root=tmp_path / "repo",
+        date="2026-05-01",
+        force_discovery=True,
+        force_real_brief=True,
+    )
+    assert result["status"] == "ready_for_visual_brainstorm"
+
+
+@pytest.mark.parametrize(
+    ("path", "mutate"),
+    [
+        ("manifest.json", lambda data: data.update({"schema_version": "9.9"})),
+        ("manifest.json", lambda data: data.update({"provider_execution": "enabled"})),
+        ("workflow_handoff.json", lambda data: data.update({"schema_version": "9.9"})),
+        (
+            "workflow_handoff.json",
+            lambda data: data.update({"human_gate_required": False}),
+        ),
+        ("structured_brief.json", lambda data: data.update({"slug": "different-slug"})),
+    ],
+)
+def test_adapt_real_brief_package_validates_source_package(tmp_path, path, mutate):
+    from vulca.real_brief.workflow_adapter import adapt_real_brief_package
+
+    source_package = _source_package(tmp_path, "seattle-polish-film-festival-poster")
+    payload_path = source_package / path
+    payload = _read_json(payload_path)
+    mutate(payload)
+    _write_json(payload_path, payload)
+
+    with pytest.raises(ValueError):
+        adapt_real_brief_package(
+            source_package=source_package,
+            root=tmp_path / "repo",
+            date="2026-05-01",
+        )
+
+
+def test_adapt_real_brief_package_requires_core_source_files(tmp_path):
+    from vulca.real_brief.workflow_adapter import adapt_real_brief_package
+
+    source_package = _source_package(tmp_path, "seattle-polish-film-festival-poster")
+    (source_package / "production_package.md").unlink()
+
+    with pytest.raises(FileNotFoundError, match="production_package.md"):
+        adapt_real_brief_package(
+            source_package=source_package,
+            root=tmp_path / "repo",
+            date="2026-05-01",
+        )
+
+
+@pytest.mark.parametrize(
+    ("slug", "expected_domain"),
+    [
+        ("erie-botanical-gardens-public-art", "public_art"),
+        ("music-video-treatment-low-budget", "video_treatment"),
+    ],
+)
+def test_adapt_real_brief_package_preserves_unsupported_domain_without_discovery(
+    tmp_path,
+    slug,
+    expected_domain,
+):
+    from vulca.real_brief.workflow_adapter import adapt_real_brief_package
+
+    source_package = _source_package(tmp_path, slug)
+
+    result = adapt_real_brief_package(
+        source_package=source_package,
+        root=tmp_path / "repo",
+        date="2026-05-01",
+    )
+
+    project_dir = (
+        tmp_path
+        / "repo"
+        / "docs"
+        / "visual-specs"
+        / slug
+    )
+    real_brief_dir = project_dir / "real_brief"
+
+    assert result["status"] == "unsupported_for_visual_chain"
+    assert "discovery_md" not in result
+    assert Path(result["workflow_seed_md"]) == project_dir / "workflow_seed.md"
+    assert (real_brief_dir / "adapter_manifest.json").exists()
+    assert (real_brief_dir / "source_package_manifest.json").exists()
+    assert (real_brief_dir / "structured_brief.json").exists()
+    assert not (project_dir / "discovery").exists()
+
+    manifest = _read_json(real_brief_dir / "adapter_manifest.json")
+    assert manifest["workflow_status"] == "unsupported_for_visual_chain"
+    assert manifest["domain"] == expected_domain
+    assert manifest["visual_workflow_domain"] is None
+    assert manifest["unsupported_reason"] == (
+        "source domain is outside /visual-brainstorm static 2D scope"
+    )
+    assert manifest["workflow_artifacts"]["discovery_md"] is None
+
+    workflow_seed = (project_dir / "workflow_seed.md").read_text(encoding="utf-8")
+    assert "unsupported_for_visual_chain" in workflow_seed
+    assert "does not start `/visual-brainstorm`" in workflow_seed

--- a/tests/test_real_brief_workflow_adapter.py
+++ b/tests/test_real_brief_workflow_adapter.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import sys
 from pathlib import Path
 
 import pytest
@@ -307,3 +308,96 @@ def test_adapt_real_brief_package_preserves_unsupported_domain_without_discovery
     workflow_seed = (project_dir / "workflow_seed.md").read_text(encoding="utf-8")
     assert "unsupported_for_visual_chain" in workflow_seed
     assert "does not start `/visual-brainstorm`" in workflow_seed
+
+
+def test_real_brief_workflow_adapter_cli_dry_run(tmp_path, capsys):
+    from scripts.real_brief_workflow_adapter import main
+
+    source_package = _source_package(tmp_path, "seattle-polish-film-festival-poster")
+
+    rc = main(
+        [
+            "--source-package",
+            str(source_package),
+            "--root",
+            str(tmp_path / "repo"),
+            "--date",
+            "2026-05-01",
+            "--dry-run",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+
+    assert rc == 0
+    assert payload["slug"] == "seattle-polish-film-festival-poster"
+    assert payload["status"] == "ready_for_visual_brainstorm"
+    assert payload["dry_run"] == "true"
+    assert not (tmp_path / "repo" / "docs").exists()
+
+
+def test_real_brief_workflow_adapter_cli_writes_files(tmp_path, capsys):
+    from scripts.real_brief_workflow_adapter import main
+
+    source_package = _source_package(tmp_path, "gsm-community-market-campaign")
+
+    rc = main(
+        [
+            "--source-package",
+            str(source_package),
+            "--root",
+            str(tmp_path / "repo"),
+            "--date",
+            "2026-05-01",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    project_dir = tmp_path / "repo" / "docs" / "visual-specs" / (
+        "gsm-community-market-campaign"
+    )
+
+    assert rc == 0
+    assert payload["status"] == "ready_for_visual_brainstorm"
+    assert (project_dir / "workflow_seed.md").exists()
+
+
+def test_real_brief_workflow_adapter_can_resolve_source_root_slug_date(tmp_path):
+    from scripts.real_brief_workflow_adapter import main
+
+    _source_package(tmp_path, "gsm-community-market-campaign")
+
+    rc = main(
+        [
+            "--source-root",
+            str(tmp_path / "source"),
+            "--slug",
+            "gsm-community-market-campaign",
+            "--root",
+            str(tmp_path / "repo"),
+            "--date",
+            "2026-05-01",
+            "--dry-run",
+        ]
+    )
+
+    assert rc == 0
+
+
+def test_real_brief_workflow_adapter_validates_selector_before_adapter_import():
+    from scripts.real_brief_workflow_adapter import main
+
+    sys.modules.pop("vulca.real_brief.workflow_adapter", None)
+
+    with pytest.raises(RuntimeError, match="--source-package"):
+        main(["--date", "2026-05-01"])
+
+    assert "vulca.real_brief.workflow_adapter" not in sys.modules
+
+
+def test_real_brief_workflow_adapter_public_export_is_lazy():
+    from vulca.real_brief import adapt_real_brief_package
+
+    assert callable(adapt_real_brief_package)

--- a/tests/test_real_brief_workflow_adapter.py
+++ b/tests/test_real_brief_workflow_adapter.py
@@ -437,3 +437,37 @@ def test_real_brief_workflow_adapter_public_export_is_lazy():
     from vulca.real_brief import adapt_real_brief_package
 
     assert callable(adapt_real_brief_package)
+
+
+def test_workflow_adapter_import_forces_litellm_local_cost_map():
+    import os
+    import subprocess
+    import sys
+
+    source_path = str(Path(__file__).resolve().parents[1] / "src")
+    env = dict(os.environ)
+    env.pop("LITELLM_LOCAL_MODEL_COST_MAP", None)
+    env["PYTHONPATH"] = (
+        source_path
+        if not env.get("PYTHONPATH")
+        else f"{source_path}{os.pathsep}{env['PYTHONPATH']}"
+    )
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            (
+                "import os\n"
+                "import vulca.real_brief.workflow_adapter\n"
+                "print(os.environ.get('LITELLM_LOCAL_MODEL_COST_MAP'))\n"
+            ),
+        ],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    assert completed.stdout.strip() == "true"
+    assert "Failed to fetch remote model cost map" not in completed.stderr

--- a/tests/test_real_brief_workflow_adapter.py
+++ b/tests/test_real_brief_workflow_adapter.py
@@ -154,6 +154,104 @@ def test_adapt_real_brief_package_generated_artifacts_do_not_leak_secrets(tmp_pa
         assert "globalai" not in text.casefold(), generated_file
 
 
+def test_adapt_real_brief_package_preserves_human_review_html_when_present(tmp_path):
+    from vulca.real_brief.artifacts import write_real_brief_dry_run
+    from vulca.real_brief.workflow_adapter import adapt_real_brief_package
+
+    result = write_real_brief_dry_run(
+        output_root=tmp_path / "source",
+        slug="seattle-polish-film-festival-poster",
+        date="2026-05-01",
+        write_html_review=True,
+    )
+    source_package = Path(result["output_dir"])
+
+    adapt_real_brief_package(
+        source_package=source_package,
+        root=tmp_path / "repo",
+        date="2026-05-01",
+    )
+
+    copied_review = (
+        tmp_path
+        / "repo"
+        / "docs"
+        / "visual-specs"
+        / "seattle-polish-film-festival-poster"
+        / "real_brief"
+        / "human_review.html"
+    )
+
+    assert copied_review.exists()
+    assert copied_review.read_text(encoding="utf-8") == (
+        source_package / "human_review.html"
+    ).read_text(encoding="utf-8")
+
+
+def test_adapt_real_brief_package_rejects_symlinked_source_files(tmp_path):
+    from vulca.real_brief.workflow_adapter import adapt_real_brief_package
+
+    source_package = _source_package(tmp_path, "seattle-polish-film-festival-poster")
+    outside_file = tmp_path / "outside-secret.txt"
+    outside_file.write_text("outside data", encoding="utf-8")
+    source_brief = source_package / "source_brief.md"
+    source_brief.unlink()
+    source_brief.symlink_to(outside_file)
+
+    with pytest.raises(ValueError, match="symlink"):
+        adapt_real_brief_package(
+            source_package=source_package,
+            root=tmp_path / "repo",
+            date="2026-05-01",
+        )
+
+    copied_outside = (
+        tmp_path
+        / "repo"
+        / "docs"
+        / "visual-specs"
+        / "seattle-polish-film-festival-poster"
+        / "real_brief"
+        / "source_brief.md"
+    )
+    assert not copied_outside.exists()
+    assert not copied_outside.parents[1].exists()
+
+
+def test_adapt_real_brief_package_rejects_symlinked_source_dirs(tmp_path):
+    from vulca.real_brief.workflow_adapter import adapt_real_brief_package
+
+    source_package = _source_package(tmp_path, "seattle-polish-film-festival-poster")
+    outside_dir = tmp_path / "outside-dir"
+    outside_dir.mkdir()
+    (outside_dir / "outside.txt").write_text("outside data", encoding="utf-8")
+    prompts_dir = source_package / "prompts"
+    for path in prompts_dir.iterdir():
+        path.unlink()
+    prompts_dir.rmdir()
+    prompts_dir.symlink_to(outside_dir, target_is_directory=True)
+
+    with pytest.raises(ValueError, match="symlink"):
+        adapt_real_brief_package(
+            source_package=source_package,
+            root=tmp_path / "repo",
+            date="2026-05-01",
+        )
+
+    copied_outside = (
+        tmp_path
+        / "repo"
+        / "docs"
+        / "visual-specs"
+        / "seattle-polish-film-festival-poster"
+        / "real_brief"
+        / "prompts"
+        / "outside.txt"
+    )
+    assert not copied_outside.exists()
+    assert not copied_outside.parents[2].exists()
+
+
 def test_adapt_real_brief_package_dry_run_writes_nothing(tmp_path):
     from vulca.real_brief.workflow_adapter import adapt_real_brief_package
 
@@ -431,6 +529,37 @@ def test_real_brief_workflow_adapter_validates_selector_before_adapter_import():
         main(["--date", "2026-05-01"])
 
     assert "vulca.real_brief.workflow_adapter" not in sys.modules
+
+
+def test_real_brief_workflow_adapter_cli_reports_missing_source_package(
+    capsys,
+    monkeypatch,
+):
+    from scripts.real_brief_workflow_adapter import _cli
+
+    missing = "/private/tmp/vulca-missing-real-brief-package"
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "real_brief_workflow_adapter.py",
+            "--source-package",
+            missing,
+            "--root",
+            "/private/tmp/vulca-target",
+            "--date",
+            "2026-05-01",
+            "--dry-run",
+        ],
+    )
+
+    with pytest.raises(SystemExit) as excinfo:
+        _cli()
+
+    captured = capsys.readouterr()
+
+    assert str(excinfo.value).startswith("error: ")
+    assert missing in str(excinfo.value)
+    assert captured.err == ""
 
 
 def test_real_brief_workflow_adapter_public_export_is_lazy():

--- a/tests/test_real_brief_workflow_adapter.py
+++ b/tests/test_real_brief_workflow_adapter.py
@@ -118,6 +118,42 @@ def test_adapt_real_brief_package_writes_supported_visual_workflow(tmp_path):
     )
 
 
+def test_adapt_real_brief_package_generated_artifacts_do_not_leak_secrets(tmp_path):
+    from vulca.real_brief.workflow_adapter import adapt_real_brief_package
+
+    source_package = _source_package(
+        tmp_path,
+        "seattle-polish-film-festival-poster",
+    )
+
+    adapt_real_brief_package(
+        source_package=source_package,
+        root=tmp_path / "repo",
+        date="2026-05-01",
+    )
+
+    project_dir = (
+        tmp_path
+        / "repo"
+        / "docs"
+        / "visual-specs"
+        / "seattle-polish-film-festival-poster"
+    )
+    generated_files = sorted(
+        path
+        for path in project_dir.rglob("*")
+        if path.suffix in {".md", ".json", ".txt"}
+    )
+
+    assert generated_files
+    for generated_file in generated_files:
+        text = generated_file.read_text(encoding="utf-8")
+        assert "sk-" not in text, generated_file
+        assert "VULCA_REAL_PROVIDER_API_KEY" not in text, generated_file
+        assert "OPENAI_API_KEY" not in text, generated_file
+        assert "globalai" not in text.casefold(), generated_file
+
+
 def test_adapt_real_brief_package_dry_run_writes_nothing(tmp_path):
     from vulca.real_brief.workflow_adapter import adapt_real_brief_package
 


### PR DESCRIPTION
## Summary
- add Phase 2 adapter from real-brief benchmark packages to docs/visual-specs/<slug>/
- write discovery/, real_brief/, and workflow_seed.md artifacts without provider execution
- preserve /visual-brainstorm, /visual-spec, and /visual-plan human gates
- mark public_art and video_treatment as unsupported for static visual workflow v1
- harden source package copying against symlink/path escape and keep adapter imports offline

## Tests
- PYTHONPATH=src python3 -m pytest tests/test_real_brief_benchmark.py tests/test_real_brief_workflow_adapter.py -q -> 76 passed
- PYTHONPATH=src python3 -m pytest tests/test_visual_discovery_benchmark.py tests/test_visual_discovery_artifacts.py tests/test_visual_discovery_cards.py tests/test_visual_discovery_types.py -q -> 22 passed
- End-to-end dry run: real_brief_benchmark.py -> real_brief_workflow_adapter.py generated discovery/, real_brief/, and workflow_seed.md under /private/tmp/vulca-real-brief-phase2-target-final2 without provider execution
