### PR TITLE
Add Seattle Polish Festival visual spec

### DIFF
--- a/docs/visual-specs/seattle-polish-film-festival-poster/design.md
+++ b/docs/visual-specs/seattle-polish-film-festival-poster/design.md
@@ -1,0 +1,85 @@
+---
+slug: seattle-polish-film-festival-poster
+status: resolved
+schema_version: "0.1"
+domain: poster
+tradition: null
+generated_by: visual-spec@0.1.0
+proposal_ref: docs/visual-specs/seattle-polish-film-festival-poster/proposal.md
+created: 2026-05-01
+updated: 2026-05-01
+---
+
+# Seattle Polish Film Festival Poster
+
+## A. Provider + generation params
+
+```yaml
+reviewed: true
+provider: openai
+seed: 1337
+steps: 30
+cfg_scale: 7.5
+```
+
+## B. Composition strategy
+
+```yaml
+reviewed: true
+strategy: series
+variation_axis: "adapt one key-art system from 11 x 17 vertical poster to program cover"
+variant_count: 2
+```
+
+## C. Prompt composition
+
+```yaml
+reviewed: true
+style_treatment: unified
+base_prompt: >-
+  Signature key-art poster concept for the 34th Seattle Polish Film Festival,
+  vertical 11 x 17 inch poster composition, contemporary Polish cinema mood,
+  one strong readable visual idea, clear hierarchy with protected title/date
+  area, reserved lower sponsor/patron band, print-aware margins, restrained
+  cultural specificity, arts-festival sophistication, no flag-only concept.
+negative_prompt: ""
+tradition_tokens: []
+color_constraint_tokens: []
+sketch_integration: ignore
+ref_integration: none
+```
+
+## D2. Thresholds + batch + rollback
+
+```yaml
+reviewed: true
+L1_threshold:          {value: 0.7, source: assumed, confidence: low}
+L2_threshold:          {value: 0.7, source: assumed, confidence: low}
+L3_threshold:          {value: 0.6, source: assumed, confidence: low}
+L4_threshold:          {value: 0.55, source: assumed, confidence: low}
+L5_threshold:          {value: 0.5, source: assumed, confidence: low}
+batch_size:            {value: 4, source: assumed, confidence: med}
+rollback_trigger:      {value: "2 consecutive outputs with unsafe text layout or missing sponsor band", source: assumed, confidence: med}
+override_rationale: null
+```
+
+## F. Cost budget
+
+```yaml
+reviewed: true
+per_gen_sec: {value: 45, source: assumed, confidence: low}
+total_session_sec: {value: 270, source: derived, confidence: low}
+fail_fast_consecutive: {value: 2, source: assumed, confidence: low}
+provider_used_for_calibration: user-supplied-policy
+provider_multiplier_applied: null
+```
+
+## Open questions
+none
+
+## Notes
+- [resume-state] turns_used: 1
+- [null-tradition] spike skipped — requires tradition-guide weights for judgment.
+- No image provider, redraw provider, evaluator, or spike was invoked by this spec draft.
+- `provider: openai` is selected for text/layout-sensitive poster ideation; `/visual-plan` must still verify exact provider/model availability before execution.
+- Cost budget is a policy placeholder because no mock or real provider calibration was run in this step.

--- a/docs/visual-specs/seattle-polish-film-festival-poster/discovery/direction_cards.json
+++ b/docs/visual-specs/seattle-polish-film-festival-poster/discovery/direction_cards.json
@@ -1,0 +1,129 @@
+{
+  "schema_version": "0.1",
+  "slug": "seattle-polish-film-festival-poster",
+  "cards": [
+    {
+      "id": "seattle-polish-film-festival-poster-1-commercial-clarity",
+      "label": "Commercial clarity",
+      "summary": "A commercial clarity route for Create layout-safe poster concept directions for a Polish film festival, including required text strategy, margins, sponsor band, and print-risk notes..",
+      "culture_terms": [],
+      "visual_ops": {
+        "composition": "large readable subject, product-first hierarchy, high scan speed",
+        "color": "limited palette aligned to the brand and medium",
+        "texture": "material treatment supports the selected direction",
+        "lighting": "clear subject readability",
+        "camera": "stable hierarchy with no accidental crop",
+        "typography": "legible and secondary to the visual concept",
+        "symbol_strategy": "specific visual behavior over decorative symbols",
+        "avoid": [
+          "generic ai aesthetic",
+          "literal cliché symbolism"
+        ]
+      },
+      "provider_hint": {
+        "sketch": {
+          "provider": "gemini",
+          "model": "gemini-3.1-flash-image-preview"
+        },
+        "final": {
+          "provider": "openai",
+          "model": "gpt-image-2"
+        },
+        "local": {
+          "provider": "comfyui"
+        }
+      },
+      "evaluation_focus": {
+        "L1": "composition is readable",
+        "L2": "execution supports the visual direction",
+        "L3": "cultural references are grounded",
+        "L4": "interpretation matches the project intent",
+        "L5": "the visual idea has depth beyond styling"
+      },
+      "risk": "Needs a selected culture term or reference to become more specific.",
+      "status": "candidate"
+    },
+    {
+      "id": "seattle-polish-film-festival-poster-2-editorial-atmosphere",
+      "label": "Editorial atmosphere",
+      "summary": "A editorial atmosphere route for Create layout-safe poster concept directions for a Polish film festival, including required text strategy, margins, sponsor band, and print-risk notes..",
+      "culture_terms": [],
+      "visual_ops": {
+        "composition": "more negative space, slower reading, stronger mood",
+        "color": "limited palette aligned to the brand and medium",
+        "texture": "material treatment supports the selected direction",
+        "lighting": "clear subject readability",
+        "camera": "stable hierarchy with no accidental crop",
+        "typography": "legible and secondary to the visual concept",
+        "symbol_strategy": "specific visual behavior over decorative symbols",
+        "avoid": [
+          "generic ai aesthetic",
+          "literal cliché symbolism"
+        ]
+      },
+      "provider_hint": {
+        "sketch": {
+          "provider": "gemini",
+          "model": "gemini-3.1-flash-image-preview"
+        },
+        "final": {
+          "provider": "openai",
+          "model": "gpt-image-2"
+        },
+        "local": {
+          "provider": "comfyui"
+        }
+      },
+      "evaluation_focus": {
+        "L1": "composition is readable",
+        "L2": "execution supports the visual direction",
+        "L3": "cultural references are grounded",
+        "L4": "interpretation matches the project intent",
+        "L5": "the visual idea has depth beyond styling"
+      },
+      "risk": "Needs a selected culture term or reference to become more specific.",
+      "status": "candidate"
+    },
+    {
+      "id": "seattle-polish-film-festival-poster-3-modern-restraint",
+      "label": "Modern restraint",
+      "summary": "A modern restraint route for Create layout-safe poster concept directions for a Polish film festival, including required text strategy, margins, sponsor band, and print-risk notes..",
+      "culture_terms": [],
+      "visual_ops": {
+        "composition": "simple geometry, low ornament, sharp hierarchy",
+        "color": "limited palette aligned to the brand and medium",
+        "texture": "material treatment supports the selected direction",
+        "lighting": "clear subject readability",
+        "camera": "stable hierarchy with no accidental crop",
+        "typography": "legible and secondary to the visual concept",
+        "symbol_strategy": "specific visual behavior over decorative symbols",
+        "avoid": [
+          "generic ai aesthetic",
+          "literal cliché symbolism"
+        ]
+      },
+      "provider_hint": {
+        "sketch": {
+          "provider": "gemini",
+          "model": "gemini-3.1-flash-image-preview"
+        },
+        "final": {
+          "provider": "openai",
+          "model": "gpt-image-2"
+        },
+        "local": {
+          "provider": "comfyui"
+        }
+      },
+      "evaluation_focus": {
+        "L1": "composition is readable",
+        "L2": "execution supports the visual direction",
+        "L3": "cultural references are grounded",
+        "L4": "interpretation matches the project intent",
+        "L5": "the visual idea has depth beyond styling"
+      },
+      "risk": "Needs a selected culture term or reference to become more specific.",
+      "status": "candidate"
+    }
+  ]
+}

--- a/docs/visual-specs/seattle-polish-film-festival-poster/discovery/discovery.md
+++ b/docs/visual-specs/seattle-polish-film-festival-poster/discovery/discovery.md
@@ -1,0 +1,34 @@
+# Visual Discovery: Seattle Polish Film Festival Poster
+
+## Status
+ready_for_brainstorm
+
+## Original Intent
+Create layout-safe poster concept directions for a Polish film festival, including required text strategy, margins, sponsor band, and print-risk notes.
+
+## Scope Decision
+accepted
+
+## Uncertainty
+low
+
+## Taste Profile Summary
+Domain: poster. Traditions: brand_design.
+
+## Direction Cards
+- `seattle-polish-film-festival-poster-1-commercial-clarity`: Commercial clarity - A commercial clarity route for Create layout-safe poster concept directions for a Polish film festival, including required text strategy, margins, sponsor band, and print-risk notes..
+- `seattle-polish-film-festival-poster-2-editorial-atmosphere`: Editorial atmosphere - A editorial atmosphere route for Create layout-safe poster concept directions for a Polish film festival, including required text strategy, margins, sponsor band, and print-risk notes..
+- `seattle-polish-film-festival-poster-3-modern-restraint`: Modern restraint - A modern restraint route for Create layout-safe poster concept directions for a Polish film festival, including required text strategy, margins, sponsor band, and print-risk notes..
+
+## User Preference Signals
+recommended: seattle-polish-film-festival-poster-1-commercial-clarity
+
+## Recommended Direction
+Commercial clarity
+
+## Handoff
+Ready for /visual-brainstorm. Suggested topic:
+"Create layout-safe poster concept directions for a Polish film festival, including required text strategy, margins, sponsor band, and print-risk notes.; selected direction: Commercial clarity; target audience: unspecified; traditions: brand_design; culture terms: unspecified; domain: poster; visual operations: composition=large readable subject, product-first hierarchy, high scan speed; color=limited palette aligned to the brand and medium; texture=material treatment supports the selected direction; lighting=clear subject readability; camera=stable hierarchy with no accidental crop; typography=legible and secondary to the visual concept; symbol_strategy=specific visual behavior over decorative symbols; avoid: generic ai aesthetic, literal cliché symbolism; output: static 2D visual brief."
+
+## Notes
+generated_by: visual-discovery@0.1.0

--- a/docs/visual-specs/seattle-polish-film-festival-poster/discovery/sketch_prompts.json
+++ b/docs/visual-specs/seattle-polish-film-festival-poster/discovery/sketch_prompts.json
@@ -1,0 +1,33 @@
+{
+  "schema_version": "0.1",
+  "slug": "seattle-polish-film-festival-poster",
+  "sketch_prompts": [
+    {
+      "card_id": "seattle-polish-film-festival-poster-1-commercial-clarity",
+      "provider": "gemini",
+      "model": "gemini-3.1-flash-image-preview",
+      "prompt": "Create an exploratory thumbnail for visual direction comparison. A commercial clarity route for Create layout-safe poster concept directions for a Polish film festival, including required text strategy, margins, sponsor band, and print-risk notes... Composition: large readable subject, product-first hierarchy, high scan speed. Color: limited palette aligned to the brand and medium. Texture/material: material treatment supports the selected direction. Lighting: clear subject readability. Camera/layout: stable hierarchy with no accidental crop. Typography: legible and secondary to the visual concept. Symbol strategy: specific visual behavior over decorative symbols. Culture terms:",
+      "negative_prompt": "generic ai aesthetic, literal cliché symbolism",
+      "size": "1024x1024",
+      "purpose": "visual workflow adapter discovery thumbnail seed"
+    },
+    {
+      "card_id": "seattle-polish-film-festival-poster-2-editorial-atmosphere",
+      "provider": "gemini",
+      "model": "gemini-3.1-flash-image-preview",
+      "prompt": "Create an exploratory thumbnail for visual direction comparison. A editorial atmosphere route for Create layout-safe poster concept directions for a Polish film festival, including required text strategy, margins, sponsor band, and print-risk notes... Composition: more negative space, slower reading, stronger mood. Color: limited palette aligned to the brand and medium. Texture/material: material treatment supports the selected direction. Lighting: clear subject readability. Camera/layout: stable hierarchy with no accidental crop. Typography: legible and secondary to the visual concept. Symbol strategy: specific visual behavior over decorative symbols. Culture terms:",
+      "negative_prompt": "generic ai aesthetic, literal cliché symbolism",
+      "size": "1024x1024",
+      "purpose": "visual workflow adapter discovery thumbnail seed"
+    },
+    {
+      "card_id": "seattle-polish-film-festival-poster-3-modern-restraint",
+      "provider": "gemini",
+      "model": "gemini-3.1-flash-image-preview",
+      "prompt": "Create an exploratory thumbnail for visual direction comparison. A modern restraint route for Create layout-safe poster concept directions for a Polish film festival, including required text strategy, margins, sponsor band, and print-risk notes... Composition: simple geometry, low ornament, sharp hierarchy. Color: limited palette aligned to the brand and medium. Texture/material: material treatment supports the selected direction. Lighting: clear subject readability. Camera/layout: stable hierarchy with no accidental crop. Typography: legible and secondary to the visual concept. Symbol strategy: specific visual behavior over decorative symbols. Culture terms:",
+      "negative_prompt": "generic ai aesthetic, literal cliché symbolism",
+      "size": "1024x1024",
+      "purpose": "visual workflow adapter discovery thumbnail seed"
+    }
+  ]
+}

--- a/docs/visual-specs/seattle-polish-film-festival-poster/discovery/taste_profile.json
+++ b/docs/visual-specs/seattle-polish-film-festival-poster/discovery/taste_profile.json
@@ -1,0 +1,42 @@
+{
+  "schema_version": "0.1",
+  "slug": "seattle-polish-film-festival-poster",
+  "source": {
+    "initial_intent": "Create layout-safe poster concept directions for a Polish film festival, including required text strategy, margins, sponsor band, and print-risk notes.",
+    "reference_paths": [],
+    "conversation_signals": []
+  },
+  "domain": {
+    "primary": "poster",
+    "candidates": [],
+    "confidence": "low"
+  },
+  "culture": {
+    "primary_tradition": "brand_design",
+    "candidate_traditions": [
+      "brand_design"
+    ],
+    "terms": [],
+    "avoid_cliches": [],
+    "risk_flags": []
+  },
+  "aesthetic": {
+    "mood": [],
+    "composition": [],
+    "color": [],
+    "material": [],
+    "typography": [],
+    "symbol_strategy": ""
+  },
+  "commercial_context": {
+    "audience": "",
+    "channel": "",
+    "conversion_pressure": "unknown",
+    "brand_maturity": "unknown"
+  },
+  "selection_history": [],
+  "confidence": {
+    "overall": "low",
+    "needs_more_questions": true
+  }
+}

--- a/docs/visual-specs/seattle-polish-film-festival-poster/proposal.md
+++ b/docs/visual-specs/seattle-polish-film-festival-poster/proposal.md
@@ -1,0 +1,108 @@
+---
+slug: seattle-polish-film-festival-poster
+status: ready
+domain: poster
+tradition: null
+style_treatment: unified
+generated_by: visual-brainstorm@0.1.0
+created: 2026-05-01
+updated: 2026-05-01
+---
+
+# Seattle Polish Film Festival Poster
+
+> Seeded from `real_brief/` artifacts. Human gate cleared for `/visual-spec`; provider execution remains blocked until `/visual-plan` approval.
+
+## Intent
+Signature poster concept for the 34th festival edition. Create layout-safe poster concept directions for a Polish film festival, including required text strategy, margins, sponsor band, and print-risk notes.
+
+## Audience
+- festival attendees
+- Polish cinema community
+- Seattle arts audience
+
+## Physical form
+- poster concept (11 x 17 in vertical, print/digital)
+- program cover adaptation (same key art, print)
+
+## Market
+Market not explicitly specified by the source brief. Use client/source context only: Seattle Polish Film Festival.
+
+## Budget & deadline
+- Budget: not specified by source
+- Timeline: source-specific contest deadline
+- Source deadline: 2026-06-01 23:59
+
+## Color constraints
+none specified
+
+## References
+- source: https://www.polishfilms.org/submit-a-poster
+- source retrieved on: 2026-04-30
+- copied real brief package: real_brief/
+- workflow seed: workflow_seed.md
+- source deadline: 2026-06-01 23:59
+- project directory: docs/visual-specs/seattle-polish-film-festival-poster
+
+## Series plan
+- Deliverable count: 2
+- Variation axis: adapt one approved key direction across required formats.
+- Deliverables:
+  - poster concept
+  - program cover adaptation
+
+## Acceptance rubric
+- brief compliance (0-2)
+- audience fit (0-2)
+- deliverable fit (0-2)
+- constraint handling (0-2)
+- cultural taste specificity (0-2)
+- structural control (0-2)
+- editability reusability (0-2)
+- production realism (0-2)
+- risk avoidance (0-2)
+- decision usefulness (0-2)
+
+## Questions resolved
+- Q: What is the source brief?
+  A: Seattle Polish Film Festival Poster
+- Q: Which workflow stage owns this draft?
+  A: /visual-brainstorm owns proposal.md; downstream stages remain gated.
+- Q: Which domain should the visual chain use?
+  A: poster
+- Q: Should provider execution happen now?
+  A: No. This is a simulation-only planning seed.
+- Q: Which stakeholder approves the final direction?
+  A: This Vulca planning session acts as the internal human gate for spec drafting; external festival approval is still required before production use.
+- Q: Which deliverable must be most production-ready first?
+  A: The 11 x 17 in vertical poster concept is primary; the program cover adaptation follows from the same key art.
+- Q: Which source assets already exist?
+  A: Treat official festival copy, dates, venue, website, producer line, and sponsor/patron band as mandatory layout placeholders. Do not assume logo files are available in this repository.
+- Q: Should style_treatment remain unified, or change to additive, collage, or wash?
+  A: Keep `unified`; this is a poster key-art system, not a preserved-photo or collage overlay task.
+- Q: Should a validated cultural tradition be declared before /visual-spec?
+  A: No. Keep `tradition: null` and express cultural specificity through brief constraints, Polish cinema context, typography-safe layout, and anti-cliche risk controls.
+
+## Open questions
+none
+
+## Notes
+Real brief seed imported from a simulation-only benchmark package.
+No image provider, redraw provider, or evaluator is invoked by this step.
+
+Constraints:
+- required festival text must be present
+- dates, venues, website, and producer line must be accounted for
+- bottom sponsor or patron logo band must remain available
+- print output should anticipate CMYK and 300 dpi production
+
+Risks:
+- broken generated text
+- unsafe margins
+- generic Polish national symbolism
+- missing sponsor band
+
+Rejected approaches / avoid:
+- illegible typography
+- crowded logo area
+- flag-only concept

--- a/docs/visual-specs/seattle-polish-film-festival-poster/real_brief/adapter_manifest.json
+++ b/docs/visual-specs/seattle-polish-film-festival-poster/real_brief/adapter_manifest.json
@@ -1,0 +1,24 @@
+{
+  "adapter": "real-brief-workflow-adapter",
+  "created": "2026-05-01",
+  "domain": "poster",
+  "human_gate_required": true,
+  "next_steps": [
+    "/visual-brainstorm seattle-polish-film-festival-poster",
+    "/visual-spec seattle-polish-film-festival-poster",
+    "/visual-plan seattle-polish-film-festival-poster",
+    "/evaluate seattle-polish-film-festival-poster"
+  ],
+  "schema_version": "0.1",
+  "simulation_only": true,
+  "slug": "seattle-polish-film-festival-poster",
+  "source_experiment": "real-brief-benchmark",
+  "source_mode": "dry_run",
+  "source_package_manifest": "source_package_manifest.json",
+  "visual_workflow_domain": "poster",
+  "workflow_artifacts": {
+    "discovery_md": "../discovery/discovery.md",
+    "workflow_seed_md": "../workflow_seed.md"
+  },
+  "workflow_status": "ready_for_visual_brainstorm"
+}

--- a/docs/visual-specs/seattle-polish-film-festival-poster/real_brief/conditions/A-one-shot.md
+++ b/docs/visual-specs/seattle-polish-film-festival-poster/real_brief/conditions/A-one-shot.md
@@ -1,0 +1,39 @@
+# Condition A: One-shot model baseline
+
+workflow_stage: one-shot
+
+purpose: Raw real brief condensed into a single model ask.
+
+## Prompt
+
+Create the requested creative output for this real brief.
+
+Client: Seattle Polish Film Festival
+Context: Signature poster concept for the 34th festival edition.
+Audience:
+- festival attendees
+- Polish cinema community
+- Seattle arts audience
+Required deliverables:
+- poster concept (11 x 17 in vertical, print/digital)
+- program cover adaptation (same key art, print)
+Constraints:
+- required festival text must be present
+- dates, venues, website, and producer line must be accounted for
+- bottom sponsor or patron logo band must remain available
+- print output should anticipate CMYK and 300 dpi production
+Budget: not specified by source
+Timeline: source-specific contest deadline
+Risks:
+- broken generated text
+- unsafe margins
+- generic Polish national symbolism
+- missing sponsor band
+Avoid:
+- illegible typography
+- crowded logo area
+- flag-only concept
+AI policy: unspecified
+Simulation only: True
+
+Return a polished concept and any visual prompt needed to generate it.

--- a/docs/visual-specs/seattle-polish-film-festival-poster/real_brief/conditions/B-structured-brief.md
+++ b/docs/visual-specs/seattle-polish-film-festival-poster/real_brief/conditions/B-structured-brief.md
@@ -1,0 +1,42 @@
+# Condition B: Structured brief baseline
+
+workflow_stage: structured-brief
+
+purpose: Same brief normalized into structured client, deliverable, and constraint fields.
+
+## Prompt
+
+Create a direction from the structured brief below.
+
+Client: Seattle Polish Film Festival
+Context: Signature poster concept for the 34th festival edition.
+Audience:
+- festival attendees
+- Polish cinema community
+- Seattle arts audience
+Required deliverables:
+- poster concept (11 x 17 in vertical, print/digital)
+- program cover adaptation (same key art, print)
+Constraints:
+- required festival text must be present
+- dates, venues, website, and producer line must be accounted for
+- bottom sponsor or patron logo band must remain available
+- print output should anticipate CMYK and 300 dpi production
+Budget: not specified by source
+Timeline: source-specific contest deadline
+Risks:
+- broken generated text
+- unsafe margins
+- generic Polish national symbolism
+- missing sponsor band
+Avoid:
+- illegible typography
+- crowded logo area
+- flag-only concept
+AI policy: unspecified
+Simulation only: True
+
+Success criteria:
+- satisfy required deliverables
+- respect every listed constraint
+- identify the most production-relevant risk

--- a/docs/visual-specs/seattle-polish-film-festival-poster/real_brief/conditions/C-vulca-planning.md
+++ b/docs/visual-specs/seattle-polish-film-festival-poster/real_brief/conditions/C-vulca-planning.md
@@ -1,0 +1,175 @@
+# Condition C: Vulca planning workflow
+
+workflow_stage: vulca-planning
+
+purpose: Ambiguity handling, direction cards, visual operations, and evaluation focus before generation.
+
+## Prompt
+
+Build a Vulca planning package before generating final pixels.
+
+Client: Seattle Polish Film Festival
+Context: Signature poster concept for the 34th festival edition.
+Audience:
+- festival attendees
+- Polish cinema community
+- Seattle arts audience
+Required deliverables:
+- poster concept (11 x 17 in vertical, print/digital)
+- program cover adaptation (same key art, print)
+Constraints:
+- required festival text must be present
+- dates, venues, website, and producer line must be accounted for
+- bottom sponsor or patron logo band must remain available
+- print output should anticipate CMYK and 300 dpi production
+Budget: not specified by source
+Timeline: source-specific contest deadline
+Risks:
+- broken generated text
+- unsafe margins
+- generic Polish national symbolism
+- missing sponsor band
+Avoid:
+- illegible typography
+- crowded logo area
+- flag-only concept
+AI policy: unspecified
+Simulation only: True
+
+Missing questions:
+- Which stakeholder approves the final direction?
+- Which deliverable must be most production-ready first?
+- Which source assets already exist?
+
+Selected direction card: Commercial clarity
+Direction summary:
+A commercial clarity route for Client: Seattle Polish Film Festival
+Context: Signature poster concept for the 34th festival edition.
+Audience:
+- festival attendees
+- Polish cinema community
+- Seattle arts audience
+Required deliverables:
+- poster concept (11 x 17 in vertical, print/digital)
+- program cover adaptation (same key art, print)
+Constraints:
+- required festival text must be present
+- dates, venues, website, and producer line must be accounted for
+- bottom sponsor or patron logo band must remain available
+- print output should anticipate CMYK and 300 dpi production
+Budget: not specified by source
+Timeline: source-specific contest deadline
+Risks:
+- broken generated text
+- unsafe margins
+- generic Polish national symbolism
+- missing sponsor band
+Avoid:
+- illegible typography
+- crowded logo area
+- flag-only concept
+AI policy: unspecified
+Simulation only: True.
+Visual operations:
+- Composition: large readable subject, product-first hierarchy, high scan speed
+- Color: limited palette aligned to the brand and medium
+- Texture/material: material treatment supports the selected direction
+- Typography: legible and secondary to the visual concept
+- Symbol strategy: specific visual behavior over decorative symbols
+Evaluation focus:
+- L1: composition is readable
+- L2: execution supports the visual direction
+- L3: cultural references are grounded
+- L4: interpretation matches the project intent
+- L5: the visual idea has depth beyond styling
+
+Generated direction set for comparison:
+Direction 1 id: seattle-polish-film-festival-poster-1-commercial-clarity
+Direction 1 label: Commercial clarity
+Direction 1 summary: A commercial clarity route for Client: Seattle Polish Film Festival
+Context: Signature poster concept for the 34th festival edition.
+Audience:
+- festival attendees
+- Polish cinema community
+- Seattle arts audience
+Required deliverables:
+- poster concept (11 x 17 in vertical, print/digital)
+- program cover adaptation (same key art, print)
+Constraints:
+- required festival text must be present
+- dates, venues, website, and producer line must be accounted for
+- bottom sponsor or patron logo band must remain available
+- print output should anticipate CMYK and 300 dpi production
+Budget: not specified by source
+Timeline: source-specific contest deadline
+Risks:
+- broken generated text
+- unsafe margins
+- generic Polish national symbolism
+- missing sponsor band
+Avoid:
+- illegible typography
+- crowded logo area
+- flag-only concept
+AI policy: unspecified
+Simulation only: True.
+Direction 2 id: seattle-polish-film-festival-poster-2-editorial-atmosphere
+Direction 2 label: Editorial atmosphere
+Direction 2 summary: A editorial atmosphere route for Client: Seattle Polish Film Festival
+Context: Signature poster concept for the 34th festival edition.
+Audience:
+- festival attendees
+- Polish cinema community
+- Seattle arts audience
+Required deliverables:
+- poster concept (11 x 17 in vertical, print/digital)
+- program cover adaptation (same key art, print)
+Constraints:
+- required festival text must be present
+- dates, venues, website, and producer line must be accounted for
+- bottom sponsor or patron logo band must remain available
+- print output should anticipate CMYK and 300 dpi production
+Budget: not specified by source
+Timeline: source-specific contest deadline
+Risks:
+- broken generated text
+- unsafe margins
+- generic Polish national symbolism
+- missing sponsor band
+Avoid:
+- illegible typography
+- crowded logo area
+- flag-only concept
+AI policy: unspecified
+Simulation only: True.
+Direction 3 id: seattle-polish-film-festival-poster-3-modern-restraint
+Direction 3 label: Modern restraint
+Direction 3 summary: A modern restraint route for Client: Seattle Polish Film Festival
+Context: Signature poster concept for the 34th festival edition.
+Audience:
+- festival attendees
+- Polish cinema community
+- Seattle arts audience
+Required deliverables:
+- poster concept (11 x 17 in vertical, print/digital)
+- program cover adaptation (same key art, print)
+Constraints:
+- required festival text must be present
+- dates, venues, website, and producer line must be accounted for
+- bottom sponsor or patron logo band must remain available
+- print output should anticipate CMYK and 300 dpi production
+Budget: not specified by source
+Timeline: source-specific contest deadline
+Risks:
+- broken generated text
+- unsafe margins
+- generic Polish national symbolism
+- missing sponsor band
+Avoid:
+- illegible typography
+- crowded logo area
+- flag-only concept
+AI policy: unspecified
+Simulation only: True.
+
+Plan a candidate route before making final assets.

--- a/docs/visual-specs/seattle-polish-film-festival-poster/real_brief/conditions/D-vulca-preview-iterate.md
+++ b/docs/visual-specs/seattle-polish-film-festival-poster/real_brief/conditions/D-vulca-preview-iterate.md
@@ -1,0 +1,295 @@
+# Condition D: Vulca preview-and-iterate workflow
+
+workflow_stage: vulca-preview-iterate
+
+purpose: Preview prompts, critique, refinement, and editability checks before final composition.
+
+## Prompt
+
+Build a Vulca preview-and-iterate package for this brief.
+
+Client: Seattle Polish Film Festival
+Context: Signature poster concept for the 34th festival edition.
+Audience:
+- festival attendees
+- Polish cinema community
+- Seattle arts audience
+Required deliverables:
+- poster concept (11 x 17 in vertical, print/digital)
+- program cover adaptation (same key art, print)
+Constraints:
+- required festival text must be present
+- dates, venues, website, and producer line must be accounted for
+- bottom sponsor or patron logo band must remain available
+- print output should anticipate CMYK and 300 dpi production
+Budget: not specified by source
+Timeline: source-specific contest deadline
+Risks:
+- broken generated text
+- unsafe margins
+- generic Polish national symbolism
+- missing sponsor band
+Avoid:
+- illegible typography
+- crowded logo area
+- flag-only concept
+AI policy: unspecified
+Simulation only: True
+
+Preview plan:
+- produce 2-3 low-cost thumbnail directions before final comp
+- critique each direction against constraints and risks
+- refine the strongest direction into a final comp prompt
+- document editability, redraw, and reuse notes
+
+Generated direction set for comparison:
+Direction 1 id: seattle-polish-film-festival-poster-1-commercial-clarity
+Direction 1 label: Commercial clarity
+Direction 1 summary: A commercial clarity route for Client: Seattle Polish Film Festival
+Context: Signature poster concept for the 34th festival edition.
+Audience:
+- festival attendees
+- Polish cinema community
+- Seattle arts audience
+Required deliverables:
+- poster concept (11 x 17 in vertical, print/digital)
+- program cover adaptation (same key art, print)
+Constraints:
+- required festival text must be present
+- dates, venues, website, and producer line must be accounted for
+- bottom sponsor or patron logo band must remain available
+- print output should anticipate CMYK and 300 dpi production
+Budget: not specified by source
+Timeline: source-specific contest deadline
+Risks:
+- broken generated text
+- unsafe margins
+- generic Polish national symbolism
+- missing sponsor band
+Avoid:
+- illegible typography
+- crowded logo area
+- flag-only concept
+AI policy: unspecified
+Simulation only: True.
+Direction 2 id: seattle-polish-film-festival-poster-2-editorial-atmosphere
+Direction 2 label: Editorial atmosphere
+Direction 2 summary: A editorial atmosphere route for Client: Seattle Polish Film Festival
+Context: Signature poster concept for the 34th festival edition.
+Audience:
+- festival attendees
+- Polish cinema community
+- Seattle arts audience
+Required deliverables:
+- poster concept (11 x 17 in vertical, print/digital)
+- program cover adaptation (same key art, print)
+Constraints:
+- required festival text must be present
+- dates, venues, website, and producer line must be accounted for
+- bottom sponsor or patron logo band must remain available
+- print output should anticipate CMYK and 300 dpi production
+Budget: not specified by source
+Timeline: source-specific contest deadline
+Risks:
+- broken generated text
+- unsafe margins
+- generic Polish national symbolism
+- missing sponsor band
+Avoid:
+- illegible typography
+- crowded logo area
+- flag-only concept
+AI policy: unspecified
+Simulation only: True.
+Direction 3 id: seattle-polish-film-festival-poster-3-modern-restraint
+Direction 3 label: Modern restraint
+Direction 3 summary: A modern restraint route for Client: Seattle Polish Film Festival
+Context: Signature poster concept for the 34th festival edition.
+Audience:
+- festival attendees
+- Polish cinema community
+- Seattle arts audience
+Required deliverables:
+- poster concept (11 x 17 in vertical, print/digital)
+- program cover adaptation (same key art, print)
+Constraints:
+- required festival text must be present
+- dates, venues, website, and producer line must be accounted for
+- bottom sponsor or patron logo band must remain available
+- print output should anticipate CMYK and 300 dpi production
+Budget: not specified by source
+Timeline: source-specific contest deadline
+Risks:
+- broken generated text
+- unsafe margins
+- generic Polish national symbolism
+- missing sponsor band
+Avoid:
+- illegible typography
+- crowded logo area
+- flag-only concept
+AI policy: unspecified
+Simulation only: True.
+
+Preview prompts:
+- produce 2-3 low-cost thumbnail directions before final comp
+- Thumbnail 1: Commercial clarity (seattle-polish-film-festival-poster-1-commercial-clarity) - A commercial clarity route for Client: Seattle Polish Film Festival
+Context: Signature poster concept for the 34th festival edition.
+Audience:
+- festival attendees
+- Polish cinema community
+- Seattle arts audience
+Required deliverables:
+- poster concept (11 x 17 in vertical, print/digital)
+- program cover adaptation (same key art, print)
+Constraints:
+- required festival text must be present
+- dates, venues, website, and producer line must be accounted for
+- bottom sponsor or patron logo band must remain available
+- print output should anticipate CMYK and 300 dpi production
+Budget: not specified by source
+Timeline: source-specific contest deadline
+Risks:
+- broken generated text
+- unsafe margins
+- generic Polish national symbolism
+- missing sponsor band
+Avoid:
+- illegible typography
+- crowded logo area
+- flag-only concept
+AI policy: unspecified
+Simulation only: True.
+- Thumbnail 2: Editorial atmosphere (seattle-polish-film-festival-poster-2-editorial-atmosphere) - A editorial atmosphere route for Client: Seattle Polish Film Festival
+Context: Signature poster concept for the 34th festival edition.
+Audience:
+- festival attendees
+- Polish cinema community
+- Seattle arts audience
+Required deliverables:
+- poster concept (11 x 17 in vertical, print/digital)
+- program cover adaptation (same key art, print)
+Constraints:
+- required festival text must be present
+- dates, venues, website, and producer line must be accounted for
+- bottom sponsor or patron logo band must remain available
+- print output should anticipate CMYK and 300 dpi production
+Budget: not specified by source
+Timeline: source-specific contest deadline
+Risks:
+- broken generated text
+- unsafe margins
+- generic Polish national symbolism
+- missing sponsor band
+Avoid:
+- illegible typography
+- crowded logo area
+- flag-only concept
+AI policy: unspecified
+Simulation only: True.
+- Thumbnail 3: Modern restraint (seattle-polish-film-festival-poster-3-modern-restraint) - A modern restraint route for Client: Seattle Polish Film Festival
+Context: Signature poster concept for the 34th festival edition.
+Audience:
+- festival attendees
+- Polish cinema community
+- Seattle arts audience
+Required deliverables:
+- poster concept (11 x 17 in vertical, print/digital)
+- program cover adaptation (same key art, print)
+Constraints:
+- required festival text must be present
+- dates, venues, website, and producer line must be accounted for
+- bottom sponsor or patron logo band must remain available
+- print output should anticipate CMYK and 300 dpi production
+Budget: not specified by source
+Timeline: source-specific contest deadline
+Risks:
+- broken generated text
+- unsafe margins
+- generic Polish national symbolism
+- missing sponsor band
+Avoid:
+- illegible typography
+- crowded logo area
+- flag-only concept
+AI policy: unspecified
+Simulation only: True.
+
+Critique criteria:
+- critique each direction against constraints and risks, required deliverables, audience fit, and editability
+Refinement notes:
+- refine the strongest direction into a final comp prompt after comparing the thumbnail critiques
+Editability, redraw, and reuse notes:
+- document editability, redraw, and reuse notes for the chosen route and production handoff
+
+Selected direction card: Commercial clarity
+Direction summary:
+A commercial clarity route for Client: Seattle Polish Film Festival
+Context: Signature poster concept for the 34th festival edition.
+Audience:
+- festival attendees
+- Polish cinema community
+- Seattle arts audience
+Required deliverables:
+- poster concept (11 x 17 in vertical, print/digital)
+- program cover adaptation (same key art, print)
+Constraints:
+- required festival text must be present
+- dates, venues, website, and producer line must be accounted for
+- bottom sponsor or patron logo band must remain available
+- print output should anticipate CMYK and 300 dpi production
+Budget: not specified by source
+Timeline: source-specific contest deadline
+Risks:
+- broken generated text
+- unsafe margins
+- generic Polish national symbolism
+- missing sponsor band
+Avoid:
+- illegible typography
+- crowded logo area
+- flag-only concept
+AI policy: unspecified
+Simulation only: True.
+Visual operations:
+- Composition: large readable subject, product-first hierarchy, high scan speed
+- Color: limited palette aligned to the brand and medium
+- Texture/material: material treatment supports the selected direction
+- Typography: legible and secondary to the visual concept
+- Symbol strategy: specific visual behavior over decorative symbols
+Evaluation focus:
+- L1: composition is readable
+- L2: execution supports the visual direction
+- L3: cultural references are grounded
+- L4: interpretation matches the project intent
+- L5: the visual idea has depth beyond styling
+
+Final comp prompt: Create a high-fidelity commercial visual candidate. A commercial clarity route for Client: Seattle Polish Film Festival
+Context: Signature poster concept for the 34th festival edition.
+Audience:
+- festival attendees
+- Polish cinema community
+- Seattle arts audience
+Required deliverables:
+- poster concept (11 x 17 in vertical, print/digital)
+- program cover adaptation (same key art, print)
+Constraints:
+- required festival text must be present
+- dates, venues, website, and producer line must be accounted for
+- bottom sponsor or patron logo band must remain available
+- print output should anticipate CMYK and 300 dpi production
+Budget: not specified by source
+Timeline: source-specific contest deadline
+Risks:
+- broken generated text
+- unsafe margins
+- generic Polish national symbolism
+- missing sponsor band
+Avoid:
+- illegible typography
+- crowded logo area
+- flag-only concept
+AI policy: unspecified
+Simulation only: True.. Composition: large readable subject, product-first hierarchy, high scan speed. Color: limited palette aligned to the brand and medium. Texture/material: material treatment supports the selected direction. Lighting: clear subject readability. Camera/layout: stable hierarchy with no accidental crop. Typography: legible and secondary to the visual concept. Symbol strategy: specific visual behavior over decorative symbols. Culture terms:
+
+Negative prompt: generic ai aesthetic, literal cliché symbolism

--- a/docs/visual-specs/seattle-polish-film-festival-poster/real_brief/decision_package.md
+++ b/docs/visual-specs/seattle-polish-film-festival-poster/real_brief/decision_package.md
@@ -1,0 +1,168 @@
+# Decision Package: Seattle Polish Film Festival Poster
+
+## Brief Digest
+
+Client: Seattle Polish Film Festival
+Domain: poster
+Context: Signature poster concept for the 34th festival edition.
+Audience:
+- festival attendees
+- Polish cinema community
+- Seattle arts audience
+Deliverables:
+- poster concept (11 x 17 in vertical, print/digital)
+- program cover adaptation (same key art, print)
+Constraints:
+- required festival text must be present
+- dates, venues, website, and producer line must be accounted for
+- bottom sponsor or patron logo band must remain available
+- print output should anticipate CMYK and 300 dpi production
+
+## Assumptions
+
+- This package is a simulation-only planning artifact.
+- No image provider is invoked by this dry run.
+- Final production requires a human gate and source-asset review.
+
+## Missing Questions
+
+- Which stakeholder approves the final direction?
+- Which deliverable must be most production-ready first?
+- Which source assets already exist?
+
+## Creative Directions
+
+- Commercial clarity: A commercial clarity route for Client: Seattle Polish Film Festival
+Context: Signature poster concept for the 34th festival edition.
+Audience:
+- festival attendees
+- Polish cinema community
+- Seattle arts audience
+Required deliverables:
+- poster concept (11 x 17 in vertical, print/digital)
+- program cover adaptation (same key art, print)
+Constraints:
+- required festival text must be present
+- dates, venues, website, and producer line must be accounted for
+- bottom sponsor or patron logo band must remain available
+- print output should anticipate CMYK and 300 dpi production
+Budget: not specified by source
+Timeline: source-specific contest deadline
+Risks:
+- broken generated text
+- unsafe margins
+- generic Polish national symbolism
+- missing sponsor band
+Avoid:
+- illegible typography
+- crowded logo area
+- flag-only concept
+AI policy: unspecified
+Simulation only: True.
+- Editorial atmosphere: A editorial atmosphere route for Client: Seattle Polish Film Festival
+Context: Signature poster concept for the 34th festival edition.
+Audience:
+- festival attendees
+- Polish cinema community
+- Seattle arts audience
+Required deliverables:
+- poster concept (11 x 17 in vertical, print/digital)
+- program cover adaptation (same key art, print)
+Constraints:
+- required festival text must be present
+- dates, venues, website, and producer line must be accounted for
+- bottom sponsor or patron logo band must remain available
+- print output should anticipate CMYK and 300 dpi production
+Budget: not specified by source
+Timeline: source-specific contest deadline
+Risks:
+- broken generated text
+- unsafe margins
+- generic Polish national symbolism
+- missing sponsor band
+Avoid:
+- illegible typography
+- crowded logo area
+- flag-only concept
+AI policy: unspecified
+Simulation only: True.
+- Modern restraint: A modern restraint route for Client: Seattle Polish Film Festival
+Context: Signature poster concept for the 34th festival edition.
+Audience:
+- festival attendees
+- Polish cinema community
+- Seattle arts audience
+Required deliverables:
+- poster concept (11 x 17 in vertical, print/digital)
+- program cover adaptation (same key art, print)
+Constraints:
+- required festival text must be present
+- dates, venues, website, and producer line must be accounted for
+- bottom sponsor or patron logo band must remain available
+- print output should anticipate CMYK and 300 dpi production
+Budget: not specified by source
+Timeline: source-specific contest deadline
+Risks:
+- broken generated text
+- unsafe margins
+- generic Polish national symbolism
+- missing sponsor band
+Avoid:
+- illegible typography
+- crowded logo area
+- flag-only concept
+AI policy: unspecified
+Simulation only: True.
+
+## Direction Rationale
+
+A commercial clarity route for Client: Seattle Polish Film Festival
+Context: Signature poster concept for the 34th festival edition.
+Audience:
+- festival attendees
+- Polish cinema community
+- Seattle arts audience
+Required deliverables:
+- poster concept (11 x 17 in vertical, print/digital)
+- program cover adaptation (same key art, print)
+Constraints:
+- required festival text must be present
+- dates, venues, website, and producer line must be accounted for
+- bottom sponsor or patron logo band must remain available
+- print output should anticipate CMYK and 300 dpi production
+Budget: not specified by source
+Timeline: source-specific contest deadline
+Risks:
+- broken generated text
+- unsafe margins
+- generic Polish national symbolism
+- missing sponsor band
+Avoid:
+- illegible typography
+- crowded logo area
+- flag-only concept
+AI policy: unspecified
+Simulation only: True.
+
+## Risks And Rejected Approaches
+
+Risks:
+- broken generated text
+- unsafe margins
+- generic Polish national symbolism
+- missing sponsor band
+Rejected approaches:
+- illegible typography
+- crowded logo area
+- flag-only concept
+
+## Recommended Direction
+
+Commercial clarity
+
+## Decision Checklist
+
+- Required deliverables represented
+- Constraints acknowledged
+- Known risks documented
+- Human approval required before provider execution

--- a/docs/visual-specs/seattle-polish-film-festival-poster/real_brief/evaluations/README.md
+++ b/docs/visual-specs/seattle-polish-film-festival-poster/real_brief/evaluations/README.md
@@ -1,0 +1,3 @@
+# Evaluations
+
+Dry-run placeholder. No image evaluations are run here.

--- a/docs/visual-specs/seattle-polish-film-festival-poster/real_brief/images/README.md
+++ b/docs/visual-specs/seattle-polish-film-festival-poster/real_brief/images/README.md
@@ -1,0 +1,3 @@
+# Images
+
+Dry-run placeholder. No images are generated here.

--- a/docs/visual-specs/seattle-polish-film-festival-poster/real_brief/production_package.md
+++ b/docs/visual-specs/seattle-polish-film-festival-poster/real_brief/production_package.md
@@ -1,0 +1,70 @@
+# Production Package: Seattle Polish Film Festival Poster
+
+## Selected Direction
+
+Commercial clarity
+
+## Prompt Packet
+
+- Condition A: prompts/A.txt
+- Condition B: prompts/B.txt
+- Condition C: prompts/C.txt
+- Condition D: prompts/D.txt
+
+## Visual Operations
+
+- Composition: large readable subject, product-first hierarchy, high scan speed
+- Color: limited palette aligned to the brand and medium
+- Texture: material treatment supports the selected direction
+- Lighting: clear subject readability
+- Camera: stable hierarchy with no accidental crop
+- Typography: legible and secondary to the visual concept
+- Symbol Strategy: specific visual behavior over decorative symbols
+- Avoid: ['generic ai aesthetic', 'literal cliché symbolism']
+
+## Layout And Structure Constraints
+
+- required festival text must be present
+- dates, venues, website, and producer line must be accounted for
+- bottom sponsor or patron logo band must remain available
+- print output should anticipate CMYK and 300 dpi production
+
+## Channel And Deliverable Constraints
+
+- poster concept (11 x 17 in vertical, print/digital)
+- program cover adaptation (same key art, print)
+
+## Preview Or Thumbnail Plan
+
+- Produce 2-3 low-cost thumbnail directions before final comp.
+- Critique thumbnails against constraints, risks, and deliverables.
+- Refine the strongest route into a final comp prompt.
+
+## Evaluation Checklist
+
+- brief_compliance
+- audience_fit
+- deliverable_fit
+- constraint_handling
+- cultural_taste_specificity
+- structural_control
+- editability_reusability
+- production_realism
+- risk_avoidance
+- decision_usefulness
+
+## Editability And Reusability Notes
+
+- Document reusable components before final execution.
+- Keep source constraints visible in the handoff package.
+
+## Redraw And Layer Notes
+
+- No redraw or mask provider runs in dry-run mode.
+- Layer decisions should wait for explicit real-provider opt-in.
+
+## Next Iteration Plan
+
+- Review human scoring schema.
+- Select one direction for Task 5 review rendering.
+- Proceed only after the human gate is cleared.

--- a/docs/visual-specs/seattle-polish-film-festival-poster/real_brief/prompts/A.txt
+++ b/docs/visual-specs/seattle-polish-film-festival-poster/real_brief/prompts/A.txt
@@ -1,0 +1,31 @@
+Create the requested creative output for this real brief.
+
+Client: Seattle Polish Film Festival
+Context: Signature poster concept for the 34th festival edition.
+Audience:
+- festival attendees
+- Polish cinema community
+- Seattle arts audience
+Required deliverables:
+- poster concept (11 x 17 in vertical, print/digital)
+- program cover adaptation (same key art, print)
+Constraints:
+- required festival text must be present
+- dates, venues, website, and producer line must be accounted for
+- bottom sponsor or patron logo band must remain available
+- print output should anticipate CMYK and 300 dpi production
+Budget: not specified by source
+Timeline: source-specific contest deadline
+Risks:
+- broken generated text
+- unsafe margins
+- generic Polish national symbolism
+- missing sponsor band
+Avoid:
+- illegible typography
+- crowded logo area
+- flag-only concept
+AI policy: unspecified
+Simulation only: True
+
+Return a polished concept and any visual prompt needed to generate it.

--- a/docs/visual-specs/seattle-polish-film-festival-poster/real_brief/prompts/B.txt
+++ b/docs/visual-specs/seattle-polish-film-festival-poster/real_brief/prompts/B.txt
@@ -1,0 +1,34 @@
+Create a direction from the structured brief below.
+
+Client: Seattle Polish Film Festival
+Context: Signature poster concept for the 34th festival edition.
+Audience:
+- festival attendees
+- Polish cinema community
+- Seattle arts audience
+Required deliverables:
+- poster concept (11 x 17 in vertical, print/digital)
+- program cover adaptation (same key art, print)
+Constraints:
+- required festival text must be present
+- dates, venues, website, and producer line must be accounted for
+- bottom sponsor or patron logo band must remain available
+- print output should anticipate CMYK and 300 dpi production
+Budget: not specified by source
+Timeline: source-specific contest deadline
+Risks:
+- broken generated text
+- unsafe margins
+- generic Polish national symbolism
+- missing sponsor band
+Avoid:
+- illegible typography
+- crowded logo area
+- flag-only concept
+AI policy: unspecified
+Simulation only: True
+
+Success criteria:
+- satisfy required deliverables
+- respect every listed constraint
+- identify the most production-relevant risk

--- a/docs/visual-specs/seattle-polish-film-festival-poster/real_brief/prompts/C.txt
+++ b/docs/visual-specs/seattle-polish-film-festival-poster/real_brief/prompts/C.txt
@@ -1,0 +1,167 @@
+Build a Vulca planning package before generating final pixels.
+
+Client: Seattle Polish Film Festival
+Context: Signature poster concept for the 34th festival edition.
+Audience:
+- festival attendees
+- Polish cinema community
+- Seattle arts audience
+Required deliverables:
+- poster concept (11 x 17 in vertical, print/digital)
+- program cover adaptation (same key art, print)
+Constraints:
+- required festival text must be present
+- dates, venues, website, and producer line must be accounted for
+- bottom sponsor or patron logo band must remain available
+- print output should anticipate CMYK and 300 dpi production
+Budget: not specified by source
+Timeline: source-specific contest deadline
+Risks:
+- broken generated text
+- unsafe margins
+- generic Polish national symbolism
+- missing sponsor band
+Avoid:
+- illegible typography
+- crowded logo area
+- flag-only concept
+AI policy: unspecified
+Simulation only: True
+
+Missing questions:
+- Which stakeholder approves the final direction?
+- Which deliverable must be most production-ready first?
+- Which source assets already exist?
+
+Selected direction card: Commercial clarity
+Direction summary:
+A commercial clarity route for Client: Seattle Polish Film Festival
+Context: Signature poster concept for the 34th festival edition.
+Audience:
+- festival attendees
+- Polish cinema community
+- Seattle arts audience
+Required deliverables:
+- poster concept (11 x 17 in vertical, print/digital)
+- program cover adaptation (same key art, print)
+Constraints:
+- required festival text must be present
+- dates, venues, website, and producer line must be accounted for
+- bottom sponsor or patron logo band must remain available
+- print output should anticipate CMYK and 300 dpi production
+Budget: not specified by source
+Timeline: source-specific contest deadline
+Risks:
+- broken generated text
+- unsafe margins
+- generic Polish national symbolism
+- missing sponsor band
+Avoid:
+- illegible typography
+- crowded logo area
+- flag-only concept
+AI policy: unspecified
+Simulation only: True.
+Visual operations:
+- Composition: large readable subject, product-first hierarchy, high scan speed
+- Color: limited palette aligned to the brand and medium
+- Texture/material: material treatment supports the selected direction
+- Typography: legible and secondary to the visual concept
+- Symbol strategy: specific visual behavior over decorative symbols
+Evaluation focus:
+- L1: composition is readable
+- L2: execution supports the visual direction
+- L3: cultural references are grounded
+- L4: interpretation matches the project intent
+- L5: the visual idea has depth beyond styling
+
+Generated direction set for comparison:
+Direction 1 id: seattle-polish-film-festival-poster-1-commercial-clarity
+Direction 1 label: Commercial clarity
+Direction 1 summary: A commercial clarity route for Client: Seattle Polish Film Festival
+Context: Signature poster concept for the 34th festival edition.
+Audience:
+- festival attendees
+- Polish cinema community
+- Seattle arts audience
+Required deliverables:
+- poster concept (11 x 17 in vertical, print/digital)
+- program cover adaptation (same key art, print)
+Constraints:
+- required festival text must be present
+- dates, venues, website, and producer line must be accounted for
+- bottom sponsor or patron logo band must remain available
+- print output should anticipate CMYK and 300 dpi production
+Budget: not specified by source
+Timeline: source-specific contest deadline
+Risks:
+- broken generated text
+- unsafe margins
+- generic Polish national symbolism
+- missing sponsor band
+Avoid:
+- illegible typography
+- crowded logo area
+- flag-only concept
+AI policy: unspecified
+Simulation only: True.
+Direction 2 id: seattle-polish-film-festival-poster-2-editorial-atmosphere
+Direction 2 label: Editorial atmosphere
+Direction 2 summary: A editorial atmosphere route for Client: Seattle Polish Film Festival
+Context: Signature poster concept for the 34th festival edition.
+Audience:
+- festival attendees
+- Polish cinema community
+- Seattle arts audience
+Required deliverables:
+- poster concept (11 x 17 in vertical, print/digital)
+- program cover adaptation (same key art, print)
+Constraints:
+- required festival text must be present
+- dates, venues, website, and producer line must be accounted for
+- bottom sponsor or patron logo band must remain available
+- print output should anticipate CMYK and 300 dpi production
+Budget: not specified by source
+Timeline: source-specific contest deadline
+Risks:
+- broken generated text
+- unsafe margins
+- generic Polish national symbolism
+- missing sponsor band
+Avoid:
+- illegible typography
+- crowded logo area
+- flag-only concept
+AI policy: unspecified
+Simulation only: True.
+Direction 3 id: seattle-polish-film-festival-poster-3-modern-restraint
+Direction 3 label: Modern restraint
+Direction 3 summary: A modern restraint route for Client: Seattle Polish Film Festival
+Context: Signature poster concept for the 34th festival edition.
+Audience:
+- festival attendees
+- Polish cinema community
+- Seattle arts audience
+Required deliverables:
+- poster concept (11 x 17 in vertical, print/digital)
+- program cover adaptation (same key art, print)
+Constraints:
+- required festival text must be present
+- dates, venues, website, and producer line must be accounted for
+- bottom sponsor or patron logo band must remain available
+- print output should anticipate CMYK and 300 dpi production
+Budget: not specified by source
+Timeline: source-specific contest deadline
+Risks:
+- broken generated text
+- unsafe margins
+- generic Polish national symbolism
+- missing sponsor band
+Avoid:
+- illegible typography
+- crowded logo area
+- flag-only concept
+AI policy: unspecified
+Simulation only: True.
+
+Plan a candidate route before making final assets.

--- a/docs/visual-specs/seattle-polish-film-festival-poster/real_brief/prompts/D.txt
+++ b/docs/visual-specs/seattle-polish-film-festival-poster/real_brief/prompts/D.txt
@@ -1,0 +1,287 @@
+Build a Vulca preview-and-iterate package for this brief.
+
+Client: Seattle Polish Film Festival
+Context: Signature poster concept for the 34th festival edition.
+Audience:
+- festival attendees
+- Polish cinema community
+- Seattle arts audience
+Required deliverables:
+- poster concept (11 x 17 in vertical, print/digital)
+- program cover adaptation (same key art, print)
+Constraints:
+- required festival text must be present
+- dates, venues, website, and producer line must be accounted for
+- bottom sponsor or patron logo band must remain available
+- print output should anticipate CMYK and 300 dpi production
+Budget: not specified by source
+Timeline: source-specific contest deadline
+Risks:
+- broken generated text
+- unsafe margins
+- generic Polish national symbolism
+- missing sponsor band
+Avoid:
+- illegible typography
+- crowded logo area
+- flag-only concept
+AI policy: unspecified
+Simulation only: True
+
+Preview plan:
+- produce 2-3 low-cost thumbnail directions before final comp
+- critique each direction against constraints and risks
+- refine the strongest direction into a final comp prompt
+- document editability, redraw, and reuse notes
+
+Generated direction set for comparison:
+Direction 1 id: seattle-polish-film-festival-poster-1-commercial-clarity
+Direction 1 label: Commercial clarity
+Direction 1 summary: A commercial clarity route for Client: Seattle Polish Film Festival
+Context: Signature poster concept for the 34th festival edition.
+Audience:
+- festival attendees
+- Polish cinema community
+- Seattle arts audience
+Required deliverables:
+- poster concept (11 x 17 in vertical, print/digital)
+- program cover adaptation (same key art, print)
+Constraints:
+- required festival text must be present
+- dates, venues, website, and producer line must be accounted for
+- bottom sponsor or patron logo band must remain available
+- print output should anticipate CMYK and 300 dpi production
+Budget: not specified by source
+Timeline: source-specific contest deadline
+Risks:
+- broken generated text
+- unsafe margins
+- generic Polish national symbolism
+- missing sponsor band
+Avoid:
+- illegible typography
+- crowded logo area
+- flag-only concept
+AI policy: unspecified
+Simulation only: True.
+Direction 2 id: seattle-polish-film-festival-poster-2-editorial-atmosphere
+Direction 2 label: Editorial atmosphere
+Direction 2 summary: A editorial atmosphere route for Client: Seattle Polish Film Festival
+Context: Signature poster concept for the 34th festival edition.
+Audience:
+- festival attendees
+- Polish cinema community
+- Seattle arts audience
+Required deliverables:
+- poster concept (11 x 17 in vertical, print/digital)
+- program cover adaptation (same key art, print)
+Constraints:
+- required festival text must be present
+- dates, venues, website, and producer line must be accounted for
+- bottom sponsor or patron logo band must remain available
+- print output should anticipate CMYK and 300 dpi production
+Budget: not specified by source
+Timeline: source-specific contest deadline
+Risks:
+- broken generated text
+- unsafe margins
+- generic Polish national symbolism
+- missing sponsor band
+Avoid:
+- illegible typography
+- crowded logo area
+- flag-only concept
+AI policy: unspecified
+Simulation only: True.
+Direction 3 id: seattle-polish-film-festival-poster-3-modern-restraint
+Direction 3 label: Modern restraint
+Direction 3 summary: A modern restraint route for Client: Seattle Polish Film Festival
+Context: Signature poster concept for the 34th festival edition.
+Audience:
+- festival attendees
+- Polish cinema community
+- Seattle arts audience
+Required deliverables:
+- poster concept (11 x 17 in vertical, print/digital)
+- program cover adaptation (same key art, print)
+Constraints:
+- required festival text must be present
+- dates, venues, website, and producer line must be accounted for
+- bottom sponsor or patron logo band must remain available
+- print output should anticipate CMYK and 300 dpi production
+Budget: not specified by source
+Timeline: source-specific contest deadline
+Risks:
+- broken generated text
+- unsafe margins
+- generic Polish national symbolism
+- missing sponsor band
+Avoid:
+- illegible typography
+- crowded logo area
+- flag-only concept
+AI policy: unspecified
+Simulation only: True.
+
+Preview prompts:
+- produce 2-3 low-cost thumbnail directions before final comp
+- Thumbnail 1: Commercial clarity (seattle-polish-film-festival-poster-1-commercial-clarity) - A commercial clarity route for Client: Seattle Polish Film Festival
+Context: Signature poster concept for the 34th festival edition.
+Audience:
+- festival attendees
+- Polish cinema community
+- Seattle arts audience
+Required deliverables:
+- poster concept (11 x 17 in vertical, print/digital)
+- program cover adaptation (same key art, print)
+Constraints:
+- required festival text must be present
+- dates, venues, website, and producer line must be accounted for
+- bottom sponsor or patron logo band must remain available
+- print output should anticipate CMYK and 300 dpi production
+Budget: not specified by source
+Timeline: source-specific contest deadline
+Risks:
+- broken generated text
+- unsafe margins
+- generic Polish national symbolism
+- missing sponsor band
+Avoid:
+- illegible typography
+- crowded logo area
+- flag-only concept
+AI policy: unspecified
+Simulation only: True.
+- Thumbnail 2: Editorial atmosphere (seattle-polish-film-festival-poster-2-editorial-atmosphere) - A editorial atmosphere route for Client: Seattle Polish Film Festival
+Context: Signature poster concept for the 34th festival edition.
+Audience:
+- festival attendees
+- Polish cinema community
+- Seattle arts audience
+Required deliverables:
+- poster concept (11 x 17 in vertical, print/digital)
+- program cover adaptation (same key art, print)
+Constraints:
+- required festival text must be present
+- dates, venues, website, and producer line must be accounted for
+- bottom sponsor or patron logo band must remain available
+- print output should anticipate CMYK and 300 dpi production
+Budget: not specified by source
+Timeline: source-specific contest deadline
+Risks:
+- broken generated text
+- unsafe margins
+- generic Polish national symbolism
+- missing sponsor band
+Avoid:
+- illegible typography
+- crowded logo area
+- flag-only concept
+AI policy: unspecified
+Simulation only: True.
+- Thumbnail 3: Modern restraint (seattle-polish-film-festival-poster-3-modern-restraint) - A modern restraint route for Client: Seattle Polish Film Festival
+Context: Signature poster concept for the 34th festival edition.
+Audience:
+- festival attendees
+- Polish cinema community
+- Seattle arts audience
+Required deliverables:
+- poster concept (11 x 17 in vertical, print/digital)
+- program cover adaptation (same key art, print)
+Constraints:
+- required festival text must be present
+- dates, venues, website, and producer line must be accounted for
+- bottom sponsor or patron logo band must remain available
+- print output should anticipate CMYK and 300 dpi production
+Budget: not specified by source
+Timeline: source-specific contest deadline
+Risks:
+- broken generated text
+- unsafe margins
+- generic Polish national symbolism
+- missing sponsor band
+Avoid:
+- illegible typography
+- crowded logo area
+- flag-only concept
+AI policy: unspecified
+Simulation only: True.
+
+Critique criteria:
+- critique each direction against constraints and risks, required deliverables, audience fit, and editability
+Refinement notes:
+- refine the strongest direction into a final comp prompt after comparing the thumbnail critiques
+Editability, redraw, and reuse notes:
+- document editability, redraw, and reuse notes for the chosen route and production handoff
+
+Selected direction card: Commercial clarity
+Direction summary:
+A commercial clarity route for Client: Seattle Polish Film Festival
+Context: Signature poster concept for the 34th festival edition.
+Audience:
+- festival attendees
+- Polish cinema community
+- Seattle arts audience
+Required deliverables:
+- poster concept (11 x 17 in vertical, print/digital)
+- program cover adaptation (same key art, print)
+Constraints:
+- required festival text must be present
+- dates, venues, website, and producer line must be accounted for
+- bottom sponsor or patron logo band must remain available
+- print output should anticipate CMYK and 300 dpi production
+Budget: not specified by source
+Timeline: source-specific contest deadline
+Risks:
+- broken generated text
+- unsafe margins
+- generic Polish national symbolism
+- missing sponsor band
+Avoid:
+- illegible typography
+- crowded logo area
+- flag-only concept
+AI policy: unspecified
+Simulation only: True.
+Visual operations:
+- Composition: large readable subject, product-first hierarchy, high scan speed
+- Color: limited palette aligned to the brand and medium
+- Texture/material: material treatment supports the selected direction
+- Typography: legible and secondary to the visual concept
+- Symbol strategy: specific visual behavior over decorative symbols
+Evaluation focus:
+- L1: composition is readable
+- L2: execution supports the visual direction
+- L3: cultural references are grounded
+- L4: interpretation matches the project intent
+- L5: the visual idea has depth beyond styling
+
+Final comp prompt: Create a high-fidelity commercial visual candidate. A commercial clarity route for Client: Seattle Polish Film Festival
+Context: Signature poster concept for the 34th festival edition.
+Audience:
+- festival attendees
+- Polish cinema community
+- Seattle arts audience
+Required deliverables:
+- poster concept (11 x 17 in vertical, print/digital)
+- program cover adaptation (same key art, print)
+Constraints:
+- required festival text must be present
+- dates, venues, website, and producer line must be accounted for
+- bottom sponsor or patron logo band must remain available
+- print output should anticipate CMYK and 300 dpi production
+Budget: not specified by source
+Timeline: source-specific contest deadline
+Risks:
+- broken generated text
+- unsafe margins
+- generic Polish national symbolism
+- missing sponsor band
+Avoid:
+- illegible typography
+- crowded logo area
+- flag-only concept
+AI policy: unspecified
+Simulation only: True.. Composition: large readable subject, product-first hierarchy, high scan speed. Color: limited palette aligned to the brand and medium. Texture/material: material treatment supports the selected direction. Lighting: clear subject readability. Camera/layout: stable hierarchy with no accidental crop. Typography: legible and secondary to the visual concept. Symbol strategy: specific visual behavior over decorative symbols. Culture terms:
+
+Negative prompt: generic ai aesthetic, literal cliché symbolism

--- a/docs/visual-specs/seattle-polish-film-festival-poster/real_brief/review_schema.json
+++ b/docs/visual-specs/seattle-polish-film-festival-poster/real_brief/review_schema.json
@@ -1,0 +1,56 @@
+{
+  "condition_ids": [
+    "A",
+    "B",
+    "C",
+    "D"
+  ],
+  "dimensions": [
+    {
+      "id": "brief_compliance",
+      "label": "brief compliance"
+    },
+    {
+      "id": "audience_fit",
+      "label": "audience fit"
+    },
+    {
+      "id": "deliverable_fit",
+      "label": "deliverable fit"
+    },
+    {
+      "id": "constraint_handling",
+      "label": "constraint handling"
+    },
+    {
+      "id": "cultural_taste_specificity",
+      "label": "cultural taste specificity"
+    },
+    {
+      "id": "structural_control",
+      "label": "structural control"
+    },
+    {
+      "id": "editability_reusability",
+      "label": "editability reusability"
+    },
+    {
+      "id": "production_realism",
+      "label": "production realism"
+    },
+    {
+      "id": "risk_avoidance",
+      "label": "risk avoidance"
+    },
+    {
+      "id": "decision_usefulness",
+      "label": "decision usefulness"
+    }
+  ],
+  "scale": {
+    "max": 2,
+    "min": 0,
+    "step": 1
+  },
+  "schema_version": "0.1"
+}

--- a/docs/visual-specs/seattle-polish-film-festival-poster/real_brief/source_brief.md
+++ b/docs/visual-specs/seattle-polish-film-festival-poster/real_brief/source_brief.md
@@ -1,0 +1,1 @@
+Create layout-safe poster concept directions for a Polish film festival, including required text strategy, margins, sponsor band, and print-risk notes.

--- a/docs/visual-specs/seattle-polish-film-festival-poster/real_brief/source_package_manifest.json
+++ b/docs/visual-specs/seattle-polish-film-festival-poster/real_brief/source_package_manifest.json
@@ -1,0 +1,71 @@
+{
+  "condition_ids": [
+    "A",
+    "B",
+    "C",
+    "D"
+  ],
+  "conditions": [
+    {
+      "condition_path": "conditions/A-one-shot.md",
+      "id": "A",
+      "label": "One-shot model baseline",
+      "prompt_path": "prompts/A.txt",
+      "purpose": "Raw real brief condensed into a single model ask."
+    },
+    {
+      "condition_path": "conditions/B-structured-brief.md",
+      "id": "B",
+      "label": "Structured brief baseline",
+      "prompt_path": "prompts/B.txt",
+      "purpose": "Same brief normalized into structured client, deliverable, and constraint fields."
+    },
+    {
+      "condition_path": "conditions/C-vulca-planning.md",
+      "id": "C",
+      "label": "Vulca planning workflow",
+      "prompt_path": "prompts/C.txt",
+      "purpose": "Ambiguity handling, direction cards, visual operations, and evaluation focus before generation."
+    },
+    {
+      "condition_path": "conditions/D-vulca-preview-iterate.md",
+      "id": "D",
+      "label": "Vulca preview-and-iterate workflow",
+      "prompt_path": "prompts/D.txt",
+      "purpose": "Preview prompts, critique, refinement, and editability checks before final composition."
+    }
+  ],
+  "date": "2026-05-01",
+  "experiment": "real-brief-benchmark",
+  "files": [
+    "conditions/A-one-shot.md",
+    "conditions/B-structured-brief.md",
+    "conditions/C-vulca-planning.md",
+    "conditions/D-vulca-preview-iterate.md",
+    "decision_package.md",
+    "evaluations/README.md",
+    "images/README.md",
+    "manifest.json",
+    "production_package.md",
+    "prompts/A.txt",
+    "prompts/B.txt",
+    "prompts/C.txt",
+    "prompts/D.txt",
+    "review_schema.json",
+    "source_brief.md",
+    "structured_brief.json",
+    "summary.md",
+    "workflow_handoff.json"
+  ],
+  "fixture": {
+    "slug": "seattle-polish-film-festival-poster",
+    "title": "Seattle Polish Film Festival Poster"
+  },
+  "fixture_slug": "seattle-polish-film-festival-poster",
+  "mode": "dry_run",
+  "provider_execution": "disabled",
+  "review_schema_path": "review_schema.json",
+  "schema_version": "0.1",
+  "simulation_only": true,
+  "workflow_handoff_path": "workflow_handoff.json"
+}

--- a/docs/visual-specs/seattle-polish-film-festival-poster/real_brief/structured_brief.json
+++ b/docs/visual-specs/seattle-polish-film-festival-poster/real_brief/structured_brief.json
@@ -1,0 +1,76 @@
+{
+  "ai_policy": "unspecified",
+  "audience": [
+    "festival attendees",
+    "Polish cinema community",
+    "Seattle arts audience"
+  ],
+  "avoid": [
+    "illegible typography",
+    "crowded logo area",
+    "flag-only concept"
+  ],
+  "budget": "not specified by source",
+  "client": "Seattle Polish Film Festival",
+  "constraints": [
+    "required festival text must be present",
+    "dates, venues, website, and producer line must be accounted for",
+    "bottom sponsor or patron logo band must remain available",
+    "print output should anticipate CMYK and 300 dpi production"
+  ],
+  "context": "Signature poster concept for the 34th festival edition.",
+  "deliverables": [
+    {
+      "channel": "print/digital",
+      "format": "11 x 17 in vertical",
+      "name": "poster concept",
+      "required": true
+    },
+    {
+      "channel": "print",
+      "format": "same key art",
+      "name": "program cover adaptation",
+      "required": true
+    }
+  ],
+  "domain": "poster",
+  "evaluation_dimensions": [
+    "brief_compliance",
+    "audience_fit",
+    "deliverable_fit",
+    "constraint_handling",
+    "cultural_taste_specificity",
+    "structural_control",
+    "editability_reusability",
+    "production_realism",
+    "risk_avoidance",
+    "decision_usefulness"
+  ],
+  "required_outputs": [
+    "decision_package",
+    "production_package"
+  ],
+  "risks": [
+    "broken generated text",
+    "unsafe margins",
+    "generic Polish national symbolism",
+    "missing sponsor band"
+  ],
+  "schema_version": "0.1",
+  "simulation_only": true,
+  "slug": "seattle-polish-film-festival-poster",
+  "source": {
+    "deadline": "2026-06-01 23:59",
+    "retrieved_on": "2026-04-30",
+    "url": "https://www.polishfilms.org/submit-a-poster",
+    "usage_note": "Internal benchmark only"
+  },
+  "source_brief": "Create layout-safe poster concept directions for a Polish film festival, including required text strategy, margins, sponsor band, and print-risk notes.",
+  "tags": [
+    "poster",
+    "film",
+    "layout"
+  ],
+  "timeline": "source-specific contest deadline",
+  "title": "Seattle Polish Film Festival Poster"
+}

--- a/docs/visual-specs/seattle-polish-film-festival-poster/real_brief/summary.md
+++ b/docs/visual-specs/seattle-polish-film-festival-poster/real_brief/summary.md
@@ -1,0 +1,8 @@
+# Real Brief Dry Run: seattle-polish-film-festival-poster
+
+date: 2026-05-01
+simulation_only: true
+condition_count: 4
+
+No image quality conclusion is made by this dry run.
+It writes benchmark prompts, handoff data, and review scaffolding only.

--- a/docs/visual-specs/seattle-polish-film-festival-poster/real_brief/workflow_handoff.json
+++ b/docs/visual-specs/seattle-polish-film-festival-poster/real_brief/workflow_handoff.json
@@ -1,0 +1,96 @@
+{
+  "condition_ids": [
+    "A",
+    "B",
+    "C",
+    "D"
+  ],
+  "evaluate_seed": {
+    "mode": "brief_compliance",
+    "review_schema_path": "review_schema.json"
+  },
+  "fixture_slug": "seattle-polish-film-festival-poster",
+  "human_gate_required": true,
+  "schema_version": "0.1",
+  "simulation_only": true,
+  "slug": "seattle-polish-film-festival-poster",
+  "structured_brief_path": "structured_brief.json",
+  "visual_brainstorm_seed": {
+    "audience": [
+      "festival attendees",
+      "Polish cinema community",
+      "Seattle arts audience"
+    ],
+    "avoid": [
+      "illegible typography",
+      "crowded logo area",
+      "flag-only concept"
+    ],
+    "client": "Seattle Polish Film Festival",
+    "constraints": [
+      "required festival text must be present",
+      "dates, venues, website, and producer line must be accounted for",
+      "bottom sponsor or patron logo band must remain available",
+      "print output should anticipate CMYK and 300 dpi production"
+    ],
+    "deliverables": [
+      {
+        "channel": "print/digital",
+        "format": "11 x 17 in vertical",
+        "name": "poster concept",
+        "required": true
+      },
+      {
+        "channel": "print",
+        "format": "same key art",
+        "name": "program cover adaptation",
+        "required": true
+      }
+    ],
+    "domain": "poster",
+    "physical_form": "poster concept",
+    "risks": [
+      "broken generated text",
+      "unsafe margins",
+      "generic Polish national symbolism",
+      "missing sponsor band"
+    ],
+    "slug": "seattle-polish-film-festival-poster"
+  },
+  "visual_discovery_seed": {
+    "domain": "poster",
+    "initial_intent": "Create layout-safe poster concept directions for a Polish film festival, including required text strategy, margins, sponsor band, and print-risk notes.",
+    "slug": "seattle-polish-film-festival-poster",
+    "source_usage_note": "Internal benchmark only",
+    "tags": [
+      "poster",
+      "film",
+      "layout"
+    ],
+    "title": "Seattle Polish Film Festival Poster"
+  },
+  "visual_plan_seed": {
+    "condition_ids": [
+      "A",
+      "B",
+      "C",
+      "D"
+    ],
+    "requires_explicit_real_provider_opt_in": true
+  },
+  "visual_spec_seed": {
+    "evaluation_dimensions": [
+      "brief_compliance",
+      "audience_fit",
+      "deliverable_fit",
+      "constraint_handling",
+      "cultural_taste_specificity",
+      "structural_control",
+      "editability_reusability",
+      "production_realism",
+      "risk_avoidance",
+      "decision_usefulness"
+    ],
+    "provider_policy": "dry_run_default"
+  }
+}

--- a/docs/visual-specs/seattle-polish-film-festival-poster/workflow_seed.md
+++ b/docs/visual-specs/seattle-polish-film-festival-poster/workflow_seed.md
@@ -1,0 +1,23 @@
+# Real Brief Workflow Seed: Seattle Polish Film Festival Poster
+
+status: ready_for_visual_brainstorm
+human_gate_required: true
+simulation_only: true
+slug: seattle-polish-film-festival-poster
+domain: poster
+source_package: /private/tmp/vulca-seattle-polish-visual-spec/source/2026-05-01-seattle-polish-film-festival-poster
+
+This file preserves the real-brief handoff context for the visual workflow.
+It is not a substitute for `proposal.md`; /visual-brainstorm must still create and resolve the human-reviewed proposal.
+
+## Human Gates
+- Review the copied real_brief source package before using any production workflow.
+- /visual-brainstorm must produce `proposal.md` and wait for human approval.
+- /visual-spec must resolve design.md before planning or generation.
+- /visual-plan must not execute production work without explicit human approval.
+
+## Suggested Next Steps
+- /visual-brainstorm seattle-polish-film-festival-poster
+- /visual-spec seattle-polish-film-festival-poster
+- /visual-plan seattle-polish-film-festival-poster
+- /evaluate seattle-polish-film-festival-poster


### PR DESCRIPTION
## Summary
- add the Seattle Polish Film Festival real-brief workflow package under docs/visual-specs
- finalize proposal.md as ready and design.md as resolved after the human accept-all gate
- keep provider execution gated; no image generation or evaluation artifacts are produced here

## Visual-spec decisions
- domain: poster
- tradition: null
- style_treatment: unified
- provider: openai
- primary output: 11 x 17 vertical poster; program cover adaptation follows the same key art

## Verification
- PYTHONPATH=src /opt/homebrew/bin/python3.11 -m pytest tests/test_real_brief_benchmark.py tests/test_real_brief_workflow_adapter.py tests/test_real_brief_brainstorm_seed.py tests/test_real_brief_workflow_review_html.py tests/test_visual_spec_schema_invariants.py tests/test_visual_spec_source_confidence_matrix.py tests/test_visual_spec_d1_registry_copy.py tests/test_prompting.py -q
- parser smoke: compose_prompt_from_design(docs/visual-specs/seattle-polish-film-festival-poster/design.md)
- git diff --check
- secret scan over docs/visual-specs/seattle-polish-film-festival-poster