### PR TITLE
feat: seed real brief brainstorm proposals

### DIFF
--- a/.agents/skills/visual-brainstorm/SKILL.md
+++ b/.agents/skills/visual-brainstorm/SKILL.md
@@ -35,13 +35,20 @@ Before the first turn, scan the topic and any args for scope violations:
 2. **If the target `docs/visual-specs/<slug>/proposal.md` already exists** — read its frontmatter:
    - `status: ready` → Error #1: refuse to overwrite; print branch instructions; terminate.
    - `status: draft` → **resume path**: read the `## Open questions` section; continue the question loop from there; preserve accumulated turn count. **Skip** the A2 solicited-sketch question (turn 1 was already spent in the original draft). On successful finalize, **bump** `updated:` to today's date; leave `created:` unchanged.
-3. **If no sketch was provided**, open with this solicited-sketch question (A2):
+3. **If no proposal exists but `workflow_seed.md` and `real_brief/adapter_manifest.json` exist**:
+   - Read `real_brief/adapter_manifest.json`.
+   - If `workflow_status: ready_for_visual_brainstorm`, run the real-brief seed step instead of starting from an empty question loop:
+     `PYTHONPATH=src python3 scripts/real_brief_brainstorm_seed.py --slug <slug> --date <YYYY-MM-DD>`.
+   - Show the generated `proposal.md` draft in full and continue from `## Open questions`.
+   - Do not flip `status: draft` to `ready` until the user says `finalize` / `done` / `ready` / `lock it` / `approve`.
+   - If `workflow_status` is not `ready_for_visual_brainstorm`, print the unsupported status and terminate.
+4. **If no sketch was provided**, open with this solicited-sketch question (A2):
 
    > "Do you have a sketch or reference image I should look at? Paste a path if yes, or say 'no' to continue text-only."
 
    If yes → call `view_image` once on the path for grounding. If no → proceed text-only. Either answer counts as turn 1.
-4. **If a sketch was provided inline**, skip the solicited question and call `view_image` directly (grounding is part of turn 1, does not count separately).
-5. **If `--ref-dir <path>` was provided**, list the images in that directory by filename (do NOT call `view_image` or analyze pixels). Ask the user which to record in `## References`. Accept a subset, "all", or "none". Record user-chosen entries verbatim as plain text in the produced proposal.md's `## References` section. Listing + confirm counts as 1 turn.
+5. **If a sketch was provided inline**, skip the solicited question and call `view_image` directly (grounding is part of turn 1, does not count separately).
+6. **If `--ref-dir <path>` was provided**, list the images in that directory by filename (do NOT call `view_image` or analyze pixels). Ask the user which to record in `## References`. Accept a subset, "all", or "none". Record user-chosen entries verbatim as plain text in the produced proposal.md's `## References` section. Listing + confirm counts as 1 turn.
 
 ## Slug generation
 

--- a/.claude/skills/visual-brainstorm/SKILL.md
+++ b/.claude/skills/visual-brainstorm/SKILL.md
@@ -35,13 +35,20 @@ Before the first turn, scan the topic and any args for scope violations:
 2. **If the target `docs/visual-specs/<slug>/proposal.md` already exists** — read its frontmatter:
    - `status: ready` → Error #1: refuse to overwrite; print branch instructions; terminate.
    - `status: draft` → **resume path**: read the `## Open questions` section; continue the question loop from there; preserve accumulated turn count. **Skip** the A2 solicited-sketch question (turn 1 was already spent in the original draft). On successful finalize, **bump** `updated:` to today's date; leave `created:` unchanged.
-3. **If no sketch was provided**, open with this solicited-sketch question (A2):
+3. **If no proposal exists but `workflow_seed.md` and `real_brief/adapter_manifest.json` exist**:
+   - Read `real_brief/adapter_manifest.json`.
+   - If `workflow_status: ready_for_visual_brainstorm`, run the real-brief seed step instead of starting from an empty question loop:
+     `PYTHONPATH=src python3 scripts/real_brief_brainstorm_seed.py --slug <slug> --date <YYYY-MM-DD>`.
+   - Show the generated `proposal.md` draft in full and continue from `## Open questions`.
+   - Do not flip `status: draft` to `ready` until the user says `finalize` / `done` / `ready` / `lock it` / `approve`.
+   - If `workflow_status` is not `ready_for_visual_brainstorm`, print the unsupported status and terminate.
+4. **If no sketch was provided**, open with this solicited-sketch question (A2):
 
    > "Do you have a sketch or reference image I should look at? Paste a path if yes, or say 'no' to continue text-only."
 
    If yes → call `view_image` once on the path for grounding. If no → proceed text-only. Either answer counts as turn 1.
-4. **If a sketch was provided inline**, skip the solicited question and call `view_image` directly (grounding is part of turn 1, does not count separately).
-5. **If `--ref-dir <path>` was provided**, list the images in that directory by filename (do NOT call `view_image` or analyze pixels). Ask the user which to record in `## References`. Accept a subset, "all", or "none". Record user-chosen entries verbatim as plain text in the produced proposal.md's `## References` section. Listing + confirm counts as 1 turn.
+5. **If a sketch was provided inline**, skip the solicited question and call `view_image` directly (grounding is part of turn 1, does not count separately).
+6. **If `--ref-dir <path>` was provided**, list the images in that directory by filename (do NOT call `view_image` or analyze pixels). Ask the user which to record in `## References`. Accept a subset, "all", or "none". Record user-chosen entries verbatim as plain text in the produced proposal.md's `## References` section. Listing + confirm counts as 1 turn.
 
 ## Slug generation
 

--- a/docs/superpowers/plans/2026-05-01-real-brief-brainstorm-seed.md
+++ b/docs/superpowers/plans/2026-05-01-real-brief-brainstorm-seed.md
@@ -1,0 +1,83 @@
+# Real Brief Brainstorm Seed Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Generate a draft `/visual-brainstorm` `proposal.md` from Phase 2 real-brief workflow seed artifacts.
+
+**Architecture:** Add a small `vulca.real_brief.brainstorm_seed` module plus CLI wrapper. The module reads an adapted visual-spec project directory, validates its real-brief seed status, renders the existing proposal schema, and writes only `proposal.md`.
+
+**Tech Stack:** Python standard library, pytest, existing Vulca real-brief artifact helpers.
+
+---
+
+### Task 1: Proposal Seeder Tests
+
+**Files:**
+- Create: `tests/test_real_brief_brainstorm_seed.py`
+
+- [ ] **Step 1: Write tests for supported seed generation**
+
+Use `write_real_brief_dry_run` and `adapt_real_brief_package` to create a seeded project in `tmp_path`, call `seed_real_brief_brainstorm_proposal`, and assert `proposal.md` exists with `status: draft`, `domain: poster`, `tradition: null`, `style_treatment: unified`, brief-specific content, and human gate open questions.
+
+- [ ] **Step 2: Write tests for gates and CLI**
+
+Cover ready proposal overwrite refusal, draft overwrite requiring force, unsupported seed refusal, dry-run no-write behavior, CLI write behavior, and secret leakage.
+
+- [ ] **Step 3: Verify red**
+
+Run `PYTHONPATH=src python3 -m pytest tests/test_real_brief_brainstorm_seed.py -q`. Expected: import failure for `vulca.real_brief.brainstorm_seed`.
+
+### Task 2: Proposal Seeder Module
+
+**Files:**
+- Create: `src/vulca/real_brief/brainstorm_seed.py`
+- Modify: `src/vulca/real_brief/__init__.py`
+
+- [ ] **Step 1: Implement loader and validation**
+
+Read `workflow_seed.md`, `real_brief/adapter_manifest.json`, `real_brief/structured_brief.json`, and `real_brief/workflow_handoff.json`. Require `workflow_status == ready_for_visual_brainstorm`, `human_gate_required is true`, and a supported visual domain.
+
+- [ ] **Step 2: Implement proposal renderer**
+
+Render exactly the `/visual-brainstorm` proposal template with eight frontmatter fields and non-empty sections. Use `tradition: null`, `status: draft`, and `style_treatment: unified`.
+
+- [ ] **Step 3: Implement write gates**
+
+Refuse finalized `proposal.md`, refuse draft overwrite without `force=True`, support `dry_run=True`, and return paths/status in a result dict.
+
+- [ ] **Step 4: Export lazily**
+
+Add `seed_real_brief_brainstorm_proposal` to `vulca.real_brief.__all__` and `_LAZY_EXPORTS` without importing provider-facing modules.
+
+### Task 3: CLI and Skill Contract
+
+**Files:**
+- Create: `scripts/real_brief_brainstorm_seed.py`
+- Modify: `skills/visual-brainstorm/SKILL.md`
+- Modify: `.agents/skills/visual-brainstorm/SKILL.md`
+- Modify: `.claude/skills/visual-brainstorm/SKILL.md`
+
+- [ ] **Step 1: Add CLI**
+
+Accept `--root`, `--slug`, `--date`, `--force`, and `--dry-run`; print JSON result.
+
+- [ ] **Step 2: Update skill docs**
+
+Document that when `workflow_seed.md` and `real_brief/adapter_manifest.json` exist with `ready_for_visual_brainstorm`, `/visual-brainstorm <slug>` should seed or resume `proposal.md` from the real brief package, then show the full draft and wait for explicit `ready` or equivalent.
+
+### Task 4: Verification and Publish
+
+**Files:**
+- Test files and changed implementation files.
+
+- [ ] **Step 1: Run focused tests**
+
+Run `PYTHONPATH=src python3 -m pytest tests/test_real_brief_brainstorm_seed.py tests/test_real_brief_workflow_adapter.py -q`.
+
+- [ ] **Step 2: Run adjacent workflow tests**
+
+Run `PYTHONPATH=src python3 -m pytest tests/test_real_brief_benchmark.py tests/test_visual_brainstorm_discovery_integration.py tests/test_visual_discovery_artifacts.py tests/test_visual_discovery_cards.py tests/test_visual_discovery_types.py -q`.
+
+- [ ] **Step 3: Commit and push**
+
+Commit the isolated branch and open a PR against `master`.

--- a/docs/superpowers/specs/2026-05-01-real-brief-brainstorm-seed-design.md
+++ b/docs/superpowers/specs/2026-05-01-real-brief-brainstorm-seed-design.md
@@ -1,0 +1,30 @@
+# Real Brief Brainstorm Seed Design
+
+## Goal
+
+Convert a Phase 2 real-brief workflow seed into a draft `/visual-brainstorm` proposal so real commercial briefs can enter the existing `proposal.md -> design.md -> plan.md -> evaluate` chain without bypassing the human gate.
+
+## Scope
+
+This phase adds an offline proposal seeding step for supported static visual domains. It reads `docs/visual-specs/<slug>/workflow_seed.md`, `real_brief/structured_brief.json`, and `real_brief/workflow_handoff.json`, then writes `docs/visual-specs/<slug>/proposal.md` with `status: draft`.
+
+It does not finalize the proposal, invoke image providers, run `/visual-spec`, or judge image quality.
+
+## Approach
+
+Add a focused Python module under `vulca.real_brief` that owns the mapping from real brief fields to the existing `/visual-brainstorm` proposal schema. Add a small CLI wrapper for repeatable local use and tests. Update the skill text so an agent running `/visual-brainstorm <slug>` checks for a real-brief seed and uses the seeded proposal as the first draft instead of starting from an empty question loop.
+
+## Behavior
+
+- Supported domains remain the same as the Phase 2 adapter: `poster`, `packaging`, `brand_visual`, `illustration`, `editorial_cover`, `photography_brief`, and `hero_visual_for_ui`.
+- Unsupported workflow seeds are refused with a clear error.
+- Existing `proposal.md` with `status: ready` is never overwritten.
+- Existing draft proposal requires an explicit `force=True` or CLI `--force`.
+- The generated proposal keeps exactly the eight frontmatter fields required by `/visual-brainstorm`.
+- `style_treatment` defaults to `unified` unless the real brief handoff later supplies a stricter value.
+- `tradition` is YAML `null`; this keeps the cultural rubric honest until a human declares a tradition.
+- The proposal includes the copied real brief source, deliverables, constraints, risks, and open questions so the user can review it inline before approving.
+
+## Testing
+
+Tests cover supported proposal generation, overwrite gates, unsupported seed refusal, CLI dry-run/write behavior, and secret leakage checks. Existing Phase 2 adapter and visual discovery tests must continue passing.

--- a/plugins/vulca/skills/visual-brainstorm/SKILL.md
+++ b/plugins/vulca/skills/visual-brainstorm/SKILL.md
@@ -35,13 +35,20 @@ Before the first turn, scan the topic and any args for scope violations:
 2. **If the target `docs/visual-specs/<slug>/proposal.md` already exists** — read its frontmatter:
    - `status: ready` → Error #1: refuse to overwrite; print branch instructions; terminate.
    - `status: draft` → **resume path**: read the `## Open questions` section; continue the question loop from there; preserve accumulated turn count. **Skip** the A2 solicited-sketch question (turn 1 was already spent in the original draft). On successful finalize, **bump** `updated:` to today's date; leave `created:` unchanged.
-3. **If no sketch was provided**, open with this solicited-sketch question (A2):
+3. **If no proposal exists but `workflow_seed.md` and `real_brief/adapter_manifest.json` exist**:
+   - Read `real_brief/adapter_manifest.json`.
+   - If `workflow_status: ready_for_visual_brainstorm`, run the real-brief seed step instead of starting from an empty question loop:
+     `PYTHONPATH=src python3 scripts/real_brief_brainstorm_seed.py --slug <slug> --date <YYYY-MM-DD>`.
+   - Show the generated `proposal.md` draft in full and continue from `## Open questions`.
+   - Do not flip `status: draft` to `ready` until the user says `finalize` / `done` / `ready` / `lock it` / `approve`.
+   - If `workflow_status` is not `ready_for_visual_brainstorm`, print the unsupported status and terminate.
+4. **If no sketch was provided**, open with this solicited-sketch question (A2):
 
    > "Do you have a sketch or reference image I should look at? Paste a path if yes, or say 'no' to continue text-only."
 
    If yes → call `view_image` once on the path for grounding. If no → proceed text-only. Either answer counts as turn 1.
-4. **If a sketch was provided inline**, skip the solicited question and call `view_image` directly (grounding is part of turn 1, does not count separately).
-5. **If `--ref-dir <path>` was provided**, list the images in that directory by filename (do NOT call `view_image` or analyze pixels). Ask the user which to record in `## References`. Accept a subset, "all", or "none". Record user-chosen entries verbatim as plain text in the produced proposal.md's `## References` section. Listing + confirm counts as 1 turn.
+5. **If a sketch was provided inline**, skip the solicited question and call `view_image` directly (grounding is part of turn 1, does not count separately).
+6. **If `--ref-dir <path>` was provided**, list the images in that directory by filename (do NOT call `view_image` or analyze pixels). Ask the user which to record in `## References`. Accept a subset, "all", or "none". Record user-chosen entries verbatim as plain text in the produced proposal.md's `## References` section. Listing + confirm counts as 1 turn.
 
 ## Slug generation
 

--- a/scripts/real_brief_brainstorm_seed.py
+++ b/scripts/real_brief_brainstorm_seed.py
@@ -1,0 +1,42 @@
+"""CLI wrapper for seeding /visual-brainstorm proposals from real-brief packages."""
+from __future__ import annotations
+
+import argparse
+import json
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Seed a draft /visual-brainstorm proposal from real-brief artifacts."
+    )
+    parser.add_argument("--root", default=".")
+    parser.add_argument("--slug", required=True)
+    parser.add_argument("--date", required=True)
+    parser.add_argument("--force", action="store_true")
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args(argv)
+
+    from vulca.real_brief.brainstorm_seed import (
+        seed_real_brief_brainstorm_proposal,
+    )
+
+    result = seed_real_brief_brainstorm_proposal(
+        root=args.root,
+        slug=args.slug,
+        date=args.date,
+        force=args.force,
+        dry_run=args.dry_run,
+    )
+    print(json.dumps(result, ensure_ascii=False, indent=2, sort_keys=True))
+    return 0
+
+
+def _cli() -> int:
+    try:
+        return main()
+    except (FileNotFoundError, RuntimeError, ValueError) as exc:
+        raise SystemExit(f"error: {exc}") from None
+
+
+if __name__ == "__main__":
+    raise SystemExit(_cli())

--- a/skills/visual-brainstorm/SKILL.md
+++ b/skills/visual-brainstorm/SKILL.md
@@ -35,13 +35,20 @@ Before the first turn, scan the topic and any args for scope violations:
 2. **If the target `docs/visual-specs/<slug>/proposal.md` already exists** — read its frontmatter:
    - `status: ready` → Error #1: refuse to overwrite; print branch instructions; terminate.
    - `status: draft` → **resume path**: read the `## Open questions` section; continue the question loop from there; preserve accumulated turn count. **Skip** the A2 solicited-sketch question (turn 1 was already spent in the original draft). On successful finalize, **bump** `updated:` to today's date; leave `created:` unchanged.
-3. **If no sketch was provided**, open with this solicited-sketch question (A2):
+3. **If no proposal exists but `workflow_seed.md` and `real_brief/adapter_manifest.json` exist**:
+   - Read `real_brief/adapter_manifest.json`.
+   - If `workflow_status: ready_for_visual_brainstorm`, run the real-brief seed step instead of starting from an empty question loop:
+     `PYTHONPATH=src python3 scripts/real_brief_brainstorm_seed.py --slug <slug> --date <YYYY-MM-DD>`.
+   - Show the generated `proposal.md` draft in full and continue from `## Open questions`.
+   - Do not flip `status: draft` to `ready` until the user says `finalize` / `done` / `ready` / `lock it` / `approve`.
+   - If `workflow_status` is not `ready_for_visual_brainstorm`, print the unsupported status and terminate.
+4. **If no sketch was provided**, open with this solicited-sketch question (A2):
 
    > "Do you have a sketch or reference image I should look at? Paste a path if yes, or say 'no' to continue text-only."
 
    If yes → call `view_image` once on the path for grounding. If no → proceed text-only. Either answer counts as turn 1.
-4. **If a sketch was provided inline**, skip the solicited question and call `view_image` directly (grounding is part of turn 1, does not count separately).
-5. **If `--ref-dir <path>` was provided**, list the images in that directory by filename (do NOT call `view_image` or analyze pixels). Ask the user which to record in `## References`. Accept a subset, "all", or "none". Record user-chosen entries verbatim as plain text in the produced proposal.md's `## References` section. Listing + confirm counts as 1 turn.
+5. **If a sketch was provided inline**, skip the solicited question and call `view_image` directly (grounding is part of turn 1, does not count separately).
+6. **If `--ref-dir <path>` was provided**, list the images in that directory by filename (do NOT call `view_image` or analyze pixels). Ask the user which to record in `## References`. Accept a subset, "all", or "none". Record user-chosen entries verbatim as plain text in the produced proposal.md's `## References` section. Listing + confirm counts as 1 turn.
 
 ## Slug generation
 

--- a/src/vulca/real_brief/__init__.py
+++ b/src/vulca/real_brief/__init__.py
@@ -24,6 +24,7 @@ __all__ = [
     "Deliverable",
     "get_real_brief_fixture",
     "RealBriefFixture",
+    "seed_real_brief_brainstorm_proposal",
     "SourceInfo",
     "safe_slug",
     "write_real_brief_dry_run",
@@ -33,6 +34,10 @@ _LAZY_EXPORTS = {
     "adapt_real_brief_package": (
         "vulca.real_brief.workflow_adapter",
         "adapt_real_brief_package",
+    ),
+    "seed_real_brief_brainstorm_proposal": (
+        "vulca.real_brief.brainstorm_seed",
+        "seed_real_brief_brainstorm_proposal",
     ),
     "brief_digest": ("vulca.real_brief.conditions", "brief_digest"),
     "build_real_brief_conditions": (

--- a/src/vulca/real_brief/brainstorm_seed.py
+++ b/src/vulca/real_brief/brainstorm_seed.py
@@ -1,0 +1,351 @@
+"""Seed /visual-brainstorm proposal drafts from adapted real-brief packages."""
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+from vulca.real_brief.types import safe_slug
+from vulca.real_brief.workflow_adapter import SUPPORTED_STATIC_VISUAL_DOMAINS
+
+
+_RUN_DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+_STATUS_RE = re.compile(r"(?im)^\s*status\s*:\s*([a-z0-9_-]+)\s*$")
+_ALLOWED_STYLE_TREATMENTS = {"additive", "unified", "collage", "wash"}
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _safe_date(date: str) -> str:
+    if not _RUN_DATE_RE.fullmatch(date):
+        raise ValueError("date must use YYYY-MM-DD")
+    return date
+
+
+def _project_dir(root: Path, slug: str) -> Path:
+    return root / "docs" / "visual-specs" / slug
+
+
+def _status_from_markdown(path: Path) -> str:
+    match = _STATUS_RE.search(path.read_text(encoding="utf-8"))
+    return match.group(1).lower() if match else ""
+
+
+def _require_file(path: Path) -> Path:
+    if not path.exists():
+        raise FileNotFoundError(f"required brainstorm seed file missing: {path}")
+    return path
+
+
+def _bullet_list(items: list[Any]) -> str:
+    values = [str(item).strip() for item in items if str(item).strip()]
+    return "\n".join(f"- {item}" for item in values) if values else "none"
+
+
+def _deliverable_lines(deliverables: list[dict[str, Any]]) -> str:
+    lines = []
+    for item in deliverables:
+        name = str(item.get("name") or "deliverable").strip()
+        fmt = str(item.get("format") or "unspecified format").strip()
+        channel = str(item.get("channel") or "unspecified channel").strip()
+        required = item.get("required", True)
+        suffix = "" if required else " (optional)"
+        lines.append(f"- {name} ({fmt}, {channel}){suffix}")
+    return "\n".join(lines) if lines else "none"
+
+
+def _color_constraints(constraints: list[str]) -> str:
+    matches = [
+        item
+        for item in constraints
+        if any(term in item.casefold() for term in ("color", "colour", "palette"))
+    ]
+    return _bullet_list(matches) if matches else "none specified"
+
+
+def _style_treatment(handoff: dict[str, Any]) -> str:
+    seed = handoff.get("visual_brainstorm_seed", {})
+    value = str(seed.get("style_treatment") or "unified").strip().lower()
+    return value if value in _ALLOWED_STYLE_TREATMENTS else "unified"
+
+
+def _series_plan(deliverables: list[dict[str, Any]]) -> str:
+    if len(deliverables) <= 1:
+        return "none"
+    names = [str(item.get("name") or "deliverable").strip() for item in deliverables]
+    return "\n".join(
+        [
+            f"- Deliverable count: {len(deliverables)}",
+            "- Variation axis: adapt one approved key direction across required formats.",
+            "- Deliverables:",
+            *[f"  - {name}" for name in names],
+        ]
+    )
+
+
+def _references(structured: dict[str, Any], project_dir: Path) -> str:
+    source = structured.get("source", {})
+    lines = [
+        f"- source: {source.get('url')}",
+        f"- source retrieved on: {source.get('retrieved_on')}",
+        "- copied real brief package: real_brief/",
+        "- workflow seed: workflow_seed.md",
+    ]
+    if source.get("deadline"):
+        lines.append(f"- source deadline: {source['deadline']}")
+    lines.append(f"- project directory: {project_dir}")
+    return "\n".join(str(line) for line in lines if "None" not in str(line))
+
+
+def _intent(structured: dict[str, Any]) -> str:
+    parts = [
+        str(structured.get("context") or "").strip(),
+        str(structured.get("source_brief") or "").strip(),
+    ]
+    text = " ".join(part for part in parts if part)
+    return text or str(structured.get("title") or "none").strip()
+
+
+def _market(structured: dict[str, Any]) -> str:
+    client = str(structured.get("client") or "").strip()
+    source = structured.get("source", {})
+    source_url = str(source.get("url") or "").strip()
+    if client or source_url:
+        return (
+            "Market not explicitly specified by the source brief. "
+            f"Use client/source context only: {client or source_url}."
+        )
+    return "domestic, no multilingual"
+
+
+def _budget_deadline(structured: dict[str, Any]) -> str:
+    source = structured.get("source", {})
+    lines = [
+        f"- Budget: {structured.get('budget') or 'none specified'}",
+        f"- Timeline: {structured.get('timeline') or 'none specified'}",
+    ]
+    if source.get("deadline"):
+        lines.append(f"- Source deadline: {source['deadline']}")
+    return "\n".join(lines)
+
+
+def _questions_resolved(structured: dict[str, Any], handoff: dict[str, Any]) -> str:
+    seed = handoff.get("visual_brainstorm_seed", {})
+    return "\n".join(
+        [
+            "- Q: What is the source brief?",
+            f"  A: {structured.get('title')}",
+            "- Q: Which workflow stage owns this draft?",
+            "  A: /visual-brainstorm owns proposal.md; downstream stages remain gated.",
+            "- Q: Which domain should the visual chain use?",
+            f"  A: {seed.get('domain') or structured.get('domain')}",
+            "- Q: Should provider execution happen now?",
+            "  A: No. This is a simulation-only planning seed.",
+        ]
+    )
+
+
+def _open_questions() -> str:
+    return "\n".join(
+        [
+            "- Which stakeholder approves the final direction?",
+            "- Which deliverable must be most production-ready first?",
+            "- Which source assets already exist?",
+            "- Should style_treatment remain unified, or change to additive, collage, or wash?",
+            "- Should a validated cultural tradition be declared before /visual-spec?",
+            "- Human approval required before `/visual-spec`.",
+        ]
+    )
+
+
+def _notes(structured: dict[str, Any]) -> str:
+    constraints = _bullet_list(list(structured.get("constraints", [])))
+    risks = _bullet_list(list(structured.get("risks", [])))
+    avoid = _bullet_list(list(structured.get("avoid", [])))
+    return "\n".join(
+        [
+            "Real brief seed imported from a simulation-only benchmark package.",
+            "No image provider, redraw provider, or evaluator is invoked by this step.",
+            "",
+            "Constraints:",
+            constraints,
+            "",
+            "Risks:",
+            risks,
+            "",
+            "Rejected approaches / avoid:",
+            avoid,
+        ]
+    )
+
+
+def _proposal_markdown(
+    *,
+    project_dir: Path,
+    structured: dict[str, Any],
+    handoff: dict[str, Any],
+    date: str,
+) -> str:
+    slug = safe_slug(str(structured.get("slug") or handoff.get("slug") or ""))
+    title = str(structured.get("title") or slug)
+    domain = str(
+        structured.get("domain")
+        or handoff.get("visual_brainstorm_seed", {}).get("domain")
+        or ""
+    )
+    style_treatment = _style_treatment(handoff)
+    audience = _bullet_list(list(structured.get("audience", [])))
+    deliverables = list(structured.get("deliverables", []))
+    constraints = list(structured.get("constraints", []))
+
+    return "\n".join(
+        [
+            "---",
+            f"slug: {slug}",
+            "status: draft",
+            f"domain: {domain}",
+            "tradition: null",
+            f"style_treatment: {style_treatment}",
+            "generated_by: visual-brainstorm@0.1.0",
+            f"created: {date}",
+            f"updated: {date}",
+            "---",
+            "",
+            f"# {title}",
+            "",
+            (
+                "> Seeded from `real_brief/` artifacts. This is a draft; "
+                "human approval is still required before `/visual-spec`."
+            ),
+            "",
+            "## Intent",
+            _intent(structured),
+            "",
+            "## Audience",
+            audience,
+            "",
+            "## Physical form",
+            _deliverable_lines(deliverables),
+            "",
+            "## Market",
+            _market(structured),
+            "",
+            "## Budget & deadline",
+            _budget_deadline(structured),
+            "",
+            "## Color constraints",
+            _color_constraints(constraints),
+            "",
+            "## References",
+            _references(structured, project_dir),
+            "",
+            "## Series plan",
+            _series_plan(deliverables),
+            "",
+            "## Acceptance rubric",
+            "none",
+            "",
+            "## Questions resolved",
+            _questions_resolved(structured, handoff),
+            "",
+            "## Open questions",
+            _open_questions(),
+            "",
+            "## Notes",
+            _notes(structured),
+            "",
+        ]
+    )
+
+
+def _load_seed(project_dir: Path) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any]]:
+    _require_file(project_dir / "workflow_seed.md")
+    real_brief_dir = project_dir / "real_brief"
+    adapter_manifest = _read_json(
+        _require_file(real_brief_dir / "adapter_manifest.json")
+    )
+    structured = _read_json(_require_file(real_brief_dir / "structured_brief.json"))
+    handoff = _read_json(_require_file(real_brief_dir / "workflow_handoff.json"))
+    return adapter_manifest, structured, handoff
+
+
+def _assert_ready_seed(
+    adapter_manifest: dict[str, Any],
+    structured: dict[str, Any],
+    handoff: dict[str, Any],
+) -> None:
+    status = adapter_manifest.get("workflow_status")
+    if status != "ready_for_visual_brainstorm":
+        raise RuntimeError(
+            f"real brief seed is not ready_for_visual_brainstorm: {status}"
+        )
+    if adapter_manifest.get("human_gate_required") is not True:
+        raise ValueError("adapter_manifest.human_gate_required must be true")
+    if handoff.get("human_gate_required") is not True:
+        raise ValueError("workflow_handoff.human_gate_required must be true")
+
+    domain = str(
+        structured.get("domain")
+        or handoff.get("visual_brainstorm_seed", {}).get("domain")
+        or adapter_manifest.get("visual_workflow_domain")
+        or ""
+    )
+    if domain not in SUPPORTED_STATIC_VISUAL_DOMAINS:
+        raise RuntimeError(f"unsupported visual brainstorm domain: {domain}")
+
+
+def _assert_can_write(proposal_path: Path, force: bool) -> None:
+    if not proposal_path.exists():
+        return
+
+    status = _status_from_markdown(proposal_path)
+    if status == "ready":
+        raise RuntimeError(f"already finalized at {proposal_path}")
+    if not force:
+        raise RuntimeError(
+            f"{proposal_path} already exists; pass force=True to overwrite"
+        )
+
+
+def seed_real_brief_brainstorm_proposal(
+    *,
+    root: str | Path,
+    slug: str,
+    date: str,
+    dry_run: bool = False,
+    force: bool = False,
+) -> dict[str, str]:
+    """Write a draft /visual-brainstorm proposal from an adapted real brief seed."""
+    safe = safe_slug(slug)
+    safe_date = _safe_date(date)
+    root_path = Path(root)
+    project_dir = _project_dir(root_path, safe)
+    proposal_path = project_dir / "proposal.md"
+
+    adapter_manifest, structured, handoff = _load_seed(project_dir)
+    _assert_ready_seed(adapter_manifest, structured, handoff)
+    _assert_can_write(proposal_path, force)
+
+    result = {
+        "slug": safe,
+        "status": "draft",
+        "project_dir": str(project_dir),
+        "proposal_md": str(proposal_path),
+    }
+    if dry_run:
+        result["dry_run"] = "true"
+        return result
+
+    proposal_path.write_text(
+        _proposal_markdown(
+            project_dir=project_dir,
+            structured=structured,
+            handoff=handoff,
+            date=safe_date,
+        ),
+        encoding="utf-8",
+    )
+    return result

--- a/tests/test_real_brief_brainstorm_seed.py
+++ b/tests/test_real_brief_brainstorm_seed.py
@@ -1,0 +1,262 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+def _source_package(tmp_path: Path, slug: str) -> Path:
+    from vulca.real_brief.artifacts import write_real_brief_dry_run
+
+    result = write_real_brief_dry_run(
+        output_root=tmp_path / "source",
+        slug=slug,
+        date="2026-05-01",
+        write_html_review=False,
+    )
+    return Path(result["output_dir"])
+
+
+def _adapted_project(tmp_path: Path, slug: str) -> Path:
+    from vulca.real_brief.workflow_adapter import adapt_real_brief_package
+
+    source_package = _source_package(tmp_path, slug)
+    result = adapt_real_brief_package(
+        source_package=source_package,
+        root=tmp_path / "repo",
+        date="2026-05-01",
+    )
+    return Path(result["project_dir"])
+
+
+def _frontmatter(markdown: str) -> dict[str, str]:
+    assert markdown.startswith("---\n")
+    frontmatter = markdown.split("---\n", 2)[1]
+    parsed: dict[str, str] = {}
+    for line in frontmatter.strip().splitlines():
+        key, value = line.split(": ", 1)
+        parsed[key] = value
+    return parsed
+
+
+def test_seed_real_brief_brainstorm_proposal_writes_draft_proposal(tmp_path):
+    from vulca.real_brief.brainstorm_seed import (
+        seed_real_brief_brainstorm_proposal,
+    )
+
+    project_dir = _adapted_project(tmp_path, "seattle-polish-film-festival-poster")
+
+    result = seed_real_brief_brainstorm_proposal(
+        root=tmp_path / "repo",
+        slug="seattle-polish-film-festival-poster",
+        date="2026-05-01",
+    )
+
+    proposal_path = project_dir / "proposal.md"
+    assert result == {
+        "slug": "seattle-polish-film-festival-poster",
+        "status": "draft",
+        "project_dir": str(project_dir),
+        "proposal_md": str(proposal_path),
+    }
+    assert proposal_path.exists()
+
+    proposal = proposal_path.read_text(encoding="utf-8")
+    frontmatter = _frontmatter(proposal)
+    assert list(frontmatter) == [
+        "slug",
+        "status",
+        "domain",
+        "tradition",
+        "style_treatment",
+        "generated_by",
+        "created",
+        "updated",
+    ]
+    assert frontmatter["slug"] == "seattle-polish-film-festival-poster"
+    assert frontmatter["status"] == "draft"
+    assert frontmatter["domain"] == "poster"
+    assert frontmatter["tradition"] == "null"
+    assert frontmatter["style_treatment"] == "unified"
+    assert frontmatter["generated_by"] == "visual-brainstorm@0.1.0"
+    assert frontmatter["created"] == "2026-05-01"
+    assert frontmatter["updated"] == "2026-05-01"
+
+    assert "# Seattle Polish Film Festival Poster" in proposal
+    assert "## Intent" in proposal
+    assert "Signature poster concept for the 34th festival edition." in proposal
+    assert "festival attendees" in proposal
+    assert "poster concept (11 x 17 in vertical, print/digital)" in proposal
+    assert "bottom sponsor or patron logo band must remain available" in proposal
+    assert "not specified by source" in proposal
+    assert "source: https://www.polishfilms.org/submit-a-poster" in proposal
+    assert "## Acceptance rubric\nnone" in proposal
+    assert "Which stakeholder approves the final direction?" in proposal
+    assert "Human approval required before `/visual-spec`." in proposal
+
+
+def test_seed_real_brief_brainstorm_proposal_dry_run_writes_nothing(tmp_path):
+    from vulca.real_brief.brainstorm_seed import (
+        seed_real_brief_brainstorm_proposal,
+    )
+
+    project_dir = _adapted_project(tmp_path, "gsm-community-market-campaign")
+
+    result = seed_real_brief_brainstorm_proposal(
+        root=tmp_path / "repo",
+        slug="gsm-community-market-campaign",
+        date="2026-05-01",
+        dry_run=True,
+    )
+
+    assert result["dry_run"] == "true"
+    assert result["status"] == "draft"
+    assert not (project_dir / "proposal.md").exists()
+
+
+def test_seed_real_brief_brainstorm_proposal_refuses_ready_proposal(tmp_path):
+    from vulca.real_brief.brainstorm_seed import (
+        seed_real_brief_brainstorm_proposal,
+    )
+
+    project_dir = _adapted_project(tmp_path, "seattle-polish-film-festival-poster")
+    (project_dir / "proposal.md").write_text(
+        "---\nstatus: ready\n---\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(RuntimeError, match="already finalized"):
+        seed_real_brief_brainstorm_proposal(
+            root=tmp_path / "repo",
+            slug="seattle-polish-film-festival-poster",
+            date="2026-05-01",
+        )
+
+
+def test_seed_real_brief_brainstorm_proposal_requires_force_for_draft(tmp_path):
+    from vulca.real_brief.brainstorm_seed import (
+        seed_real_brief_brainstorm_proposal,
+    )
+
+    project_dir = _adapted_project(tmp_path, "seattle-polish-film-festival-poster")
+    proposal_path = project_dir / "proposal.md"
+    proposal_path.write_text(
+        "---\nstatus: draft\n---\n\n# Existing\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(RuntimeError, match="pass force=True"):
+        seed_real_brief_brainstorm_proposal(
+            root=tmp_path / "repo",
+            slug="seattle-polish-film-festival-poster",
+            date="2026-05-01",
+        )
+
+    seed_real_brief_brainstorm_proposal(
+        root=tmp_path / "repo",
+        slug="seattle-polish-film-festival-poster",
+        date="2026-05-01",
+        force=True,
+    )
+    assert "# Seattle Polish Film Festival Poster" in proposal_path.read_text(
+        encoding="utf-8"
+    )
+
+
+def test_seed_real_brief_brainstorm_proposal_refuses_unsupported_seed(tmp_path):
+    from vulca.real_brief.brainstorm_seed import (
+        seed_real_brief_brainstorm_proposal,
+    )
+
+    _adapted_project(tmp_path, "erie-botanical-gardens-public-art")
+
+    with pytest.raises(RuntimeError, match="not ready_for_visual_brainstorm"):
+        seed_real_brief_brainstorm_proposal(
+            root=tmp_path / "repo",
+            slug="erie-botanical-gardens-public-art",
+            date="2026-05-01",
+        )
+
+
+def test_seed_real_brief_brainstorm_proposal_generated_draft_has_no_secrets(
+    tmp_path,
+):
+    from vulca.real_brief.brainstorm_seed import (
+        seed_real_brief_brainstorm_proposal,
+    )
+
+    project_dir = _adapted_project(tmp_path, "model-young-package-unpacking-taboo")
+
+    seed_real_brief_brainstorm_proposal(
+        root=tmp_path / "repo",
+        slug="model-young-package-unpacking-taboo",
+        date="2026-05-01",
+    )
+
+    proposal = (project_dir / "proposal.md").read_text(encoding="utf-8")
+    assert "sk-" not in proposal
+    assert "VULCA_REAL_PROVIDER_API_KEY" not in proposal
+    assert "OPENAI_API_KEY" not in proposal
+    assert "globalai" not in proposal.casefold()
+
+
+def test_real_brief_brainstorm_seed_cli_writes_json_result(tmp_path):
+    project_dir = _adapted_project(tmp_path, "seattle-polish-film-festival-poster")
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "scripts/real_brief_brainstorm_seed.py",
+            "--root",
+            str(tmp_path / "repo"),
+            "--slug",
+            "seattle-polish-film-festival-poster",
+            "--date",
+            "2026-05-01",
+        ],
+        cwd=Path(__file__).resolve().parents[1],
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+
+    result = json.loads(completed.stdout)
+    assert result["status"] == "draft"
+    assert result["proposal_md"] == str(project_dir / "proposal.md")
+    assert (project_dir / "proposal.md").exists()
+
+
+def test_real_brief_brainstorm_seed_cli_dry_run_writes_nothing(tmp_path):
+    project_dir = _adapted_project(tmp_path, "seattle-polish-film-festival-poster")
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "scripts/real_brief_brainstorm_seed.py",
+            "--root",
+            str(tmp_path / "repo"),
+            "--slug",
+            "seattle-polish-film-festival-poster",
+            "--date",
+            "2026-05-01",
+            "--dry-run",
+        ],
+        cwd=Path(__file__).resolve().parents[1],
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+
+    result = json.loads(completed.stdout)
+    assert result["dry_run"] == "true"
+    assert result["proposal_md"] == str(project_dir / "proposal.md")
+    assert not (project_dir / "proposal.md").exists()
+
+
+def test_real_brief_package_lazy_exports_brainstorm_seed_without_provider_imports():
+    import vulca.real_brief as real_brief
+
+    assert callable(real_brief.seed_real_brief_brainstorm_proposal)


### PR DESCRIPTION
## Summary

- Add `vulca.real_brief.brainstorm_seed` to generate draft `/visual-brainstorm` `proposal.md` files from Phase 2 real-brief workflow seeds.
- Add `scripts/real_brief_brainstorm_seed.py` for repeatable CLI use.
- Update all mirrored `visual-brainstorm` skill packages to detect `workflow_seed.md + real_brief/adapter_manifest.json` and continue from the generated draft instead of starting empty.

## Test Plan

- `PYTHONPATH=src python3 -m pytest tests/test_real_brief_brainstorm_seed.py -q` -> 9 passed
- `PYTHONPATH=src python3 -m pytest tests/test_real_brief_brainstorm_seed.py tests/test_real_brief_workflow_adapter.py -q` -> 36 passed
- `PYTHONPATH=src python3 -m pytest tests/test_real_brief_benchmark.py tests/test_visual_brainstorm_discovery_integration.py tests/test_visual_discovery_artifacts.py tests/test_visual_discovery_cards.py tests/test_visual_discovery_types.py -q` -> 59 passed, 1 skipped
- `PYTHONPATH=src python3 -m pytest tests/test_skill_discovery.py tests/test_visual_discovery_skill_contract.py tests/test_visual_discovery_docs_truth.py -q` -> 33 passed
- `PYTHONPATH=src /opt/homebrew/bin/python3.11 -m pytest tests/test_real_brief_brainstorm_seed.py tests/test_real_brief_workflow_adapter.py tests/test_real_brief_benchmark.py tests/test_skill_discovery.py tests/test_visual_discovery_docs_truth.py -q` -> 115 passed
- `ruff check src/ tests/` -> passed
- `git diff --check` -> passed
- E2E dry run: `real_brief_benchmark.py` -> `real_brief_workflow_adapter.py` -> `real_brief_brainstorm_seed.py` wrote draft proposal at `/private/tmp/vulca-phase3-e2e-workflow/docs/visual-specs/seattle-polish-film-festival-poster/proposal.md`.

## Local Full-Suite Note

The CI-like local suite with the repository ignore list reached collection and most tests, but failed in sandboxed local execution because existing checkpoint tests clear `VULCA_DATA_DIR`; later pipeline tests then try to write `~/.vulca/data/checkpoints`, which is outside the writable sandbox. GitHub CI runs outside this desktop sandbox and remains the authoritative full-suite check.
