### PR TITLE
[codex] Stabilize v0.23 small botanical redraw replacement

### DIFF
--- a/docs/superpowers/plans/2026-05-04-general-redraw-strategy.md
+++ b/docs/superpowers/plans/2026-05-04-general-redraw-strategy.md
@@ -1,0 +1,274 @@
+# General Redraw Strategy Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Turn the botanical showcase findings into a named first redraw strategy while preserving a general product architecture for future UI, poster, product, and texture strategies.
+
+**Architecture:** Keep shared redraw routing, provider calls, debug artifacts, pasteback, and quality gates in the core. Add strategy naming and target-aware refinement for `small_botanical_subject_replacement`, and keep broad texture edits gated until a dedicated broad-texture strategy exists.
+
+**Tech Stack:** Python 3.11, Pillow, NumPy, pytest, Vulca layers redraw pipeline.
+
+---
+
+## File Map
+
+- Modify: `src/vulca/layers/mask_refine.py`
+  - Rename the current `bright_small_subject` profile to `small_botanical_subject_replacement`.
+  - Keep the extraction implementation local to the refinement module.
+  - Preserve white and yellow evidence extraction.
+
+- Modify: `src/vulca/layers/redraw.py`
+  - Report the new strategy name in `redraw_advisory`.
+  - Rename user-facing matte labels from flower-only wording to small botanical wording where safe.
+  - Keep existing source-context replacement behavior unchanged.
+
+- Modify: `src/vulca/layers/redraw_quality.py`
+  - Keep broad texture repaint detection.
+  - Make metrics/advisory serve the broader product contract.
+
+- Modify: `tests/test_mask_refine.py`
+  - Update strategy-name expectations.
+  - Add yellow/buttercup/dandelion coverage assertions.
+
+- Modify: `tests/test_layers_redraw_refinement.py`
+  - Update advisory expectations.
+  - Keep provider-call refusal test for broad hedge texture.
+
+- Modify: `tests/test_layers_redraw_quality_gates.py`
+  - Keep broad texture quality gate coverage.
+
+- Create: `docs/superpowers/specs/2026-05-04-general-redraw-strategy-design.md`
+  - Product architecture and scope.
+
+- Create: `docs/superpowers/plans/2026-05-04-general-redraw-strategy.md`
+  - This implementation plan.
+
+## Task 1: Rename The Refinement Strategy Contract
+
+**Files:**
+- Modify: `tests/test_mask_refine.py`
+- Modify: `src/vulca/layers/mask_refine.py`
+
+- [x] **Step 1: Write failing tests**
+
+Change strategy assertions in `tests/test_mask_refine.py` to expect:
+
+```python
+assert result.strategy == "small_botanical_subject_replacement"
+```
+
+Add or keep a yellow subject test:
+
+```python
+def test_refines_yellow_dandelion_heads_without_flower_keyword():
+    source = Image.new("RGB", (320, 220), (76, 112, 52))
+    draw = ImageDraw.Draw(source)
+    centers = (
+        (58, 42),
+        (104, 56),
+        (152, 48),
+        (214, 78),
+        (260, 96),
+        (90, 138),
+        (184, 152),
+        (250, 166),
+    )
+    for cx, cy in centers:
+        draw.line((cx, cy + 5, cx - 4, cy + 34), fill=(64, 105, 48), width=2)
+        draw.ellipse((cx - 7, cy - 6, cx + 7, cy + 6), fill=(232, 190, 31))
+        draw.ellipse((cx - 2, cy - 2, cx + 2, cy + 2), fill=(176, 130, 18))
+
+    alpha = Image.new("L", source.size, 0)
+    ImageDraw.Draw(alpha).rectangle((20, 18, 300, 190), fill=255)
+
+    result = refine_mask_for_target(
+        source,
+        alpha,
+        description="roadside dandelion heads in grass",
+        instruction="turn the yellow dots into buttercup meadow rhythm",
+    )
+
+    assert result.applied is True
+    assert result.strategy == "small_botanical_subject_replacement"
+    assert len(result.child_masks) >= 4
+    assert result.metrics["refined_coverage_pct"] < 0.25
+```
+
+- [x] **Step 2: Verify red**
+
+Run:
+
+```bash
+PYTHONPATH=src /opt/homebrew/bin/python3.11 -m pytest tests/test_mask_refine.py -q
+```
+
+Expected: strategy-name assertions fail while existing extraction behavior still works.
+
+- [x] **Step 3: Implement minimal rename**
+
+In `src/vulca/layers/mask_refine.py`:
+
+```python
+SMALL_BOTANICAL_SUBJECT_REPLACEMENT = "small_botanical_subject_replacement"
+```
+
+Use it for `TargetRefinementProfile.kind`, `MaskRefinementResult.strategy`, and the formerly bright-small-subject profile.
+
+- [x] **Step 4: Verify green**
+
+Run:
+
+```bash
+PYTHONPATH=src /opt/homebrew/bin/python3.11 -m pytest tests/test_mask_refine.py -q
+```
+
+Expected: all tests in `tests/test_mask_refine.py` pass.
+
+## Task 2: Update Redraw Advisory To Match Strategy Product Language
+
+**Files:**
+- Modify: `tests/test_layers_redraw_refinement.py`
+- Modify: `src/vulca/layers/redraw.py`
+
+- [x] **Step 1: Write failing advisory tests**
+
+Update refinement advisory expectations:
+
+```python
+assert advisory["refinement_strategy"] == "small_botanical_subject_replacement"
+assert advisory["refinement_edit_matte"] == "small_botanical_evidence"
+assert advisory["refinement_replacement_matte"] == "small_botanical_removal"
+assert advisory["refinement_composition"] == "small_botanical_evidence_paint_cover"
+```
+
+Keep the broad hedge test expectation:
+
+```python
+assert advisory["redraw_skip_reason"] == "broad_texture_repaint_risk"
+assert provider.calls == []
+```
+
+- [x] **Step 2: Verify red**
+
+Run:
+
+```bash
+PYTHONPATH=src /opt/homebrew/bin/python3.11 -m pytest tests/test_layers_redraw_refinement.py::test_refined_flower_layer_uses_one_masked_edit_per_child tests/test_layers_redraw_refinement.py::test_auto_redraw_skips_broad_leaf_texture_risk -q
+```
+
+Expected: advisory string assertions fail before implementation.
+
+- [x] **Step 3: Implement advisory rename**
+
+In `src/vulca/layers/redraw.py`, change only advisory labels. Do not change the image generation behavior:
+
+```python
+"refinement_edit_matte": "small_botanical_evidence"
+"refinement_replacement_matte": "small_botanical_removal"
+"refinement_composition": "small_botanical_evidence_paint_cover"
+```
+
+- [x] **Step 4: Verify green**
+
+Run:
+
+```bash
+PYTHONPATH=src /opt/homebrew/bin/python3.11 -m pytest tests/test_layers_redraw_refinement.py::test_refined_flower_layer_uses_one_masked_edit_per_child tests/test_layers_redraw_refinement.py::test_auto_redraw_skips_broad_leaf_texture_risk -q
+```
+
+Expected: both tests pass.
+
+## Task 3: Keep Broad Texture Edits Gated
+
+**Files:**
+- Modify: `tests/test_layers_redraw_quality_gates.py`
+- Modify: `src/vulca/layers/redraw_quality.py`
+
+- [x] **Step 1: Preserve broad texture tests**
+
+Keep this behavior:
+
+```python
+report = evaluate_redraw_quality(
+    source,
+    output,
+    description="leafy hedge texture",
+    instruction="redraw leaf highlights as hand-painted botanical texture",
+    refinement_applied=False,
+    refined_child_count=0,
+)
+
+assert not report.passed
+assert "broad_texture_repaint" in report.failures
+assert report.metrics["src_area_pct"] > 50
+assert report.metrics["output_luma_delta_pct"] < -25
+```
+
+- [x] **Step 2: Verify**
+
+Run:
+
+```bash
+PYTHONPATH=src /opt/homebrew/bin/python3.11 -m pytest tests/test_layers_redraw_quality_gates.py -q
+```
+
+Expected: quality gate tests pass after the strategy rename.
+
+## Task 4: Full Targeted Regression
+
+**Files:**
+- Verify only.
+
+- [x] **Step 1: Run targeted redraw regression**
+
+Run:
+
+```bash
+PYTHONPATH=src /opt/homebrew/bin/python3.11 -m pytest tests/test_layers_redraw_refinement.py tests/test_mask_refine.py tests/test_layers_redraw.py tests/test_layers_redraw_crop_pipeline.py tests/test_layers_redraw_mask_aware.py tests/test_layers_redraw_strategy.py tests/test_inpaint_mask.py tests/test_mcp_layers_redraw_advisory.py tests/test_layers_redraw_quality_gates.py -q
+```
+
+Expected: all targeted tests pass.
+
+- [x] **Step 2: Run diff check**
+
+Run:
+
+```bash
+git diff --check
+```
+
+Expected: no whitespace errors.
+
+## Task 5: Product Follow-Up Tracking
+
+**Files:**
+- No code changes.
+
+- [x] **Step 1: Record next strategy candidates**
+
+After the v0.23 patch is verified, track future strategy candidates outside
+this branch:
+
+- `ui_element_redraw`
+- `poster_layout_redraw`
+- `product_photo_retouch`
+- `broad_texture_style_edit`
+- `text_region_edit`
+
+- [x] **Step 2: Do not implement future strategies in this branch**
+
+This branch stays scoped to the first production strategy and the broad-texture
+safety gate.
+
+## Execution Evidence
+
+- RED verified for `tests/test_mask_refine.py`: strategy-name assertions failed
+  against the old `bright_small_subject` contract.
+- RED verified for
+  `tests/test_layers_redraw_refinement.py::test_refined_flower_layer_uses_one_masked_edit_per_child`:
+  advisory strategy assertion failed against the old contract.
+- GREEN verified for `tests/test_mask_refine.py`: `8 passed`.
+- GREEN verified for the targeted redraw advisory tests: `2 passed`.
+- Full targeted regression:
+  `90 passed, 5 warnings`.
+- `git diff --check`: passed.

--- a/docs/superpowers/specs/2026-05-04-general-redraw-strategy-design.md
+++ b/docs/superpowers/specs/2026-05-04-general-redraw-strategy-design.md
@@ -1,0 +1,156 @@
+# General Redraw Strategy Design
+
+## Status
+
+Draft for v0.23 implementation. This document turns the roadside botanical
+showcase findings into a general redraw product architecture, while keeping the
+current branch scoped to the first production strategy.
+
+## Product Direction
+
+Vulca redraw should not become a pile of case-specific prompt patches. The
+general product should be a strategy-routed edit system:
+
+1. Diagnose the requested edit and current mask.
+2. Choose a strategy with explicit constraints.
+3. Run a provider edit with source context and mask contracts.
+4. Apply quality gates before accepting the pasteback.
+5. Return advisory when the request is unsafe for the selected strategy.
+
+The generality comes from shared contracts and routing. Specialized behavior is
+allowed only inside named strategies with tests and quality gates.
+
+## Strategy Model
+
+### Shared Redraw Core
+
+The shared core owns provider routing, source crop padding, mask diagnostics,
+debug artifacts, cost/usage reporting, pasteback, and quality reporting.
+Strategies should not duplicate these responsibilities.
+
+### Strategy Registry
+
+Each strategy declares:
+
+- Intent class: remove, replace, add, local style, global style, layout edit,
+  text edit, or product/background edit.
+- Target class: small object, large texture, UI element, poster element,
+  product object, text block, or unknown.
+- Mask policy: allowed coverage, component count, child split policy, and
+  source-context padding.
+- Matte contract: edit matte, removal matte, generation matte, and output alpha.
+- Provider contract: endpoint, model knobs, prompt constraints, and fallback.
+- Quality gates: artifact checks, preservation checks, and refusal conditions.
+
+The current branch should add the first production strategy:
+
+```text
+small_botanical_subject_replacement
+```
+
+This strategy covers small repeated botanical objects such as white flower
+heads, yellow dandelion heads, buttercups, blossoms, petals, and similar small
+visual targets. It does not cover broad hedge, grass, foliage, tree, or leaf
+texture redraw.
+
+## Current Findings
+
+The roadside showcase produced three important observations:
+
+- White flower and yellow flower edits work when the target is split into small
+  child masks and the model edits source-context crops.
+- Old flower residue is reduced when removal matte and generation matte are
+  separated instead of using one alpha mask for every stage.
+- Broad leaf/hedge texture repaint is unsafe. A temporary green-leaf probe had
+  roughly 57% crop mask coverage and produced a dark pasted texture block.
+
+These findings mean botanical small-object replacement is worth productizing,
+but broad plant texture redraw must be gated until a dedicated strategy exists.
+
+## v0.23 Scope
+
+This branch should land the following only:
+
+- General naming and advisory framing for a small botanical strategy.
+- Target-aware refinement for white and yellow small botanical subjects.
+- Broad texture preflight skip/advisory when the mask is too wide for local
+  redraw.
+- Tests covering white flowers, yellow flowers, and broad hedge refusal.
+- Documentation that explains why this is the first strategy, not the whole
+  general redraw product.
+- A record that local showcase artifacts were used as evidence, without making
+  the full generated artifact directory part of the default source commit.
+
+This branch should not attempt:
+
+- UI redraw.
+- Poster/layout redraw.
+- Product photo retouching.
+- Text editing.
+- Broad hedge/grass/tree style transfer.
+
+## Artifact Policy
+
+The local roadside showcase directory
+`docs/visual-specs/2026-04-27-ipad-cartoon-roadside/v0_23_gpt_image_2/`
+contains generated provider outputs and intermediate debug files. It is useful
+for visual evidence, but it is not part of the default v0.23 source patch: the
+directory can be multiple gigabytes and contains many repeated run artifacts.
+
+For review, keep only curated paths in the written summary or a deliberately
+selected visual appendix. Do not commit every child crop, raw output, and replay
+directory unless a release or artifact-storage decision explicitly asks for it.
+
+## Product Roadmap
+
+### Phase 1: Strategy Infrastructure
+
+Define strategy metadata and diagnostics without changing user-facing behavior
+too much. Add a registry once there are at least two production strategies.
+
+Minimum shared diagnostics:
+
+- mask area percentage
+- mask bbox percentage
+- bbox fill ratio
+- component count
+- refined child count
+- refined coverage percentage
+- mask granularity score
+- output luma delta
+- artifact ratios such as dark fill and olive fill
+
+### Phase 2: Small Object Replacement
+
+Make small object replacement the stable local-edit lane. Botanical subjects are
+the first instance. Later targets can include small icons, stickers, fruit,
+jewelry, props, and other repeated objects if their masks are precise.
+
+### Phase 3: UI and Layout Strategies
+
+UI and poster redraw require different contracts:
+
+- preserve text or force OCR-safe regeneration
+- preserve layout grids and alignment
+- protect icons and logos
+- evaluate outside-mask layout drift
+- avoid source-photo botanical color heuristics
+
+They should be separate strategies, not extensions of botanical replacement.
+
+### Phase 4: Broad Texture and Global Style
+
+Broad texture redraw needs a dedicated strategy with structure preservation,
+style reference control, and stronger outside-mask metrics. Until then, broad
+texture masks should return advisory instead of being silently edited.
+
+## Success Criteria
+
+For v0.23:
+
+- White flower and yellow flower targets infer the same small botanical strategy.
+- Broad hedge/leaf texture requests with broad masks skip provider calls in auto
+  route and return advisory.
+- Quality gates report why a result is risky.
+- Debug artifacts preserve child input, mask, raw, patch, and pasteback.
+- Tests cover the intended behavior without relying on real provider calls.

--- a/docs/superpowers/specs/2026-05-05-layered-scene-reconstruction-design.md
+++ b/docs/superpowers/specs/2026-05-05-layered-scene-reconstruction-design.md
@@ -1,0 +1,478 @@
+# Layered Scene Reconstruction Design
+
+**Date:** 2026-05-05
+**Target version:** v0.24 candidate
+**Status:** Draft for user review
+
+---
+
+## Problem
+
+The v0.23 roadside redraw work improved local botanical replacement, but it also
+exposed a product boundary: a single local redraw mask is not enough when the
+desired result is closer to a cleaned, stylized reconstruction of the whole
+scene.
+
+The visible failure mode is old source residue. Small flower edits can generate
+better flower heads, but if the original source flower pixels remain outside the
+accepted output alpha, the pasteback looks like new flowers were layered on top
+of old flowers. Tightening the child prompt helps, but it cannot solve ownership
+of adjacent pixels by itself.
+
+The user direction is to explore whether Vulca can reconstruct the same photo as
+editable semantic layers: clean sky, vehicle, trees, guardrail, hedge, flowers,
+stems, and residual texture. This is not just a bigger mask. It is a workflow
+above redraw that assigns each visible surface to a layer, reconstructs or
+preserves that layer with a clear prompt contract, and composites the result
+back through the existing manifest system.
+
+## Design Question
+
+Can Vulca combine the existing layered-generation architecture with the new
+redraw replacement contract to produce a more controllable "source photo ->
+editable stylized layer stack" workflow?
+
+## Recommended Approach
+
+Use **source-driven layered reconstruction** as the first implementation lane.
+It starts from an existing image, creates semantic masks, reconstructs selected
+layers, and uses redraw only for local replacements inside those layers.
+
+This approach fits the current branch because it reuses proven pieces:
+
+- `decompose` and manifest output for semantic layers.
+- target-aware mask refinement for small repeated details.
+- source crop padding and OpenAI-compatible `/v1/images/edits`.
+- pasteback/composite for visual review.
+- quality gates and advisory for unsafe broad texture edits.
+
+It also avoids overextending the small botanical strategy. Broad hedge, grass,
+and tree surfaces need layer-specific reconstruction prompts and validation
+instead of being treated as giant flower masks.
+
+## Alternatives Considered
+
+### A. Source-driven layered reconstruction
+
+Start from a source image, segment it into named semantic layers, then
+reconstruct or clean each layer using layer-specific prompts.
+
+Pros:
+
+- Directly addresses old-source residue by assigning pixel ownership.
+- Works with user-provided images.
+- Lets the current redraw strategy remain narrow and reliable.
+- Produces artifacts a designer can inspect and edit per layer.
+
+Cons:
+
+- Depends on mask quality.
+- Requires z-index and overlap validation.
+- Large layers need different gates than small-object replacement.
+
+### B. Native layered generation from prompt
+
+Generate each layer directly from a high-level intent without relying on a
+source photo.
+
+Pros:
+
+- Cleaner alpha extraction for generated assets.
+- Better for new illustration creation.
+- Matches the earlier dual-path layer architecture.
+
+Cons:
+
+- Does not solve the current "recreate this photo" problem first.
+- Harder to preserve source geometry and object identity.
+- More likely to drift from the specific roadside image.
+
+### C. Keep improving only local redraw
+
+Continue splitting flower masks and tuning prompts.
+
+Pros:
+
+- Smallest code surface.
+- Already has tests and visual evidence.
+
+Cons:
+
+- Cannot fully remove old residue when the surrounding layer still contains old
+  target pixels.
+- Does not address larger style mismatch across sky, car, trees, hedge, and
+  guardrail.
+- Keeps pushing broad scene problems into a local edit tool.
+
+## Scope
+
+The first deliverable should be a prototype and then a productized MVP for the
+roadside photo class. It should not immediately become a universal scene
+editor.
+
+In scope:
+
+- Build a semantic layer plan for a source image.
+- Normalize masks into non-overlapping layer ownership.
+- Reconstruct selected layers using layer-specific image-edit prompts.
+- Use `redraw_layer` for small detail layers such as white and yellow flower
+  heads.
+- Composite all layers back into a full preview.
+- Save per-layer input, mask, raw, patch, pasteback, usage, and failure notes.
+- Report when a layer is unsafe to regenerate.
+
+Out of scope for this spec:
+
+- Full UI workflow.
+- Video.
+- Camera relayout or perspective redesign.
+- Text or logo editing.
+- Full product-grade broad hedge repaint before a dedicated strategy exists.
+- Committing large generated provider artifacts by default.
+
+## Roadside Layer Taxonomy
+
+For the current roadside image, start with this semantic stack:
+
+| z-index | semantic path | role | first action |
+|---:|---|---|---|
+| 0 | `background.sky.clean_blue` | sky plate | reconstruct cleanly |
+| 10 | `background.distant_trees` | far green tree mass | preserve or light cleanup |
+| 20 | `subject.vehicle.red_car` | red car | reconstruct as isolated vehicle layer |
+| 30 | `subject.vehicle.yellow_truck` | distant yellow vehicle | preserve unless mask is good |
+| 40 | `foreground.guardrail` | horizontal guardrail | reconstruct or preserve |
+| 50 | `foreground.grass_bank` | broad grass area | preserve/residual in MVP |
+| 60 | `foreground.hedge_bush` | broad leaf texture | preserve/residual until strategy exists |
+| 70 | `detail.dry_stems` | thin foreground stems | preserve or extract as line detail |
+| 80 | `detail.white_flower_cluster` | small white flower heads | redraw replacement strategy |
+| 90 | `detail.yellow_dandelion_heads` | small yellow flower heads | redraw replacement strategy |
+| 100 | `residual.source_texture` | safety layer | fills holes and unknown pixels |
+
+The stack is intentionally conservative: small detail layers can be edited
+first, while broad green texture remains source-owned until a broad-texture
+strategy exists.
+
+## Data Flow
+
+```text
+source image
+  -> semantic layer plan
+  -> masks per semantic path
+  -> mask ownership normalization
+  -> per-layer crop + prompt contract
+  -> provider edit or preserve
+  -> layer RGBA output
+  -> manifest
+  -> composite preview
+  -> per-layer and full-scene evaluation
+```
+
+### Mask Ownership
+
+Every source pixel should have one primary owner:
+
+- Foreground detail masks can overlap broad base masks during detection.
+- Before compositing, detail masks subtract from their parent base masks.
+- Any unassigned pixels go into `residual.source_texture`.
+- The residual layer is visible in MVP outputs so holes are obvious.
+
+This matters for the flower problem. If old white or yellow flower pixels remain
+inside `foreground.hedge_bush`, then new flower heads will look stacked on top
+of old ones. Layer ownership should subtract flower detail from the hedge base
+before the final composite.
+
+## Prompt Contract
+
+Prompts should be English by default because current image-edit providers
+respond more reliably to precise English spatial constraints. Chinese UI copy
+can wrap these prompts later, but the provider prompt should stay direct.
+
+### Global Layer Planning Prompt
+
+Use this with a VLM or planning model before mask creation:
+
+```text
+You are planning an editable semantic layer reconstruction of one source image.
+
+Return JSON only. Do not describe the image in prose.
+
+Goal:
+- Recreate the source image as a stack of editable visual layers.
+- Each layer must own a clear semantic surface or object.
+- Prefer fewer stable layers over many fragile fragments.
+- Use a residual layer for pixels that are uncertain or not worth editing.
+
+For each layer return:
+- semantic_path: dot-separated stable name.
+- display_name: short human-readable name.
+- z_index: integer, lower means farther back.
+- visual_role: background | subject | foreground | detail | residual.
+- mask_prompt: concise phrase for segmentation.
+- reconstruction_policy: reconstruct | preserve | local_redraw | residual.
+- edit_risk: low | medium | high.
+- forbidden_content: objects that must not appear in this layer.
+- parent_layer: semantic_path or null.
+
+Important:
+- White and yellow flower heads should be detail layers, not part of hedge.
+- Guardrail should be separate from vehicles and plants.
+- Sky should not include trees, vehicles, rail, road, or flowers.
+- Broad grass, hedge, and tree texture are high risk unless masks are clean.
+```
+
+### Common Edit Prefix
+
+Use this prefix for OpenAI-compatible `/v1/images/edits` masked edits:
+
+```text
+Edit only the transparent mask pixels where mask alpha=0.
+Leave every opaque pixel unchanged.
+Use the source crop only as geometry, lighting, edge, and scale context.
+Do not create a full miniature scene.
+Do not add objects outside the requested layer.
+Return a clean layer-compatible result with no rectangular thumbnail, black
+background, hard pasted block, or unrelated scene content.
+```
+
+### Sky Layer Prompt
+
+```text
+Reconstruct only the sky layer.
+
+Create a clean, calm blue sky plate matching the source camera angle and light.
+Keep it simple and graphic, suitable for a polished illustrated roadside scene.
+Do not include trees, vehicles, guardrail, road, hedge, flowers, stems, clouds,
+text, birds, buildings, or silhouettes.
+The sky should be smooth enough to sit behind all other layers.
+```
+
+Use policy: reconstruct. This can be a background plate rather than transparent
+RGBA because it is the bottom layer.
+
+### Distant Tree Layer Prompt
+
+```text
+Reconstruct only the distant tree canopy layer.
+
+Keep the tree mass behind the vehicles and guardrail. Preserve the broad shape,
+height, light direction, and soft depth of the source. Render it as cohesive
+illustrated foliage, not detailed noisy leaf texture.
+Do not include sky, cars, trucks, guardrail, road, foreground hedge, flowers,
+or stems.
+Avoid black fill, rectangular patches, and photo-real leaf noise.
+```
+
+Use policy: preserve first, reconstruct only if the mask is clean and layer area
+is stable.
+
+### Vehicle Layer Prompt
+
+```text
+Reconstruct only the red car as a separate visual layer.
+
+Preserve the car's source position, scale, side profile, roofline, windows,
+wheels, and perspective. Make the styling cleaner and more graphic while still
+recognizable as the same roadside vehicle.
+Do not include sky, trees, guardrail, road, hedge, flowers, stems, or other
+vehicles.
+Keep edges crisp enough for compositing, with natural antialiasing.
+```
+
+Use policy: reconstruct if the mask has clean vehicle boundaries; otherwise
+preserve.
+
+### Guardrail Layer Prompt
+
+```text
+Reconstruct only the metal roadside guardrail layer.
+
+Preserve the long horizontal rail direction, post rhythm, perspective, and
+occlusion relationship with the vehicles and plants. Use a clean illustrated
+metal surface with subtle highlights.
+Do not include cars, sky, trees, road, hedge, grass, flowers, or stems.
+Avoid thick blocky bands, broken floating rail pieces, and dark background fill.
+```
+
+Use policy: reconstruct or preserve. Guardrail is a good early candidate because
+it has strong geometry and clear z-order.
+
+### Hedge And Bush Base Prompt
+
+```text
+Reconstruct only the broad foreground hedge and bush mass.
+
+Preserve the overall silhouette, density, light direction, and roadside depth.
+Create a cohesive illustrated green plant mass with controlled texture.
+Do not generate individual white flowers, yellow flowers, car parts, guardrail,
+sky, road, or tree trunks unless those pixels are explicitly inside the mask.
+Avoid noisy photo leaves, black fill, rectangular pasted blocks, and large color
+shifts.
+```
+
+Use policy: preserve in the first MVP. This prompt is included for later broad
+texture strategy work, not for immediate unrestricted use.
+
+### White Flower Detail Prompt
+
+```text
+Reconstruct only the small white flower heads inside the transparent mask.
+
+Paint separated tiny white wildflower heads with warm centers, varied spacing,
+and a clean illustrated style. Match the source footprint, scale, lighting, and
+edge softness.
+Do not repaint hedge texture, grass, stems, guardrail, vehicles, sky, road, or
+any broad background area.
+Do not stack new flowers on top of visible old flower residue; the flower layer
+owns these pixels.
+```
+
+Use policy: local_redraw with target-aware child masks.
+
+### Yellow Dandelion Detail Prompt
+
+```text
+Reconstruct only the yellow dandelion or buttercup flower heads inside the
+transparent mask.
+
+Paint exactly {head_count} separated yellow flower head{plural_suffix}. Match
+the original head size, footprint, and spacing. Use warm yellow petals with
+slightly deeper centers and natural edge softness.
+Do not add extra heads. Do not repaint hedge texture, grass, stems, guardrail,
+vehicles, sky, road, or any broad background area.
+Do not create a whole roadside scene, thumbnail, sticker sheet, black
+background, or rectangular patch.
+```
+
+Use policy: local_redraw with target-aware child masks and yellow palette gates.
+
+### Dry Stem Detail Prompt
+
+```text
+Reconstruct only the thin dry foreground stems and small branch lines.
+
+Preserve the source position, direction, taper, and overlap relationship with
+flowers and hedge. Render as delicate natural line details with transparent
+surrounding pixels.
+Do not include flower heads, leaves, sky, vehicles, guardrail, or broad hedge
+texture.
+```
+
+Use policy: preserve first. Reconstruct only if line masks are reliable.
+
+### Negative Prompt Block
+
+Append this block when a provider tends to leak scene content:
+
+```text
+Forbidden: black background, gray background, rectangular thumbnail, full scene,
+roadside panorama, car, truck, guardrail, sky, road, hedge, grass, tree, stems,
+extra flowers, sticker sheet, poster, text, watermark, logo, frame, border.
+Only include the requested layer.
+```
+
+For layer prompts, remove terms from the forbidden list when they are the
+requested layer. For example, do not forbid `guardrail` in the guardrail prompt.
+
+## Product API Shape
+
+The eventual API should be a new workflow above individual redraw:
+
+```python
+result = await reconstruct_layers(
+    artwork,
+    source_image="source.png",
+    layer_plan="auto",
+    policies={
+        "background.sky.clean_blue": "reconstruct",
+        "foreground.guardrail": "reconstruct",
+        "detail.white_flower_cluster": "local_redraw",
+        "detail.yellow_dandelion_heads": "local_redraw",
+        "foreground.hedge_bush": "preserve",
+    },
+    provider="openai",
+    model="gpt-image-2",
+    max_cost_usd=1.50,
+)
+```
+
+This should not replace `redraw_layer`. It should call `redraw_layer` for
+layers whose policy is `local_redraw`, and use separate layer reconstruction
+helpers for larger semantic layers.
+
+## Quality Gates
+
+Layered reconstruction needs gates at two levels.
+
+### Per-layer Gates
+
+- Alpha is non-empty and not a full rectangle unless the layer is a background.
+- Output bbox is close to mask bbox.
+- Outside-mask color drift stays below threshold.
+- No black or dark fill artifacts unless the source layer is actually dark.
+- No forbidden semantic content for that layer.
+- Crop edge seams are below threshold after pasteback.
+- For small botanical details, generated head count is close to expected count.
+- For broad layers, texture frequency must not become noisy or blocky.
+
+### Full-composite Gates
+
+- No visible holes after residual layer fill.
+- Detail layers are not duplicated in parent broad layers.
+- Z-order is visually coherent: sky behind trees, trees behind vehicles,
+  guardrail in front of or behind objects according to source, flowers in front
+  of hedge.
+- Composite preserves source layout unless user requests redesign.
+- Before/after preview shows style improvement without object identity loss.
+
+## Evaluation Targets
+
+The first prototype should produce these artifacts:
+
+- `layer_plan.json`
+- `manifest.json`
+- per-layer `input.png`
+- per-layer `mask.png`
+- per-layer `raw.png`
+- per-layer `patch.png`
+- per-layer `pasteback.png`
+- full `source_pasteback.png`
+- full `layered_composite.png`
+- `summary.json` with usage, cost, layer policies, failures, and gate results
+- focused before/after crops for the flowers, guardrail, and vehicle zone
+
+## MVP Sequence
+
+1. Write this design and review it.
+2. Create an implementation plan before code changes.
+3. Prototype outside the repo artifact path on the current roadside source.
+4. Start with four active layers: sky, guardrail, white flowers, yellow flowers.
+5. Preserve hedge, grass, trees, vehicles, and residual as source layers.
+6. Add mask ownership subtraction so flower pixels are removed from the hedge
+   base before compositing.
+7. Evaluate whether old flower residue disappears.
+8. Only then consider reconstructing vehicle or tree layers.
+
+## Success Criteria
+
+The workflow is successful when:
+
+- The full preview looks like a deliberate stylized reconstruction, not a set
+  of pasted local edits.
+- Old white/yellow flower residue is not visible under regenerated flower
+  heads at 2x zoom.
+- Layer outputs are separately useful: sky can be hidden, guardrail can be
+  replaced, flowers can be regenerated without touching the car.
+- Broad hedge texture is either cleanly preserved or explicitly refused, not
+  silently degraded.
+- `summary.json` makes cost, failures, and skipped layers auditable.
+
+## Implementation Starting Point
+
+The first implementation plan should start with existing or hand-curated masks
+for the current roadside image. The visual question is layer ownership and
+composite quality, not whether a general planner can already infer the perfect
+taxonomy.
+
+A general planner pass can come after the prototype proves that subtracting
+detail layers from broad parent layers removes old-source residue and produces a
+better editable composite.

--- a/src/vulca/layers/mask_refine.py
+++ b/src/vulca/layers/mask_refine.py
@@ -9,7 +9,7 @@ from PIL import Image
 
 @dataclass(frozen=True)
 class TargetRefinementProfile:
-    kind: Literal["bright_small_subject"]
+    kind: Literal["small_botanical_subject_replacement"]
     keywords: tuple[str, ...]
 
 
@@ -22,7 +22,10 @@ class MaskRefinementResult:
     metrics: dict[str, float]
 
 
-_BRIGHT_SMALL_SUBJECT_KEYWORDS = (
+SMALL_BOTANICAL_SUBJECT_REPLACEMENT = "small_botanical_subject_replacement"
+
+
+_SMALL_BOTANICAL_SUBJECT_KEYWORDS = (
     "flower",
     "wildflower",
     "blossom",
@@ -32,6 +35,8 @@ _BRIGHT_SMALL_SUBJECT_KEYWORDS = (
     "small",
     "daisy",
     "aster",
+    "dandelion",
+    "buttercup",
 )
 
 
@@ -42,11 +47,14 @@ def infer_refinement_profile(
 ) -> TargetRefinementProfile | None:
     text = f"{description} {instruction}".lower()
     matches = tuple(
-        keyword for keyword in _BRIGHT_SMALL_SUBJECT_KEYWORDS if keyword in text
+        keyword for keyword in _SMALL_BOTANICAL_SUBJECT_KEYWORDS if keyword in text
     )
     if not matches:
         return None
-    return TargetRefinementProfile(kind="bright_small_subject", keywords=matches)
+    return TargetRefinementProfile(
+        kind=SMALL_BOTANICAL_SUBJECT_REPLACEMENT,
+        keywords=matches,
+    )
 
 
 def refine_mask_for_target(
@@ -57,7 +65,7 @@ def refine_mask_for_target(
     instruction: str = "",
     min_component_area: int = 24,
     merge_distance_px: int = 10,
-    max_children: int = 12,
+    max_children: int = 24,
 ) -> MaskRefinementResult:
     profile = infer_refinement_profile(
         description=description,
@@ -72,7 +80,7 @@ def refine_mask_for_target(
             metrics={},
         )
 
-    child_masks, metrics = _extract_bright_small_subject_masks(
+    child_masks, metrics = _extract_small_botanical_subject_masks(
         source,
         alpha,
         min_component_area=min_component_area,
@@ -97,7 +105,7 @@ def refine_mask_for_target(
     )
 
 
-def _extract_bright_small_subject_masks(
+def _extract_small_botanical_subject_masks(
     source: Image.Image,
     alpha: Image.Image,
     *,
@@ -128,6 +136,12 @@ def _extract_bright_small_subject_masks(
 
     components = _connected_component_boxes(component_seed, min_area=min_component_area)
     boxes = _merge_nearby_boxes(components, distance_px=merge_distance_px)
+    boxes = _split_oversized_boxes(
+        boxes,
+        component_seed,
+        max_span_px=128,
+        min_area=min_component_area,
+    )
     boxes = sorted(boxes, key=_box_area, reverse=True)[:max_children]
 
     height, width = parent.shape
@@ -153,6 +167,47 @@ def _extract_bright_small_subject_masks(
         "mask_granularity_score": float(len(child_masks)),
     }
     return tuple(child_masks), metrics
+
+
+def _split_oversized_boxes(
+    boxes: list[tuple[int, int, int, int]],
+    evidence: np.ndarray,
+    *,
+    max_span_px: int,
+    min_area: int,
+) -> list[tuple[int, int, int, int]]:
+    split: list[tuple[int, int, int, int]] = []
+    height, width = evidence.shape
+    for left, top, right, bottom in boxes:
+        box_w = right - left
+        box_h = bottom - top
+        if box_w <= max_span_px and box_h <= max_span_px:
+            split.append((left, top, right, bottom))
+            continue
+
+        cols = max(1, int(np.ceil(box_w / max_span_px)))
+        rows = max(1, int(np.ceil(box_h / max_span_px)))
+        tile_w = int(np.ceil(box_w / cols))
+        tile_h = int(np.ceil(box_h / rows))
+        for row in range(rows):
+            tile_top = min(height, top + row * tile_h)
+            tile_bottom = min(height, top + (row + 1) * tile_h)
+            for col in range(cols):
+                tile_left = min(width, left + col * tile_w)
+                tile_right = min(width, left + (col + 1) * tile_w)
+                local = evidence[tile_top:tile_bottom, tile_left:tile_right]
+                if int(local.sum()) < min_area:
+                    continue
+                ys, xs = np.where(local)
+                split.append(
+                    (
+                        int(tile_left + xs.min()),
+                        int(tile_top + ys.min()),
+                        int(tile_left + xs.max() + 1),
+                        int(tile_top + ys.max() + 1),
+                    )
+                )
+    return split
 
 
 def _connected_component_boxes(

--- a/src/vulca/layers/mask_refine.py
+++ b/src/vulca/layers/mask_refine.py
@@ -127,8 +127,22 @@ def _extract_small_botanical_subject_masks(
 
     white_like = (red > 185) & (green > 185) & (blue > 170) & (channel_spread < 70)
     yellow_center = (red > 170) & (green > 130) & (blue < 120)
+    green_dominant = (green > red + 12) & (green > blue + 12)
+    muted_flower_footprint = (
+        (red > 135)
+        & (green > 120)
+        & (blue > 70)
+        & (channel_spread < 115)
+        & ~green_dominant
+    )
     evidence_raw = parent & (white_like | yellow_center)
     evidence = _dilate(evidence_raw, radius=2) & parent
+    footprint_radius = max(6, min(14, merge_distance_px + 2))
+    footprint = (
+        parent
+        & (white_like | yellow_center | muted_flower_footprint)
+        & _dilate(evidence_raw, radius=footprint_radius)
+    )
 
     component_seed = _open(evidence_raw, radius=1) & parent
     if not component_seed.any():
@@ -147,10 +161,18 @@ def _extract_small_botanical_subject_masks(
     height, width = parent.shape
     child_masks: list[Image.Image] = []
     for box in boxes:
-        left, top, right, bottom = _expand_box(box, width, height, padding=6)
+        left, top, right, bottom = _expand_box(
+            box,
+            width,
+            height,
+            padding=footprint_radius,
+        )
         child = np.zeros(parent.shape, dtype=np.uint8)
         local_evidence = evidence_raw[top:bottom, left:right]
-        local_child = _dilate(local_evidence, radius=4) & parent[top:bottom, left:right]
+        local_footprint = footprint[top:bottom, left:right]
+        local_child = (
+            _dilate(local_evidence, radius=4) | local_footprint
+        ) & parent[top:bottom, left:right]
         child[top:bottom, left:right] = local_child * 255
         if np.any(child):
             child_masks.append(Image.fromarray(child, mode="L"))

--- a/src/vulca/layers/redraw.py
+++ b/src/vulca/layers/redraw.py
@@ -1307,9 +1307,10 @@ async def _redraw_source_context_with_edit_matte(
                         "raw_scene_gate": raw_scene_gate,
                     }
                 )
+        output_matte = edit_matte if target_palette == "yellow" else generation_matte
         flower_alpha = _build_flower_output_alpha(
             crop_out,
-            generation_matte,
+            output_matte,
             target_palette=target_palette,
         )
         crop_out.putalpha(flower_alpha)

--- a/src/vulca/layers/redraw.py
+++ b/src/vulca/layers/redraw.py
@@ -733,7 +733,12 @@ def _build_source_flower_cover_alpha(source_crop, removal_matte):
     return Image.fromarray(cover_arr, mode="L")
 
 
-def _build_generated_flower_cover_patch(generated_crop, source_cover_alpha):
+def _build_generated_flower_cover_patch(
+    generated_crop,
+    source_cover_alpha,
+    *,
+    target_palette: str = "mixed",
+):
     import numpy as np
 
     from PIL import Image, ImageFilter
@@ -764,7 +769,18 @@ def _build_generated_flower_cover_patch(generated_crop, source_cover_alpha):
         & (blue < 160)
         & ((red - blue) > 20)
     )
-    flower_paint = (white_like | yellow_center) & (flower_alpha > 8)
+    yellow_like = (
+        (red > 160)
+        & (green > 110)
+        & (blue < 135)
+        & ((red - blue) > 45)
+        & ((green - blue) > 15)
+        & ((red + green - 2 * blue) > 135)
+    )
+    if target_palette == "yellow":
+        flower_paint = yellow_like & (flower_alpha > 8)
+    else:
+        flower_paint = (white_like | yellow_center) & (flower_alpha > 8)
     cover_visible = cover > 8
     if not flower_paint.any() or not cover_visible.any():
         return Image.new("RGBA", flowers.size, (0, 0, 0, 0))
@@ -794,6 +810,8 @@ def _compose_flower_replacement_patch(
     cleared_crop,
     generated_crop,
     removal_matte,
+    *,
+    target_palette: str = "mixed",
 ):
     from PIL import Image
 
@@ -802,7 +820,11 @@ def _compose_flower_replacement_patch(
     flowers = generated_crop.convert("RGBA")
     base.alpha_composite(flowers)
     base.alpha_composite(
-        _build_generated_flower_cover_patch(flowers, source_cover_alpha)
+        _build_generated_flower_cover_patch(
+            flowers,
+            source_cover_alpha,
+            target_palette=target_palette,
+        )
     )
     return base
 
@@ -923,7 +945,30 @@ def _write_redraw_debug_summary(
     summary_path.write_text(json.dumps(summary, indent=2, ensure_ascii=False))
 
 
-def _build_flower_output_alpha(crop_rgba, edit_matte):
+def _image_result_cost_usd(result) -> float | None:
+    metadata = getattr(result, "metadata", {}) or {}
+    cost = metadata.get("cost_usd")
+    if isinstance(cost, (int, float)):
+        return float(cost)
+    return None
+
+
+def _infer_small_botanical_target_palette(
+    *,
+    description: str = "",
+    instruction: str = "",
+) -> str:
+    text = f"{description} {instruction}".lower()
+    if any(term in text for term in ("dandelion", "buttercup")):
+        return "yellow"
+    if "yellow" in text and not any(
+        term in text for term in ("white flower", "white wildflower", "white petal")
+    ):
+        return "yellow"
+    return "mixed"
+
+
+def _build_flower_output_alpha(crop_rgba, edit_matte, *, target_palette: str = "mixed"):
     import numpy as np
 
     from PIL import Image, ImageFilter
@@ -950,7 +995,18 @@ def _build_flower_output_alpha(crop_rgba, edit_matte):
         & (blue < 160)
         & ((red - blue) > 20)
     )
-    flower_like = (white_like | yellow_center) & (alpha_arr > 0)
+    yellow_like = (
+        (red > 160)
+        & (green > 110)
+        & (blue < 135)
+        & ((red - blue) > 45)
+        & ((green - blue) > 15)
+        & ((red + green - 2 * blue) > 135)
+    )
+    if target_palette == "yellow":
+        flower_like = yellow_like & (alpha_arr > 0)
+    else:
+        flower_like = (white_like | yellow_center) & (alpha_arr > 0)
     if flower_like.any():
         support = Image.fromarray((flower_like.astype(np.uint8) * 255))
         support = support.filter(ImageFilter.MaxFilter(5)).filter(
@@ -959,6 +1015,9 @@ def _build_flower_output_alpha(crop_rgba, edit_matte):
         alpha_arr = np.minimum(alpha_arr, np.asarray(support))
     else:
         alpha_arr[:] = 0
+
+    if target_palette == "yellow":
+        alpha_arr[~yellow_like] = 0
 
     dark_artifact = (
         (alpha_arr > 0)
@@ -973,6 +1032,7 @@ def _build_flower_output_alpha(crop_rgba, edit_matte):
         & (green < 190)
         & ~white_like
         & ~yellow_center
+        & ~yellow_like
     )
     olive_halo = (
         (red > 45)
@@ -984,6 +1044,7 @@ def _build_flower_output_alpha(crop_rgba, edit_matte):
         & (green >= red - 10)
         & ~white_like
         & ~yellow_center
+        & ~yellow_like
     )
     alpha_arr[dark_artifact] = 0
     alpha_arr[hedge_like] = 0
@@ -1005,6 +1066,7 @@ async def _redraw_source_context_with_edit_matte(
     output_format: str = "",
     debug_artifacts=None,
     debug_child_index: int = 0,
+    target_palette: str = "mixed",
 ):
     import base64
     import io as _io
@@ -1106,13 +1168,18 @@ async def _redraw_source_context_with_edit_matte(
         out_img = _fit_into_canvas(out_img, (1024, 1024), bg_rgb=CREAM_BG_RGB)
         crop_out = out_img.crop(content_box).resize(source_crop.size, Image.LANCZOS)
         crop_out = crop_out.convert("RGBA")
-        flower_alpha = _build_flower_output_alpha(crop_out, generation_matte)
+        flower_alpha = _build_flower_output_alpha(
+            crop_out,
+            generation_matte,
+            target_palette=target_palette,
+        )
         crop_out.putalpha(flower_alpha)
         crop_out = _compose_flower_replacement_patch(
             source_crop,
             cleared_crop,
             crop_out,
             replacement_matte,
+            target_palette=target_palette,
         )
         if debug_record is not None:
             crop_out.save(debug_record["patch_path"])
@@ -1229,6 +1296,8 @@ async def redraw_layer(
     input_fidelity: str = "",
     output_format: str = "",
     debug_artifact_dir: str = "",
+    max_refinement_children: int = 0,
+    max_redraw_cost_usd: float = 0.0,
 ) -> LayerResult:
     """Redraw a single layer via img2img or mask-aware inpaint (v0.20).
 
@@ -1341,9 +1410,17 @@ async def redraw_layer(
     sparse, area_pct, bbox_fill = _compute_sparsity(src_alpha)
     geometry = analyze_alpha_geometry(src_alpha)
     redraw_plan = choose_redraw_route(geometry)
+    refinement_max_children = (
+        max_refinement_children if max_refinement_children > 0 else 24
+    )
     refinement = refine_mask_for_target(
         src_rgba.convert("RGB"),
         src_alpha,
+        description=target.info.description,
+        instruction=instruction,
+        max_children=refinement_max_children,
+    )
+    target_palette = _infer_small_botanical_target_palette(
         description=target.info.description,
         instruction=instruction,
     )
@@ -1417,6 +1494,9 @@ async def redraw_layer(
 
     refined_alpha = None
     source_context = None
+    processed_refined_child_count = 0
+    redraw_estimated_cost_usd = 0.0
+    redraw_cost_cap_reached = False
     if refinement_path_available:
         source_context = _resolve_source_context_image(
             artwork_dir=artwork_dir,
@@ -1429,6 +1509,12 @@ async def redraw_layer(
         rgba = Image.new("RGBA", src_rgba.size, (0, 0, 0, 0))
         refined_alpha = Image.new("L", src_alpha.size, 0)
         for child_index, child_mask in enumerate(refinement.child_masks, start=1):
+            if (
+                max_redraw_cost_usd > 0
+                and redraw_estimated_cost_usd >= max_redraw_cost_usd
+            ):
+                redraw_cost_cap_reached = True
+                break
             child_geometry = analyze_alpha_geometry(child_mask)
             crop_box = child_geometry.bbox
             if crop_box.w <= 0 or crop_box.h <= 0:
@@ -1467,7 +1553,11 @@ async def redraw_layer(
                     output_format=output_format,
                     debug_artifacts=debug_artifacts,
                     debug_child_index=child_index,
+                    target_palette=target_palette,
                 )
+                cost_usd = _image_result_cost_usd(_result)
+                if cost_usd is not None:
+                    redraw_estimated_cost_usd += cost_usd
                 output_alpha = crop_out.split()[-1]
                 _paste_crop_preserving_alpha(rgba, crop_out, output_alpha, crop_box)
                 refined_alpha.paste(output_alpha, (crop_box.x, crop_box.y))
@@ -1494,8 +1584,17 @@ async def redraw_layer(
                     output_format=output_format,
                     resize_to_api_size=False,
                 )
+                cost_usd = _image_result_cost_usd(_result)
+                if cost_usd is not None:
+                    redraw_estimated_cost_usd += cost_usd
                 _paste_crop_preserving_alpha(rgba, crop_out, crop_alpha, crop_box)
                 refined_alpha.paste(crop_alpha, (crop_box.x, crop_box.y))
+            processed_refined_child_count += 1
+            if (
+                max_redraw_cost_usd > 0
+                and redraw_estimated_cost_usd >= max_redraw_cost_usd
+            ):
+                redraw_cost_cap_reached = True
     elif chosen_route == "inpaint" and redraw_plan.route in sparse_crop_routes:
         rgba = Image.new("RGBA", src_rgba.size, (0, 0, 0, 0))
         for crop_box in redraw_plan.crop_boxes:
@@ -1614,9 +1713,7 @@ async def redraw_layer(
         description=target.info.description,
         instruction=instruction,
         refinement_applied=refinement_path_available,
-        refined_child_count=len(refinement.child_masks)
-        if refinement_path_available
-        else 0,
+        refined_child_count=processed_refined_child_count,
         refined_coverage_pct=refinement.metrics.get("refined_coverage_pct", 0.0)
         if refinement_path_available
         else 0.0,
@@ -1674,12 +1771,17 @@ async def redraw_layer(
         "refinement_replacement_matte": "small_botanical_removal"
         if refinement_path_available and source_context is not None
         else "none",
+        "refinement_target_palette": target_palette
+        if refinement_path_available
+        else "none",
         "refinement_composition": "small_botanical_evidence_paint_cover"
         if refinement_path_available and source_context is not None
         else "generated_patch",
-        "refined_child_count": len(refinement.child_masks)
-        if refinement_path_available
-        else 0,
+        "refined_child_count": processed_refined_child_count,
+        "max_refinement_children": max_refinement_children,
+        "redraw_cost_cap_usd": max_redraw_cost_usd,
+        "redraw_cost_cap_reached": redraw_cost_cap_reached,
+        "redraw_estimated_cost_usd": round(redraw_estimated_cost_usd, 6),
         "mask_granularity_score": refinement.metrics.get(
             "mask_granularity_score", 0.0
         ),

--- a/src/vulca/layers/redraw.py
+++ b/src/vulca/layers/redraw.py
@@ -403,6 +403,14 @@ def _crop_rgba_with_alpha(src_rgba, alpha, crop_box):
     return crop, crop_alpha
 
 
+def _pad_crop_box(crop_box, canvas_w: int, canvas_h: int, padding: int):
+    x = max(0, crop_box.x - padding)
+    y = max(0, crop_box.y - padding)
+    right = min(canvas_w, crop_box.x + crop_box.w + padding)
+    bottom = min(canvas_h, crop_box.y + crop_box.h + padding)
+    return type(crop_box)(x, y, max(0, right - x), max(0, bottom - y))
+
+
 def _resolve_source_context_image(
     *,
     artwork_dir: str,
@@ -513,11 +521,290 @@ def _build_flower_edit_matte(source_crop, child_alpha):
     if not edit.any():
         return Image.new("L", child_alpha.size, 0)
 
+    seed = Image.fromarray((edit.astype(np.uint8) * 255))
+    opened = seed.filter(ImageFilter.MinFilter(3)).filter(ImageFilter.MaxFilter(3))
+    opened_arr = (np.asarray(opened) > 0) & child_visible
+    if opened_arr.any() and int(opened_arr.sum()) >= max(6, int(edit.sum() * 0.25)):
+        edit = opened_arr
+
     matte = Image.fromarray((edit.astype(np.uint8) * 255))
-    matte = matte.filter(ImageFilter.MaxFilter(5)).filter(ImageFilter.GaussianBlur(1.0))
+    matte = matte.filter(ImageFilter.MaxFilter(3)).filter(ImageFilter.GaussianBlur(0.7))
     matte_arr = np.minimum(np.asarray(matte), child).astype(np.uint8)
     matte_arr[matte_arr < 10] = 0
     return Image.fromarray(matte_arr)
+
+
+def _build_flower_removal_matte(source_crop, child_alpha, edit_matte):
+    import numpy as np
+
+    from PIL import Image, ImageFilter
+
+    rgb = np.asarray(source_crop.convert("RGB")).astype(np.int16)
+    child = np.asarray(child_alpha.convert("L")) > 0
+    edit = np.asarray(edit_matte.convert("L")) > 0
+    if rgb.shape[:2] != child.shape or child.shape != edit.shape:
+        raise ValueError("source crop, child alpha, and edit matte sizes must match")
+    if not edit.any():
+        return edit_matte.convert("L")
+
+    red = rgb[:, :, 0]
+    green = rgb[:, :, 1]
+    blue = rgb[:, :, 2]
+    channel_spread = np.maximum.reduce((red, green, blue)) - np.minimum.reduce(
+        (red, green, blue)
+    )
+    old_flower_residue = (
+        (red > 145)
+        & (green > 135)
+        & (blue > 105)
+        & (channel_spread < 105)
+        & ~((green > red + 12) & (green > blue + 12))
+    )
+
+    seed = Image.fromarray((edit.astype(np.uint8) * 255))
+    proximity = seed.filter(ImageFilter.MaxFilter(17))
+    proximity_arr = np.asarray(proximity) > 0
+    removal = proximity_arr | (old_flower_residue & child)
+    removal = _remove_tiny_binary_components(removal, min_area=4)
+    if not removal.any():
+        return edit_matte.convert("L")
+
+    matte = Image.fromarray((removal.astype(np.uint8) * 255))
+    matte = matte.filter(ImageFilter.MaxFilter(3)).filter(ImageFilter.GaussianBlur(0.8))
+    matte_arr = np.asarray(matte).astype(np.uint8)
+    matte_arr[matte_arr < 10] = 0
+    return Image.fromarray(matte_arr, mode="L")
+
+
+def _build_flower_generation_matte(edit_matte, removal_matte):
+    import numpy as np
+
+    from PIL import Image, ImageFilter
+
+    edit = edit_matte.convert("L")
+    removal = removal_matte.convert("L")
+    if edit.size != removal.size:
+        raise ValueError("edit matte and removal matte sizes must match")
+
+    edit_arr = np.asarray(edit)
+    removal_arr = np.asarray(removal)
+    if not np.any(edit_arr > 8):
+        return edit
+
+    expanded = edit.filter(ImageFilter.MaxFilter(13)).filter(
+        ImageFilter.GaussianBlur(0.8)
+    )
+    generation_arr = np.minimum(np.asarray(expanded), removal_arr).astype(np.uint8)
+    generation_arr = np.maximum(generation_arr, edit_arr).astype(np.uint8)
+    generation_arr[generation_arr < 10] = 0
+    return Image.fromarray(generation_arr, mode="L")
+
+
+def _clear_source_crop_with_matte(source_crop, removal_matte):
+    import numpy as np
+
+    from PIL import Image
+
+    source = source_crop.convert("RGB")
+    arr = np.asarray(source).copy()
+    remove = np.asarray(removal_matte.convert("L")) > 8
+    if arr.shape[:2] != remove.shape:
+        raise ValueError("source crop and removal matte sizes must match")
+    if not remove.any():
+        return source
+
+    red = arr[:, :, 0].astype(np.int16)
+    green = arr[:, :, 1].astype(np.int16)
+    blue = arr[:, :, 2].astype(np.int16)
+    channel_spread = np.maximum.reduce((red, green, blue)) - np.minimum.reduce(
+        (red, green, blue)
+    )
+    flower_like = (
+        (red > 145)
+        & (green > 135)
+        & (blue > 105)
+        & (channel_spread < 120)
+    )
+    background = (~remove) & (~flower_like)
+    if not background.any():
+        background = ~remove
+    if not background.any():
+        arr[remove] = np.array(CREAM_BG_RGB, dtype=np.uint8)
+        return Image.fromarray(arr, mode="RGB")
+
+    arr = _fill_removed_pixels_from_boundary(arr, remove, background)
+    return Image.fromarray(arr, mode="RGB")
+
+
+def _fill_removed_pixels_from_boundary(arr, remove, known):
+    import numpy as np
+
+    filled = arr.copy()
+    unknown = remove.copy()
+    known = known.copy()
+    height, width = unknown.shape
+    max_iterations = max(1, min(max(height, width), 512))
+
+    for _ in range(max_iterations):
+        if not unknown.any():
+            break
+
+        acc = np.zeros(filled.shape, dtype=np.uint32)
+        count = np.zeros(unknown.shape, dtype=np.uint8)
+        for dy in (-1, 0, 1):
+            for dx in (-1, 0, 1):
+                if dy == 0 and dx == 0:
+                    continue
+                src_y0 = max(0, -dy)
+                src_y1 = height - max(0, dy)
+                dst_y0 = max(0, dy)
+                dst_y1 = height - max(0, -dy)
+                src_x0 = max(0, -dx)
+                src_x1 = width - max(0, dx)
+                dst_x0 = max(0, dx)
+                dst_x1 = width - max(0, -dx)
+
+                src_known = known[src_y0:src_y1, src_x0:src_x1]
+                target = unknown[dst_y0:dst_y1, dst_x0:dst_x1] & src_known
+                if not target.any():
+                    continue
+                src_values = filled[src_y0:src_y1, src_x0:src_x1]
+                for channel in range(3):
+                    acc_channel = acc[dst_y0:dst_y1, dst_x0:dst_x1, channel]
+                    acc_channel[target] += src_values[:, :, channel][target]
+                count_view = count[dst_y0:dst_y1, dst_x0:dst_x1]
+                count_view[target] += 1
+
+        candidates = unknown & (count > 0)
+        if not candidates.any():
+            break
+        filled[candidates] = (
+            acc[candidates] / count[candidates, None]
+        ).astype(np.uint8)
+        known[candidates] = True
+        unknown[candidates] = False
+
+    if unknown.any():
+        fallback = np.median(filled[known], axis=0).astype(np.uint8)
+        filled[unknown] = fallback
+    return filled
+
+
+def _build_source_flower_cover_alpha(source_crop, removal_matte):
+    import numpy as np
+
+    from PIL import Image, ImageFilter
+
+    rgb = np.asarray(source_crop.convert("RGB")).astype(np.int16)
+    removal = np.asarray(removal_matte.convert("L"))
+    if rgb.shape[:2] != removal.shape:
+        raise ValueError("source crop and removal matte sizes must match")
+
+    red = rgb[:, :, 0]
+    green = rgb[:, :, 1]
+    blue = rgb[:, :, 2]
+    channel_spread = np.maximum.reduce((red, green, blue)) - np.minimum.reduce(
+        (red, green, blue)
+    )
+    white_like = (
+        (red > 155)
+        & (green > 150)
+        & (blue > 120)
+        & (channel_spread < 120)
+    )
+    yellow_center = (
+        (red > 135)
+        & (green > 105)
+        & (blue < 145)
+        & ((red - blue) > 20)
+    )
+    old_flower = (white_like | yellow_center) & (removal > 8)
+    if not old_flower.any():
+        return Image.new("L", source_crop.size, 0)
+
+    old_flower = _remove_tiny_binary_components(old_flower, min_area=1)
+    if not old_flower.any():
+        return Image.new("L", source_crop.size, 0)
+
+    cover = Image.fromarray((old_flower.astype(np.uint8) * 255))
+    cover = cover.filter(ImageFilter.MaxFilter(3)).filter(ImageFilter.GaussianBlur(0.5))
+    cover_arr = np.minimum(np.asarray(cover), removal).astype(np.uint8)
+    cover_arr[cover_arr < 10] = 0
+    return Image.fromarray(cover_arr, mode="L")
+
+
+def _build_generated_flower_cover_patch(generated_crop, source_cover_alpha):
+    import numpy as np
+
+    from PIL import Image, ImageFilter
+
+    flowers = generated_crop.convert("RGBA")
+    cover_alpha = source_cover_alpha.convert("L")
+    if flowers.size != cover_alpha.size:
+        raise ValueError("generated crop and source cover alpha sizes must match")
+
+    flower_alpha = np.asarray(flowers.split()[-1])
+    rgb = np.asarray(flowers.convert("RGB")).astype(np.int16)
+    cover = np.asarray(cover_alpha)
+    red = rgb[:, :, 0]
+    green = rgb[:, :, 1]
+    blue = rgb[:, :, 2]
+    channel_spread = np.maximum.reduce((red, green, blue)) - np.minimum.reduce(
+        (red, green, blue)
+    )
+    white_like = (
+        (red > 145)
+        & (green > 145)
+        & (blue > 120)
+        & (channel_spread < 120)
+    )
+    yellow_center = (
+        (red > 130)
+        & (green > 95)
+        & (blue < 160)
+        & ((red - blue) > 20)
+    )
+    flower_paint = (white_like | yellow_center) & (flower_alpha > 8)
+    cover_visible = cover > 8
+    if not flower_paint.any() or not cover_visible.any():
+        return Image.new("RGBA", flowers.size, (0, 0, 0, 0))
+
+    proximity = Image.fromarray((flower_paint.astype(np.uint8) * 255))
+    proximity = proximity.filter(ImageFilter.MaxFilter(25))
+    fill_area = cover_visible & (np.asarray(proximity) > 8) & ~flower_paint
+    if not fill_area.any():
+        return Image.new("RGBA", flowers.size, (0, 0, 0, 0))
+
+    flower_rgb = np.asarray(flowers.convert("RGB")).copy()
+    filled_rgb = _fill_removed_pixels_from_boundary(
+        flower_rgb,
+        fill_area,
+        flower_paint,
+    )
+    patch_arr = np.zeros((*cover.shape, 4), dtype=np.uint8)
+    patch_arr[:, :, :3] = filled_rgb
+    patch_alpha = cover.copy().astype(np.uint8)
+    patch_alpha[~fill_area] = 0
+    patch_arr[:, :, 3] = patch_alpha
+    return Image.fromarray(patch_arr, mode="RGBA")
+
+
+def _compose_flower_replacement_patch(
+    source_crop,
+    cleared_crop,
+    generated_crop,
+    removal_matte,
+):
+    from PIL import Image
+
+    source_cover_alpha = _build_source_flower_cover_alpha(source_crop, removal_matte)
+    base = Image.new("RGBA", cleared_crop.size, (0, 0, 0, 0))
+    flowers = generated_crop.convert("RGBA")
+    base.alpha_composite(flowers)
+    base.alpha_composite(
+        _build_generated_flower_cover_patch(flowers, source_cover_alpha)
+    )
+    return base
 
 
 def _build_square_padded_edit_inputs(
@@ -594,6 +881,8 @@ def _write_redraw_debug_summary(
     status: str,
     advisory: dict | None = None,
     output_path: str = "",
+    final_source_pasteback_path: str = "",
+    source_pasteback_error: str = "",
     error: str = "",
 ) -> None:
     if not debug_artifacts:
@@ -624,6 +913,10 @@ def _write_redraw_debug_summary(
         summary["redraw_advisory"] = advisory
     if output_path:
         summary["output_path"] = output_path
+    if final_source_pasteback_path:
+        summary["final_source_pasteback_path"] = final_source_pasteback_path
+    if source_pasteback_error:
+        summary["source_pasteback_error"] = source_pasteback_error
     if error:
         summary["error"] = error
     summary_path = debug_artifacts["dir"] / "summary.json"
@@ -681,8 +974,20 @@ def _build_flower_output_alpha(crop_rgba, edit_matte):
         & ~white_like
         & ~yellow_center
     )
+    olive_halo = (
+        (red > 45)
+        & (red < 120)
+        & (green > 55)
+        & (green < 135)
+        & (blue > 25)
+        & (blue < 95)
+        & (green >= red - 10)
+        & ~white_like
+        & ~yellow_center
+    )
     alpha_arr[dark_artifact] = 0
     alpha_arr[hedge_like] = 0
+    alpha_arr[olive_halo] = 0
     return Image.fromarray(alpha_arr.astype(np.uint8), mode="L")
 
 
@@ -690,6 +995,7 @@ async def _redraw_source_context_with_edit_matte(
     *,
     source_crop,
     edit_matte,
+    removal_matte=None,
     instruction: str,
     provider_inst,
     tradition: str,
@@ -704,12 +1010,16 @@ async def _redraw_source_context_with_edit_matte(
     import io as _io
     import tempfile
 
-    import numpy as np
     from PIL import Image
 
+    replacement_matte = (
+        removal_matte.convert("L") if removal_matte is not None else edit_matte
+    )
+    generation_matte = _build_flower_generation_matte(edit_matte, replacement_matte)
+    cleared_crop = _clear_source_crop_with_matte(source_crop, replacement_matte)
     input_image, mask, content_box = _build_square_padded_edit_inputs(
-        source_crop,
-        edit_matte,
+        cleared_crop,
+        generation_matte,
         target_size=1024,
     )
     image_tmp = tempfile.NamedTemporaryFile(suffix=".png", delete=False)
@@ -724,16 +1034,32 @@ async def _redraw_source_context_with_edit_matte(
         if debug_artifacts:
             index = debug_child_index or len(debug_artifacts["calls"]) + 1
             prefix = f"child_{index:02d}"
+            source_crop_path = debug_artifacts["dir"] / f"{prefix}_source_crop.png"
+            edit_matte_path = debug_artifacts["dir"] / f"{prefix}_edit_matte.png"
+            removal_matte_path = (
+                debug_artifacts["dir"] / f"{prefix}_removal_matte.png"
+            )
+            cleared_crop_path = (
+                debug_artifacts["dir"] / f"{prefix}_cleared_crop.png"
+            )
             input_path = debug_artifacts["dir"] / f"{prefix}_input.png"
             mask_path = debug_artifacts["dir"] / f"{prefix}_mask.png"
             raw_path = debug_artifacts["dir"] / f"{prefix}_raw.png"
             patch_path = debug_artifacts["dir"] / f"{prefix}_patch.png"
             pasteback_path = debug_artifacts["dir"] / f"{prefix}_pasteback.png"
+            source_crop.save(source_crop_path)
+            generation_matte.save(edit_matte_path)
+            replacement_matte.save(removal_matte_path)
+            cleared_crop.save(cleared_crop_path)
             input_image.save(input_path)
             mask.save(mask_path)
             debug_record = {
                 "index": index,
                 "status": "started",
+                "source_crop_path": str(source_crop_path),
+                "edit_matte_path": str(edit_matte_path),
+                "removal_matte_path": str(removal_matte_path),
+                "cleared_crop_path": str(cleared_crop_path),
                 "input_path": str(input_path),
                 "mask_path": str(mask_path),
                 "raw_path": str(raw_path),
@@ -750,9 +1076,11 @@ async def _redraw_source_context_with_edit_matte(
         )
         prompt = (
             f"{prompt}\n"
-            "Use the source crop as visual context. Only repaint the transparent "
-            "mask pixels. Keep opaque/unmasked hedge leaves and lighting unchanged. "
-            "Do not create a new dark hedge patch or repaint the whole crop."
+            "Use the source crop as visual context. The transparent mask pixels "
+            "are a replacement zone where the previous flowers have already been "
+            "cleared from the input. Paint new flowers there while keeping "
+            "opaque/unmasked hedge leaves and lighting unchanged. Do not create a "
+            "new dark hedge patch or repaint the whole crop."
         )
         result = await provider_inst.inpaint_with_mask(
             image_path=image_tmp.name,
@@ -778,8 +1106,14 @@ async def _redraw_source_context_with_edit_matte(
         out_img = _fit_into_canvas(out_img, (1024, 1024), bg_rgb=CREAM_BG_RGB)
         crop_out = out_img.crop(content_box).resize(source_crop.size, Image.LANCZOS)
         crop_out = crop_out.convert("RGBA")
-        output_alpha = _build_flower_output_alpha(crop_out, edit_matte)
-        crop_out.putalpha(output_alpha)
+        flower_alpha = _build_flower_output_alpha(crop_out, generation_matte)
+        crop_out.putalpha(flower_alpha)
+        crop_out = _compose_flower_replacement_patch(
+            source_crop,
+            cleared_crop,
+            crop_out,
+            replacement_matte,
+        )
         if debug_record is not None:
             crop_out.save(debug_record["patch_path"])
             pasteback = source_crop.convert("RGBA")
@@ -954,7 +1288,10 @@ async def redraw_layer(
         choose_redraw_route,
     )
     from vulca.layers.mask_refine import refine_mask_for_target
-    from vulca.layers.redraw_quality import evaluate_redraw_quality
+    from vulca.layers.redraw_quality import (
+        evaluate_redraw_quality,
+        is_texture_redraw_request,
+    )
     from vulca.providers import get_image_provider
 
     # 1. Find target layer
@@ -1010,6 +1347,18 @@ async def redraw_layer(
         description=target.info.description,
         instruction=instruction,
     )
+    bbox_area_pct = area_pct / max(0.0001, bbox_fill)
+    preflight_skip_reason = ""
+    if (
+        route == "auto"
+        and not refinement.applied
+        and is_texture_redraw_request(
+            description=target.info.description,
+            instruction=instruction,
+        )
+        and (area_pct > 5.0 or bbox_area_pct > 10.0)
+    ):
+        preflight_skip_reason = "broad_texture_repaint_risk"
     img_provider = get_image_provider(provider, api_key=api_key)
     # v0.20.1 — per-call model override, matching generate_image MCP pattern
     # (mcp_server.py:1340-1344). Silent no-op if provider has no `model` attr.
@@ -1031,7 +1380,9 @@ async def redraw_layer(
 
     refinement_path_available = refinement.applied and has_inpaint and route != "img2img"
 
-    if route == "auto":
+    if preflight_skip_reason:
+        chosen_route = "skip"
+    elif route == "auto":
         chosen_route = "inpaint" if (sparse and has_inpaint) else "img2img"
     elif route == "inpaint":
         if not has_inpaint:
@@ -1072,7 +1423,9 @@ async def redraw_layer(
             manifest_data=manifest_data,
             expected_size=src_rgba.size,
         )
-    if refinement_path_available:
+    if preflight_skip_reason:
+        rgba = src_rgba.copy()
+    elif refinement_path_available:
         rgba = Image.new("RGBA", src_rgba.size, (0, 0, 0, 0))
         refined_alpha = Image.new("L", src_alpha.size, 0)
         for child_index, child_mask in enumerate(refinement.child_masks, start=1):
@@ -1081,6 +1434,12 @@ async def redraw_layer(
             if crop_box.w <= 0 or crop_box.h <= 0:
                 continue
             if source_context is not None:
+                crop_box = _pad_crop_box(
+                    crop_box,
+                    src_rgba.size[0],
+                    src_rgba.size[1],
+                    padding=max(8, round(max(crop_box.w, crop_box.h) * 0.5)),
+                )
                 box = (
                     crop_box.x,
                     crop_box.y,
@@ -1090,9 +1449,15 @@ async def redraw_layer(
                 source_crop = source_context.crop(box).convert("RGB")
                 crop_alpha = child_mask.crop(box).convert("L")
                 edit_matte = _build_flower_edit_matte(source_crop, crop_alpha)
+                removal_matte = _build_flower_removal_matte(
+                    source_crop,
+                    crop_alpha,
+                    edit_matte,
+                )
                 crop_out, _result = await _redraw_source_context_with_edit_matte(
                     source_crop=source_crop,
                     edit_matte=edit_matte,
+                    removal_matte=removal_matte,
                     instruction=instruction,
                     provider_inst=img_provider,
                     tradition=tradition,
@@ -1259,11 +1624,17 @@ async def redraw_layer(
             "mask_granularity_score", 0.0
         ),
     )
-    if not quality_report.passed:
+    quality_failures = list(quality_report.failures)
+    quality_gate_passed = quality_report.passed
+    if preflight_skip_reason:
+        quality_failures.append(preflight_skip_reason)
+        quality_gate_passed = False
+
+    if not quality_gate_passed:
         logger.warning(
             "redraw quality gate failed for layer=%s failures=%s metrics=%s",
             layer_name,
-            quality_report.failures,
+            quality_failures,
             quality_report.metrics,
         )
     actual_redraw_route = (
@@ -1285,19 +1656,27 @@ async def redraw_layer(
         "provider_requires_mask_for_edits": bool(
             edit_caps and edit_caps.requires_mask_for_edits
         ),
-        "quality_gate_passed": quality_report.passed,
-        "quality_failures": list(quality_report.failures),
+        "quality_gate_passed": quality_gate_passed,
+        "quality_failures": quality_failures,
+        "redraw_skipped": bool(preflight_skip_reason),
+        "redraw_skip_reason": preflight_skip_reason,
         "refinement_applied": refinement_path_available,
         "refinement_reason": refinement.reason,
         "refinement_strategy": refinement.strategy,
         "refinement_source_context_used": bool(
             refinement_path_available and source_context is not None
         ),
-        "refinement_edit_matte": "flower_evidence"
+        "refinement_edit_matte": "small_botanical_evidence"
         if refinement_path_available and source_context is not None
         else "child_alpha"
         if refinement_path_available
         else "none",
+        "refinement_replacement_matte": "small_botanical_removal"
+        if refinement_path_available and source_context is not None
+        else "none",
+        "refinement_composition": "small_botanical_evidence_paint_cover"
+        if refinement_path_available and source_context is not None
+        else "generated_patch",
         "refined_child_count": len(refinement.child_masks)
         if refinement_path_available
         else 0,
@@ -1319,11 +1698,25 @@ async def redraw_layer(
 
     out_path.parent.mkdir(parents=True, exist_ok=True)
     rgba.save(str(out_path), "PNG")
+    final_source_pasteback_path = ""
+    source_pasteback_error = ""
+    if debug_artifacts and source_context is not None:
+        try:
+            source_pasteback = source_context.convert("RGBA")
+            source_pasteback.alpha_composite(rgba.convert("RGBA"))
+            final_source_pasteback_path = str(
+                debug_artifacts["dir"] / "final_source_pasteback.png"
+            )
+            source_pasteback.save(final_source_pasteback_path)
+        except Exception as exc:
+            source_pasteback_error = str(exc)
     _write_redraw_debug_summary(
         debug_artifacts,
         status="completed",
         advisory=redraw_advisory,
         output_path=str(out_path),
+        final_source_pasteback_path=final_source_pasteback_path,
+        source_pasteback_error=source_pasteback_error,
     )
 
     # v0.18.0: manifest update happens whenever the caller is NOT in legacy

--- a/src/vulca/layers/redraw.py
+++ b/src/vulca/layers/redraw.py
@@ -786,7 +786,8 @@ def _build_generated_flower_cover_patch(
         return Image.new("RGBA", flowers.size, (0, 0, 0, 0))
 
     proximity = Image.fromarray((flower_paint.astype(np.uint8) * 255))
-    proximity = proximity.filter(ImageFilter.MaxFilter(25))
+    cover_radius = 11 if target_palette == "yellow" else 25
+    proximity = proximity.filter(ImageFilter.MaxFilter(cover_radius))
     fill_area = cover_visible & (np.asarray(proximity) > 8) & ~flower_paint
     if not fill_area.any():
         return Image.new("RGBA", flowers.size, (0, 0, 0, 0))

--- a/src/vulca/layers/redraw.py
+++ b/src/vulca/layers/redraw.py
@@ -969,6 +969,76 @@ def _infer_small_botanical_target_palette(
     return "mixed"
 
 
+def _build_small_botanical_child_prompt(
+    *,
+    instruction: str,
+    tradition: str,
+    target_palette: str,
+    head_count: int = 1,
+) -> str:
+    if target_palette == "yellow":
+        subject = "compact yellow dandelion or buttercup flower head replacements"
+        style = (
+            "hand-painted flower heads with warm centers, varied spacing, and "
+            "natural scale"
+        )
+    else:
+        subject = "compact small wildflower head replacements"
+        style = "hand-painted petals with warm centers, varied spacing, and natural scale"
+    parts = [
+        "Repaint only the transparent mask pixels (mask alpha=0) as "
+        f"{subject}.",
+        "Treat the source crop only as scale, lighting, and edge context.",
+        "Leave every opaque/unmasked pixel unchanged.",
+        f"Paint exactly {max(1, head_count)} separated flower head"
+        f"{'' if max(1, head_count) == 1 else 's'}; do not add extra heads.",
+        "Match the original head size and footprint.",
+        f"Paint separated {style}.",
+        "Do not generate non-botanical background scene content, rectangular "
+        "thumbnails, or broad texture patches.",
+    ]
+    lower_instruction = instruction.lower()
+    if "storybook" in lower_instruction:
+        parts.append("Use a subtle storybook botanical accent, not a new scene.")
+    if tradition and tradition != "default":
+        parts.append(
+            f"Maintain the {tradition.replace('_', ' ')} cultural tradition "
+            "and technique."
+        )
+    return "\n".join(parts)
+
+
+def _estimate_small_botanical_head_count(edit_matte) -> int:
+    import numpy as np
+    from collections import deque
+
+    arr = np.asarray(edit_matte.convert("L")) > 8
+    height, width = arr.shape
+    seen = np.zeros(arr.shape, dtype=bool)
+    count = 0
+    for y in range(height):
+        for x in range(width):
+            if not arr[y, x] or seen[y, x]:
+                continue
+            q: deque[tuple[int, int]] = deque([(x, y)])
+            seen[y, x] = True
+            area = 0
+            while q:
+                cx, cy = q.popleft()
+                area += 1
+                for nx in (cx - 1, cx, cx + 1):
+                    for ny in (cy - 1, cy, cy + 1):
+                        if nx < 0 or ny < 0 or nx >= width or ny >= height:
+                            continue
+                        if seen[ny, nx] or not arr[ny, nx]:
+                            continue
+                        seen[ny, nx] = True
+                        q.append((nx, ny))
+            if area >= 8:
+                count += 1
+    return max(1, min(count, 8))
+
+
 def _build_flower_output_alpha(crop_rgba, edit_matte, *, target_palette: str = "mixed"):
     import numpy as np
 
@@ -1053,6 +1123,58 @@ def _build_flower_output_alpha(crop_rgba, edit_matte, *, target_palette: str = "
     return Image.fromarray(alpha_arr.astype(np.uint8), mode="L")
 
 
+def _small_botanical_scene_like_mask(rgb_arr):
+    import numpy as np
+
+    rgb = rgb_arr.astype(np.int16)
+    red = rgb[:, :, 0]
+    green = rgb[:, :, 1]
+    blue = rgb[:, :, 2]
+    spread = np.maximum.reduce((red, green, blue)) - np.minimum.reduce(
+        (red, green, blue)
+    )
+    mean = rgb.mean(axis=2)
+    sky_like = (blue > 135) & (blue > red + 35) & (blue > green + 20) & (red < 135)
+    vehicle_red = (red > 120) & (red > green + 45) & (red > blue + 35)
+    road_or_metal_gray = (mean > 105) & (mean < 225) & (spread < 34)
+    return sky_like | vehicle_red | road_or_metal_gray
+
+
+def _small_botanical_raw_scene_rejection(
+    *,
+    source_crop,
+    generated_crop,
+    target_palette: str,
+) -> dict:
+    import numpy as np
+
+    if target_palette != "yellow":
+        return {"reject": False, "reason": ""}
+    source = source_crop.convert("RGB")
+    generated = generated_crop.convert("RGB")
+    if source.size != generated.size:
+        from PIL import Image
+
+        source = source.resize(generated.size, Image.LANCZOS)
+    src_scene = _small_botanical_scene_like_mask(np.asarray(source))
+    gen_scene = _small_botanical_scene_like_mask(np.asarray(generated))
+    if not gen_scene.any():
+        return {"reject": False, "reason": "", "new_scene_like_pct": 0.0}
+    scene_growth = gen_scene & ~src_scene
+    new_scene_like_pct = 100.0 * float(scene_growth.sum()) / float(gen_scene.size)
+    if new_scene_like_pct > 8.0:
+        return {
+            "reject": True,
+            "reason": "raw_scene_thumbnail_leak",
+            "new_scene_like_pct": round(new_scene_like_pct, 3),
+        }
+    return {
+        "reject": False,
+        "reason": "",
+        "new_scene_like_pct": round(new_scene_like_pct, 3),
+    }
+
+
 async def _redraw_source_context_with_edit_matte(
     *,
     source_crop,
@@ -1132,18 +1254,11 @@ async def _redraw_source_context_with_edit_matte(
             debug_artifacts["calls"].append(debug_record)
             _write_redraw_debug_summary(debug_artifacts, status="running")
 
-        prompt = _build_inpaint_prompt(
-            instruction,
-            [target_description],
+        prompt = _build_small_botanical_child_prompt(
+            instruction=instruction,
             tradition=tradition,
-        )
-        prompt = (
-            f"{prompt}\n"
-            "Use the source crop as visual context. The transparent mask pixels "
-            "are a replacement zone where the previous flowers have already been "
-            "cleared from the input. Paint new flowers there while keeping "
-            "opaque/unmasked hedge leaves and lighting unchanged. Do not create a "
-            "new dark hedge patch or repaint the whole crop."
+            target_palette=target_palette,
+            head_count=_estimate_small_botanical_head_count(edit_matte),
         )
         result = await provider_inst.inpaint_with_mask(
             image_path=image_tmp.name,
@@ -1169,6 +1284,29 @@ async def _redraw_source_context_with_edit_matte(
         out_img = _fit_into_canvas(out_img, (1024, 1024), bg_rgb=CREAM_BG_RGB)
         crop_out = out_img.crop(content_box).resize(source_crop.size, Image.LANCZOS)
         crop_out = crop_out.convert("RGBA")
+        raw_scene_gate = _small_botanical_raw_scene_rejection(
+            source_crop=source_crop,
+            generated_crop=crop_out,
+            target_palette=target_palette,
+        )
+        if raw_scene_gate.get("reject"):
+            crop_out = Image.new("RGBA", source_crop.size, (0, 0, 0, 0))
+            if debug_record is not None:
+                debug_record.update(
+                    {
+                        "raw_scene_rejected": True,
+                        "raw_scene_reject_reason": raw_scene_gate.get("reason", ""),
+                        "raw_scene_gate": raw_scene_gate,
+                    }
+                )
+        else:
+            if debug_record is not None:
+                debug_record.update(
+                    {
+                        "raw_scene_rejected": False,
+                        "raw_scene_gate": raw_scene_gate,
+                    }
+                )
         flower_alpha = _build_flower_output_alpha(
             crop_out,
             generation_matte,

--- a/src/vulca/layers/redraw.py
+++ b/src/vulca/layers/redraw.py
@@ -786,7 +786,7 @@ def _build_generated_flower_cover_patch(
         return Image.new("RGBA", flowers.size, (0, 0, 0, 0))
 
     proximity = Image.fromarray((flower_paint.astype(np.uint8) * 255))
-    cover_radius = 11 if target_palette == "yellow" else 25
+    cover_radius = 19 if target_palette == "yellow" else 25
     proximity = proximity.filter(ImageFilter.MaxFilter(cover_radius))
     fill_area = cover_visible & (np.asarray(proximity) > 8) & ~flower_paint
     if not fill_area.any():

--- a/src/vulca/layers/redraw.py
+++ b/src/vulca/layers/redraw.py
@@ -1968,7 +1968,8 @@ async def redraw_layer(
 
     # Hybrid alpha mask still applies for legacy `extract`-mode layers whose
     # dominant_colors are stored — keep behavior parity across all branches.
-    _maybe_apply_legacy_color_mask(artwork_dir, manifest_data, target, out_path)
+    if not refinement_path_available:
+        _maybe_apply_legacy_color_mask(artwork_dir, manifest_data, target, out_path)
 
     # 9. Manifest update branch.
     #

--- a/src/vulca/layers/redraw_quality.py
+++ b/src/vulca/layers/redraw_quality.py
@@ -42,6 +42,7 @@ def evaluate_redraw_quality(
         failures.append("alpha_bbox_expanded")
 
     out_rgb = out[..., :3]
+    src_rgb = src[..., :3]
     white = (
         (out_rgb[..., 0] > 245)
         & (out_rgb[..., 1] > 245)
@@ -52,10 +53,39 @@ def evaluate_redraw_quality(
     if white_pct > 85.0 and int(out_alpha.sum()) > 1000:
         failures.append("large_white_component")
 
+    visible_count = int(out_alpha.sum())
+    dark_artifact = (
+        (out_rgb[..., 0] < 35)
+        & (out_rgb[..., 1] < 35)
+        & (out_rgb[..., 2] < 35)
+        & (out_rgb.max(axis=2) < 50)
+        & out_alpha
+    )
+    dark_artifact_pct = 100.0 * float(dark_artifact.sum()) / float(
+        max(1, visible_count)
+    )
+    olive_fill = (
+        (out_rgb[..., 0] > 45)
+        & (out_rgb[..., 0] < 120)
+        & (out_rgb[..., 1] > 55)
+        & (out_rgb[..., 1] < 135)
+        & (out_rgb[..., 2] > 25)
+        & (out_rgb[..., 2] < 95)
+        & (out_rgb[..., 1] >= out_rgb[..., 0] - 10)
+        & out_alpha
+    )
+    olive_fill_pct = 100.0 * float(olive_fill.sum()) / float(max(1, visible_count))
+
     profile = infer_refinement_profile(
         description=description,
         instruction=instruction,
     )
+    if profile is not None and refinement_applied and visible_count > 100:
+        if dark_artifact_pct > 8.0:
+            failures.append("dark_artifact_visible")
+        if olive_fill_pct > 30.0:
+            failures.append("olive_fill_visible")
+
     mask_is_broad = src_area_pct > 5.0 or src_bbox_pct > 10.0
     if (
         profile is not None
@@ -65,6 +95,30 @@ def evaluate_redraw_quality(
     ):
         failures.append("mask_too_broad_for_target")
 
+    overlap = src_alpha & out_alpha
+    if overlap.any():
+        src_luma = _luma(src_rgb)[overlap]
+        out_luma = _luma(out_rgb)[overlap]
+        src_luma_mean = float(src_luma.mean())
+        out_luma_mean = float(out_luma.mean())
+        output_luma_delta_pct = (
+            100.0 * (out_luma_mean - src_luma_mean) / max(1.0, src_luma_mean)
+        )
+    else:
+        src_luma_mean = 0.0
+        out_luma_mean = 0.0
+        output_luma_delta_pct = 0.0
+
+    if (
+        profile is None
+        and is_texture_redraw_request(description=description, instruction=instruction)
+        and not refinement_applied
+        and refined_child_count <= 0
+        and mask_is_broad
+        and output_luma_delta_pct < -25.0
+    ):
+        failures.append("broad_texture_repaint")
+
     return RedrawQualityReport(
         passed=not failures,
         failures=tuple(failures),
@@ -72,14 +126,22 @@ def evaluate_redraw_quality(
             "bbox_ratio": float(bbox_ratio),
             "white_pct": float(white_pct),
             "white_like_pct": float(white_pct),
+            "dark_artifact_pct": float(dark_artifact_pct),
+            "olive_fill_pct": float(olive_fill_pct),
             "src_area_pct": float(src_area_pct),
             "src_bbox_pct": float(src_bbox_pct),
             "alpha_bbox_expanded": float("alpha_bbox_expanded" in failures),
             "large_white_component": float("large_white_component" in failures),
+            "dark_artifact_visible": float("dark_artifact_visible" in failures),
+            "olive_fill_visible": float("olive_fill_visible" in failures),
+            "broad_texture_repaint": float("broad_texture_repaint" in failures),
             "background_bleed": 0.0,
             "refined_child_count": float(refined_child_count),
             "refined_coverage_pct": float(refined_coverage_pct),
             "mask_granularity_score": float(mask_granularity_score),
+            "source_luma_mean": float(src_luma_mean),
+            "output_luma_mean": float(out_luma_mean),
+            "output_luma_delta_pct": float(output_luma_delta_pct),
         },
     )
 
@@ -89,3 +151,27 @@ def _bbox_area(mask: np.ndarray) -> int:
         return 0
     ys, xs = np.where(mask)
     return int((xs.max() - xs.min() + 1) * (ys.max() - ys.min() + 1))
+
+
+def _luma(rgb: np.ndarray) -> np.ndarray:
+    rgb_float = rgb.astype(np.float32)
+    return (
+        0.2126 * rgb_float[..., 0]
+        + 0.7152 * rgb_float[..., 1]
+        + 0.0722 * rgb_float[..., 2]
+    )
+
+
+def is_texture_redraw_request(*, description: str, instruction: str) -> bool:
+    text = f"{description} {instruction}".lower()
+    texture_terms = (
+        "texture",
+        "leaf",
+        "leaves",
+        "leafy",
+        "hedge",
+        "ivy",
+        "foliage",
+        "grass",
+    )
+    return any(term in text for term in texture_terms)

--- a/src/vulca/providers/gemini.py
+++ b/src/vulca/providers/gemini.py
@@ -9,7 +9,7 @@ import base64
 import math
 import os
 
-from vulca.providers.base import ImageProvider, ImageResult
+from vulca.providers.base import ImageEditCapabilities, ImageProvider, ImageResult
 from vulca.providers.retry import with_retry
 
 # Gemini API uses named size tiers, not arbitrary pixel dimensions.
@@ -53,6 +53,19 @@ def _dims_to_aspect_ratio(width: int, height: int) -> str:
     return best_ratio
 
 
+def _detect_mime_type(data: bytes) -> str:
+    """Detect image mime type from magic bytes."""
+    if data[:3] == b"\xff\xd8\xff":
+        return "image/jpeg"
+    if data[:8] == b"\x89PNG\r\n\x1a\n":
+        return "image/png"
+    if data[:6] in (b"GIF87a", b"GIF89a"):
+        return "image/gif"
+    if data[:4] == b"RIFF" and data[8:12] == b"WEBP":
+        return "image/webp"
+    return "image/png"
+
+
 class GeminiImageProvider:
     """Image generation via Google Gemini API.
 
@@ -75,6 +88,14 @@ class GeminiImageProvider:
         )
         self.model = model
         self.timeout = timeout
+
+    def edit_capabilities(self) -> ImageEditCapabilities:
+        return ImageEditCapabilities(
+            supports_edits=True,
+            requires_mask_for_edits=True,
+            supports_unmasked_edits=False,
+            supports_masked_edits=True,
+        )
 
     async def generate(
         self,
@@ -123,17 +144,7 @@ class GeminiImageProvider:
         contents: list = []
         if reference_image_b64:
             ref_bytes = base64.b64decode(reference_image_b64)
-            # Detect mime type from magic bytes — wrong type makes Gemini hang.
-            if ref_bytes[:3] == b"\xff\xd8\xff":
-                ref_mime = "image/jpeg"
-            elif ref_bytes[:8] == b"\x89PNG\r\n\x1a\n":
-                ref_mime = "image/png"
-            elif ref_bytes[:6] in (b"GIF87a", b"GIF89a"):
-                ref_mime = "image/gif"
-            elif ref_bytes[:4] == b"RIFF" and ref_bytes[8:12] == b"WEBP":
-                ref_mime = "image/webp"
-            else:
-                ref_mime = "image/png"  # safe fallback
+            ref_mime = _detect_mime_type(ref_bytes)
             contents.append(types.Part.from_bytes(data=ref_bytes, mime_type=ref_mime))
         contents.append(full_prompt)
 
@@ -234,6 +245,154 @@ class GeminiImageProvider:
 
         raise RuntimeError(
             "Gemini returned no image data "
+            "(enable VULCA_DEBUG=1 for raw response inspection)"
+        )
+
+    async def inpaint_with_mask(
+        self,
+        *,
+        image_path: str,
+        mask_path: str,
+        prompt: str,
+        tradition: str = "default",
+        size: str = "",
+        quality: str | None = None,
+        input_fidelity: str | None = None,
+        output_format: str | None = None,
+    ) -> ImageResult:
+        if not self.api_key:
+            raise ValueError(
+                "Gemini API key required. Set GOOGLE_API_KEY env var "
+                "or pass api_key to GeminiImageProvider()."
+            )
+
+        from google import genai
+        from google.genai import types
+        from PIL import Image
+
+        _ = (quality, input_fidelity, output_format)
+        with open(image_path, "rb") as image_fh:
+            image_bytes = image_fh.read()
+        with open(mask_path, "rb") as mask_fh:
+            mask_bytes = mask_fh.read()
+
+        if size and "x" in size:
+            try:
+                width_text, height_text = size.lower().split("x", 1)
+                width, height = int(width_text), int(height_text)
+            except ValueError:
+                with Image.open(image_path) as source_probe:
+                    width, height = source_probe.size
+        else:
+            with Image.open(image_path) as source_probe:
+                width, height = source_probe.size
+
+        image_size = _pixels_to_image_size(max(width, height))
+        aspect_ratio = _dims_to_aspect_ratio(width, height)
+        full_prompt = (
+            f"{prompt}\n\n"
+            "Use the first image as the source crop. Use the second image as an "
+            "RGBA edit mask: transparent mask pixels mark the edit region, and "
+            "opaque mask pixels mark source context that should stay visually "
+            "preserved. Repaint only the transparent mask pixels. Do not create "
+            "a new scene outside the masked replacement area."
+        )
+        if tradition and tradition != "default":
+            full_prompt += (
+                f"\nMaintain the {tradition.replace('_', ' ')} cultural tradition "
+                "and technique."
+            )
+
+        client = genai.Client(api_key=self.api_key)
+        contents = [
+            types.Part.from_bytes(
+                data=image_bytes,
+                mime_type=_detect_mime_type(image_bytes),
+            ),
+            types.Part.from_bytes(
+                data=mask_bytes,
+                mime_type=_detect_mime_type(mask_bytes),
+            ),
+            full_prompt,
+        ]
+        config = types.GenerateContentConfig(
+            response_modalities=["Text", "Image"],
+            image_config=types.ImageConfig(
+                image_size=image_size,
+                aspect_ratio=aspect_ratio,
+            ),
+        )
+
+        def _is_retryable(exc: Exception) -> bool:
+            if isinstance(exc, asyncio.TimeoutError):
+                return True
+            status = getattr(exc, "status_code", None) or getattr(exc, "code", None)
+            return status in (429, 500, 503)
+
+        async def _call() -> object:
+            try:
+                return await asyncio.wait_for(
+                    asyncio.to_thread(
+                        client.models.generate_content,
+                        model=self.model,
+                        contents=contents,
+                        config=config,
+                    ),
+                    timeout=self.timeout,
+                )
+            except asyncio.TimeoutError:
+                raise TimeoutError(f"Gemini image edit timed out after {self.timeout}s")
+
+        response = await with_retry(
+            _call,
+            max_retries=3,
+            base_delay_ms=500,
+            max_delay_ms=16_000,
+            retryable_check=_is_retryable,
+        )
+
+        if response.candidates:
+            for part in response.candidates[0].content.parts:
+                if part.inline_data and part.inline_data.mime_type.startswith("image/"):
+                    img_b64 = base64.b64encode(part.inline_data.data).decode()
+                    return ImageResult(
+                        image_b64=img_b64,
+                        mime=part.inline_data.mime_type,
+                        metadata={
+                            "model": self.model,
+                            "mode": "gemini_mask_adapter",
+                            "image_size": image_size,
+                            "aspect_ratio": aspect_ratio,
+                        },
+                    )
+
+        prompt_feedback = getattr(response, "prompt_feedback", None)
+        block_reason = getattr(prompt_feedback, "block_reason", None) if prompt_feedback else None
+        if block_reason:
+            raise RuntimeError(
+                f"Gemini blocked the edit request: {block_reason}. "
+                f"Check content policy or tune prompt."
+            )
+
+        raw_text = ""
+        try:
+            raw_text = str(response)
+        except Exception:
+            raw_text = ""
+        lowered = raw_text.lower()
+        if (
+            "quota" in lowered
+            or "limit: 0" in lowered
+            or "resource_exhausted" in lowered
+            or "billing" in lowered
+        ):
+            raise RuntimeError(
+                "Gemini quota exhausted or free tier blocked for image edits. "
+                "Upgrade via aistudio.google.com/app/apikey or switch provider."
+            )
+
+        raise RuntimeError(
+            "Gemini returned no image data for masked edit "
             "(enable VULCA_DEBUG=1 for raw response inspection)"
         )
 

--- a/tests/test_gemini_image_size.py
+++ b/tests/test_gemini_image_size.py
@@ -1,4 +1,12 @@
 """Tests for Gemini provider imageSize + aspectRatio mapping."""
+import asyncio
+import base64
+import io
+import sys
+import types as py_types
+
+from PIL import Image
+
 from vulca.providers.gemini import (
     _pixels_to_image_size,
     _dims_to_aspect_ratio,
@@ -96,3 +104,107 @@ class TestGeminiProviderConfig:
         p = GeminiImageProvider(api_key="fake")
         prompt = p._build_prompt("test", "default", "", "1:1", {})
         assert "tradition" not in prompt.lower()
+
+    def test_declares_masked_edit_adapter_capabilities(self):
+        p = GeminiImageProvider(api_key="fake")
+
+        caps = p.edit_capabilities()
+
+        assert caps.supports_edits is True
+        assert caps.supports_masked_edits is True
+        assert caps.requires_mask_for_edits is True
+        assert caps.supports_unmasked_edits is False
+
+    def test_inpaint_with_mask_sends_source_and_mask_parts(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        recorded = {}
+
+        class FakeInlineData:
+            mime_type = "image/png"
+
+            def __init__(self, data):
+                self.data = data
+
+        class FakePart:
+            def __init__(self, data=None, mime_type="", inline_data=None):
+                self.data = data
+                self.mime_type = mime_type
+                self.inline_data = inline_data
+
+            @classmethod
+            def from_bytes(cls, *, data, mime_type):
+                return cls(data=data, mime_type=mime_type)
+
+        class FakeImageConfig:
+            def __init__(self, **kwargs):
+                self.kwargs = kwargs
+
+        class FakeGenerateContentConfig:
+            def __init__(self, **kwargs):
+                self.kwargs = kwargs
+
+        class FakeModels:
+            def generate_content(self, *, model, contents, config):
+                recorded["model"] = model
+                recorded["contents"] = contents
+                recorded["config"] = config
+                out = Image.new("RGB", (8, 8), (232, 190, 42))
+                buf = io.BytesIO()
+                out.save(buf, format="PNG")
+                inline = FakeInlineData(buf.getvalue())
+                return py_types.SimpleNamespace(
+                    candidates=[
+                        py_types.SimpleNamespace(
+                            content=py_types.SimpleNamespace(
+                                parts=[FakePart(inline_data=inline)]
+                            )
+                        )
+                    ],
+                    prompt_feedback=None,
+                )
+
+        class FakeClient:
+            def __init__(self, api_key):
+                recorded["api_key"] = api_key
+                self.models = FakeModels()
+
+        fake_types = py_types.SimpleNamespace(
+            Part=FakePart,
+            ImageConfig=FakeImageConfig,
+            GenerateContentConfig=FakeGenerateContentConfig,
+        )
+        fake_genai = py_types.SimpleNamespace(Client=FakeClient, types=fake_types)
+        fake_google = py_types.SimpleNamespace(genai=fake_genai)
+        monkeypatch.setitem(sys.modules, "google", fake_google)
+        monkeypatch.setitem(sys.modules, "google.genai", fake_genai)
+        monkeypatch.setitem(sys.modules, "google.genai.types", fake_types)
+
+        image_path = tmp_path / "source.png"
+        mask_path = tmp_path / "mask.png"
+        Image.new("RGB", (16, 12), (35, 92, 43)).save(image_path)
+        mask = Image.new("RGBA", (16, 12), (0, 0, 0, 255))
+        mask.putpixel((8, 6), (0, 0, 0, 0))
+        mask.save(mask_path)
+
+        result = asyncio.run(
+            GeminiImageProvider(api_key="gemini-key").inpaint_with_mask(
+                image_path=str(image_path),
+                mask_path=str(mask_path),
+                prompt="paint one compact yellow flower head",
+                tradition="default",
+            )
+        )
+
+        assert recorded["api_key"] == "gemini-key"
+        assert recorded["model"] == "gemini-3.1-flash-image-preview"
+        assert recorded["contents"][0].mime_type == "image/png"
+        assert recorded["contents"][1].mime_type == "image/png"
+        assert "transparent mask pixels" in recorded["contents"][2]
+        assert "opaque mask pixels" in recorded["contents"][2]
+        assert "paint one compact yellow flower head" in recorded["contents"][2]
+        assert result.mime == "image/png"
+        assert base64.b64decode(result.image_b64).startswith(b"\x89PNG")
+        assert result.metadata["mode"] == "gemini_mask_adapter"

--- a/tests/test_layers_redraw_quality_gates.py
+++ b/tests/test_layers_redraw_quality_gates.py
@@ -58,3 +58,78 @@ def test_quality_gate_flags_broad_small_bright_target_without_refinement():
     assert "mask_too_broad_for_target" in report.failures
     assert report.metrics["refined_child_count"] == 0
     assert report.metrics["mask_granularity_score"] == 0
+
+
+def test_quality_gate_flags_dark_artifact_for_refined_flower_output():
+    source = _rgba(
+        size=(120, 80),
+        color=(35, 92, 43),
+        box=(20, 20, 60, 40),
+    )
+    output = Image.new("RGBA", (120, 80), (0, 0, 0, 0))
+    output.alpha_composite(Image.new("RGBA", (60, 40), (12, 18, 14, 255)), (20, 20))
+    output.alpha_composite(Image.new("RGBA", (20, 20), (242, 240, 224, 255)), (40, 30))
+
+    report = evaluate_redraw_quality(
+        source,
+        output,
+        description="wildflower cluster on hedge",
+        instruction="storybook botanical wildflowers",
+        refinement_applied=True,
+        refined_child_count=4,
+    )
+
+    assert not report.passed
+    assert "dark_artifact_visible" in report.failures
+    assert report.metrics["dark_artifact_pct"] > 25
+
+
+def test_quality_gate_flags_olive_fill_for_refined_flower_output():
+    source = _rgba(
+        size=(120, 80),
+        color=(35, 92, 43),
+        box=(20, 20, 60, 40),
+    )
+    output = Image.new("RGBA", (120, 80), (0, 0, 0, 0))
+    output.alpha_composite(Image.new("RGBA", (60, 40), (78, 91, 44, 255)), (20, 20))
+    output.alpha_composite(Image.new("RGBA", (18, 18), (242, 240, 224, 255)), (42, 30))
+
+    report = evaluate_redraw_quality(
+        source,
+        output,
+        description="wildflower cluster on hedge",
+        instruction="storybook botanical wildflowers",
+        refinement_applied=True,
+        refined_child_count=4,
+    )
+
+    assert not report.passed
+    assert "olive_fill_visible" in report.failures
+    assert report.metrics["olive_fill_pct"] > 25
+
+
+def test_quality_gate_flags_broad_leaf_texture_repaint():
+    source = _rgba(
+        size=(240, 180),
+        color=(72, 116, 58),
+        box=(12, 10, 216, 150),
+    )
+    output = _rgba(
+        size=(240, 180),
+        color=(18, 58, 20),
+        box=(12, 10, 216, 150),
+    )
+
+    report = evaluate_redraw_quality(
+        source,
+        output,
+        description="leafy hedge texture",
+        instruction="redraw leaf highlights as hand-painted botanical texture",
+        refinement_applied=False,
+        refined_child_count=0,
+    )
+
+    assert not report.passed
+    assert "broad_texture_repaint" in report.failures
+    assert report.metrics["src_area_pct"] > 50
+    assert report.metrics["output_luma_delta_pct"] < -25

--- a/tests/test_layers_redraw_refinement.py
+++ b/tests/test_layers_redraw_refinement.py
@@ -966,6 +966,38 @@ def test_yellow_replacement_patch_uses_yellow_paint_not_scene_context():
     assert old_pixel[2] < 120
 
 
+def test_yellow_replacement_patch_covers_source_head_footprint_edges():
+    from vulca.layers import redraw as redraw_module
+
+    source = Image.new("RGB", (72, 56), (35, 92, 43))
+    draw = ImageDraw.Draw(source)
+    draw.ellipse((22, 14, 50, 42), fill=(156, 154, 132))
+    draw.ellipse((31, 23, 41, 33), fill=(232, 190, 42))
+
+    cleared = Image.new("RGB", source.size, (95, 120, 65))
+    removal_matte = Image.new("L", source.size, 0)
+    ImageDraw.Draw(removal_matte).ellipse((20, 12, 52, 44), fill=255)
+    generated = Image.new("RGBA", source.size, (0, 0, 0, 0))
+    ImageDraw.Draw(generated).ellipse((31, 23, 41, 33), fill=(232, 190, 42, 255))
+
+    patch = redraw_module._compose_flower_replacement_patch(
+        source,
+        cleared,
+        generated,
+        removal_matte,
+        target_palette="yellow",
+    )
+
+    left_edge = patch.getpixel((23, 28))
+    right_edge = patch.getpixel((49, 28))
+
+    assert left_edge[3] > 0
+    assert right_edge[3] > 0
+    assert left_edge[0] > 180
+    assert left_edge[1] > 130
+    assert left_edge[2] < 140
+
+
 def test_yellow_replacement_patch_does_not_expand_across_whole_old_head():
     from vulca.layers import redraw as redraw_module
 

--- a/tests/test_layers_redraw_refinement.py
+++ b/tests/test_layers_redraw_refinement.py
@@ -801,6 +801,31 @@ def test_yellow_replacement_patch_uses_yellow_paint_not_scene_context():
     assert old_pixel[2] < 120
 
 
+def test_yellow_replacement_patch_does_not_expand_across_whole_old_head():
+    from vulca.layers import redraw as redraw_module
+
+    source = Image.new("RGB", (60, 40), (35, 92, 43))
+    old_flower_xy = (20, 20)
+    ImageDraw.Draw(source).ellipse((16, 16, 28, 24), fill=(232, 190, 42))
+
+    cleared = Image.new("RGB", source.size, (95, 120, 65))
+    removal_matte = Image.new("L", source.size, 0)
+    ImageDraw.Draw(removal_matte).ellipse((14, 14, 30, 26), fill=255)
+    generated = Image.new("RGBA", source.size, (0, 0, 0, 0))
+    generated.putpixel((33, 20), (232, 190, 42, 255))
+
+    patch = redraw_module._compose_flower_replacement_patch(
+        source,
+        cleared,
+        generated,
+        removal_matte,
+        target_palette="yellow",
+    )
+
+    assert patch.getpixel(old_flower_xy)[3] == 0
+    assert patch.getpixel((33, 20))[3] > 0
+
+
 def test_flower_replacement_patch_does_not_fill_distant_old_flowers():
     from vulca.layers import redraw as redraw_module
 

--- a/tests/test_layers_redraw_refinement.py
+++ b/tests/test_layers_redraw_refinement.py
@@ -383,6 +383,42 @@ def test_refined_flower_layer_outputs_flower_edit_matte_not_child_context(
     assert out_area <= sum(call["edit_pixels"] for call in provider.calls)
 
 
+def test_refined_flower_layer_ignores_legacy_color_mask_dominant_colors(
+    tmp_path, monkeypatch
+):
+    from vulca.layers import redraw as redraw_module
+    import vulca.providers as providers_mod
+
+    provider = RecordingEditProvider()
+    monkeypatch.setattr(
+        providers_mod, "get_image_provider", lambda name, api_key="": provider
+    )
+    artwork = _stage_broad_flower_layer(tmp_path)
+    artwork.layers[0].info.dominant_colors = ["#235c2b"]
+    parent_alpha = Image.open(tmp_path / "flowers.png").convert("RGBA").split()[-1]
+    parent_area = int(np.asarray(parent_alpha).astype(bool).sum())
+
+    result = _run(
+        redraw_module.redraw_layer(
+            artwork,
+            layer_name="flowers",
+            instruction="small bright white wildflowers with warm yellow centers",
+            provider="openai",
+            artwork_dir=str(tmp_path),
+            route="auto",
+            preserve_alpha=True,
+        )
+    )
+
+    out_alpha = Image.open(result.image_path).convert("RGBA").split()[-1]
+    out_area = int(np.asarray(out_alpha).astype(bool).sum())
+    advisory = getattr(result, "redraw_advisory", {})
+
+    assert advisory["refinement_applied"] is True
+    assert out_area < parent_area * 0.5
+    assert out_area <= sum(call["edit_pixels"] for call in provider.calls)
+
+
 def test_refined_flower_layer_suppresses_black_generated_artifacts(
     tmp_path, monkeypatch
 ):

--- a/tests/test_layers_redraw_refinement.py
+++ b/tests/test_layers_redraw_refinement.py
@@ -119,6 +119,35 @@ def _stage_broad_flower_layer(tmp_path: Path):
     return load_manifest(str(tmp_path))
 
 
+def _stage_broad_leaf_texture_layer(tmp_path: Path):
+    size = (240, 180)
+    source = Image.new("RGB", size, (72, 116, 58))
+    draw = ImageDraw.Draw(source)
+    for x in range(18, 220, 18):
+        for y in range(16, 150, 16):
+            draw.ellipse((x - 6, y - 4, x + 7, y + 5), fill=(92, 134, 62))
+    alpha = Image.new("L", size, 0)
+    ImageDraw.Draw(alpha).rectangle((12, 10, 228, 160), fill=255)
+    Image.merge("RGBA", (*source.split(), alpha)).save(tmp_path / "hedge.png")
+    source.save(tmp_path / "source.png")
+
+    write_manifest(
+        [
+            LayerInfo(
+                name="hedge",
+                description="leafy hedge texture",
+                z_index=1,
+                content_type="subject",
+            )
+        ],
+        output_dir=str(tmp_path),
+        width=size[0],
+        height=size[1],
+        source_image="source.png",
+    )
+    return load_manifest(str(tmp_path))
+
+
 def test_refined_flower_layer_uses_one_masked_edit_per_child(tmp_path, monkeypatch):
     from vulca.layers import redraw as redraw_module
     import vulca.providers as providers_mod
@@ -151,11 +180,49 @@ def test_refined_flower_layer_uses_one_masked_edit_per_child(tmp_path, monkeypat
     assert out_area < parent_area
     assert advisory["refinement_applied"] is True
     assert advisory["refinement_reason"] == "target_evidence_components"
-    assert advisory["refinement_strategy"] == "bright_small_subject"
+    assert advisory["refinement_strategy"] == "small_botanical_subject_replacement"
     assert advisory["refined_child_count"] >= 3
     assert advisory["mask_granularity_score"] >= 3
     assert advisory["refinement_source_context_used"] is True
-    assert advisory["refinement_edit_matte"] == "flower_evidence"
+    assert advisory["refinement_edit_matte"] == "small_botanical_evidence"
+    assert advisory["refinement_replacement_matte"] == "small_botanical_removal"
+    assert advisory["refinement_composition"] == (
+        "small_botanical_evidence_paint_cover"
+    )
+
+
+def test_auto_redraw_skips_broad_leaf_texture_risk(tmp_path, monkeypatch):
+    from vulca.layers import redraw as redraw_module
+    import vulca.providers as providers_mod
+
+    provider = RecordingEditProvider(output_rgb=(18, 58, 20))
+    monkeypatch.setattr(
+        providers_mod, "get_image_provider", lambda name, api_key="": provider
+    )
+    artwork = _stage_broad_leaf_texture_layer(tmp_path)
+
+    result = _run(
+        redraw_module.redraw_layer(
+            artwork,
+            layer_name="hedge",
+            instruction="redraw leaf highlights as hand-painted botanical texture",
+            provider="openai",
+            artwork_dir=str(tmp_path),
+            route="auto",
+            preserve_alpha=True,
+        )
+    )
+
+    advisory = getattr(result, "redraw_advisory", {})
+    original = Image.open(tmp_path / "hedge.png").convert("RGBA")
+    output = Image.open(result.image_path).convert("RGBA")
+
+    assert provider.calls == []
+    assert np.array_equal(np.asarray(output), np.asarray(original))
+    assert advisory["redraw_skipped"] is True
+    assert advisory["redraw_skip_reason"] == "broad_texture_repaint_risk"
+    assert advisory["quality_gate_passed"] is False
+    assert "broad_texture_repaint_risk" in advisory["quality_failures"]
 
 
 def test_refined_flower_layer_uses_source_crop_square_padding(tmp_path, monkeypatch):
@@ -258,7 +325,7 @@ def test_refined_flower_layer_suppresses_black_generated_artifacts(
     assert not dark_visible.any()
 
 
-def test_refined_flower_layer_suppresses_generated_hedge_fill_inside_matte(
+def test_refined_flower_layer_drops_pure_hedge_generated_fill(
     tmp_path, monkeypatch
 ):
     from vulca.layers import redraw as redraw_module
@@ -285,14 +352,8 @@ def test_refined_flower_layer_suppresses_generated_hedge_fill_inside_matte(
     out = Image.open(result.image_path).convert("RGBA")
     arr = np.asarray(out)
     visible = arr[:, :, 3] > 0
-    green_fill = (
-        visible
-        & (arr[:, :, 0] < 70)
-        & (arr[:, :, 1] > 70)
-        & (arr[:, :, 2] < 70)
-    )
 
-    assert not green_fill.any()
+    assert not visible.any()
 
 
 def test_refined_flower_layer_suppresses_olive_generated_fill_inside_matte(
@@ -320,8 +381,20 @@ def test_refined_flower_layer_suppresses_olive_generated_fill_inside_matte(
     )
 
     out_alpha = Image.open(result.image_path).convert("RGBA").split()[-1]
+    out = Image.open(result.image_path).convert("RGBA")
+    arr = np.asarray(out)
+    visible = np.asarray(out_alpha).astype(bool)
+    olive_fill = (
+        visible
+        & (arr[:, :, 0] > 80)
+        & (arr[:, :, 0] < 120)
+        & (arr[:, :, 1] > 105)
+        & (arr[:, :, 1] < 135)
+        & (arr[:, :, 2] > 50)
+        & (arr[:, :, 2] < 80)
+    )
 
-    assert not np.asarray(out_alpha).astype(bool).any()
+    assert not olive_fill.any()
 
 
 def test_flower_output_alpha_removes_green_fill_adjacent_to_petals():
@@ -330,6 +403,23 @@ def test_flower_output_alpha_removes_green_fill_adjacent_to_petals():
     patch = Image.new("RGB", (20, 20), (95, 120, 65))
     patch.putpixel((10, 10), (238, 235, 220))
     patch.putpixel((11, 10), (218, 172, 54))
+    matte = Image.new("L", patch.size, 255)
+
+    alpha = redraw_module._build_flower_output_alpha(patch, matte)
+    arr = np.asarray(alpha)
+
+    assert arr[10, 10] > 0
+    assert arr[10, 11] > 0
+    assert arr[10, 12] == 0
+
+
+def test_flower_output_alpha_removes_neutral_olive_halo_adjacent_to_petals():
+    from vulca.layers import redraw as redraw_module
+
+    patch = Image.new("RGB", (20, 20), (30, 82, 38))
+    patch.putpixel((10, 10), (238, 235, 220))
+    patch.putpixel((11, 10), (218, 172, 54))
+    patch.putpixel((12, 10), (105, 100, 65))
     matte = Image.new("L", patch.size, 255)
 
     alpha = redraw_module._build_flower_output_alpha(patch, matte)
@@ -359,6 +449,285 @@ def test_flower_edit_matte_removes_isolated_bright_specks():
     assert arr[6, 6] == 0
     assert arr[9, 72] == 0
     assert arr[52, 12] == 0
+
+
+def test_flower_edit_matte_keeps_dense_clusters_organic():
+    from vulca.layers import redraw as redraw_module
+
+    source = Image.new("RGB", (220, 150), (35, 92, 43))
+    draw = ImageDraw.Draw(source)
+    for x in range(60, 170, 24):
+        for y in range(42, 112, 22):
+            draw.ellipse((x - 8, y - 7, x + 8, y + 7), fill=(238, 235, 220))
+            draw.ellipse((x - 2, y - 2, x + 2, y + 2), fill=(218, 172, 54))
+    for y in range(42, 112, 22):
+        draw.line((60, y, 168, y), fill=(238, 235, 220), width=1)
+
+    child_alpha = Image.new("L", source.size, 0)
+    ImageDraw.Draw(child_alpha).rectangle((38, 25, 190, 130), fill=255)
+
+    matte = redraw_module._build_flower_edit_matte(source, child_alpha)
+    arr = np.asarray(matte) > 8
+    ys, xs = np.where(arr)
+    bbox_area = int((xs.max() - xs.min() + 1) * (ys.max() - ys.min() + 1))
+    fill_ratio = float(arr.sum()) / float(bbox_area)
+
+    assert fill_ratio < 0.75
+
+
+def test_flower_removal_matte_expands_to_cover_old_flower_residue():
+    from vulca.layers import redraw as redraw_module
+
+    source = Image.new("RGB", (80, 60), (35, 92, 43))
+    draw = ImageDraw.Draw(source)
+    draw.ellipse((32, 22, 47, 37), fill=(238, 235, 220))
+    draw.ellipse((38, 28, 42, 32), fill=(218, 172, 54))
+    residue_xy = (23, 30)
+    source.putpixel(residue_xy, (156, 154, 132))
+
+    child_alpha = Image.new("L", source.size, 0)
+    ImageDraw.Draw(child_alpha).rectangle((22, 16, 55, 44), fill=255)
+
+    edit_matte = redraw_module._build_flower_edit_matte(source, child_alpha)
+    removal_matte = redraw_module._build_flower_removal_matte(
+        source,
+        child_alpha,
+        edit_matte,
+    )
+    edit_arr = np.asarray(edit_matte)
+    removal_arr = np.asarray(removal_matte)
+
+    assert edit_arr[residue_xy[1], residue_xy[0]] == 0
+    assert removal_arr[residue_xy[1], residue_xy[0]] > 0
+
+
+def test_source_context_generation_uses_edit_matte_not_broad_removal_matte():
+    from vulca.layers import redraw as redraw_module
+
+    provider = RecordingEditProvider(output_rgb=(242, 240, 224))
+    source = Image.new("RGB", (64, 64), (35, 92, 43))
+    edit_matte = Image.new("L", source.size, 0)
+    ImageDraw.Draw(edit_matte).ellipse((27, 27, 37, 37), fill=255)
+    removal_matte = Image.new("L", source.size, 0)
+    ImageDraw.Draw(removal_matte).rectangle((10, 10, 54, 54), fill=255)
+
+    crop_out, _result = _run(
+        redraw_module._redraw_source_context_with_edit_matte(
+            source_crop=source,
+            edit_matte=edit_matte,
+            removal_matte=removal_matte,
+            instruction="paint small white wildflowers",
+            provider_inst=provider,
+            tradition="default",
+            target_description="wildflower cluster on hedge",
+        )
+    )
+
+    output_alpha_px = int(
+        (np.asarray(crop_out.convert("RGBA").split()[-1]) > 0).sum()
+    )
+
+    assert provider.calls[0]["edit_pixels"] < 260_000
+    assert output_alpha_px < 900
+
+
+def test_source_context_generation_expands_organic_matte_without_filling_removal():
+    from vulca.layers import redraw as redraw_module
+
+    provider = RecordingEditProvider(output_rgb=(242, 240, 224))
+    source = Image.new("RGB", (64, 64), (35, 92, 43))
+    edit_matte = Image.new("L", source.size, 0)
+    draw = ImageDraw.Draw(edit_matte)
+    draw.ellipse((17, 24, 27, 34), fill=255)
+    draw.ellipse((36, 25, 46, 35), fill=255)
+    removal_matte = Image.new("L", source.size, 0)
+    ImageDraw.Draw(removal_matte).rectangle((10, 10, 54, 54), fill=255)
+
+    crop_out, _result = _run(
+        redraw_module._redraw_source_context_with_edit_matte(
+            source_crop=source,
+            edit_matte=edit_matte,
+            removal_matte=removal_matte,
+            instruction="paint small white wildflowers",
+            provider_inst=provider,
+            tradition="default",
+            target_description="wildflower cluster on hedge",
+        )
+    )
+
+    output_alpha_px = int(
+        (np.asarray(crop_out.convert("RGBA").split()[-1]) > 0).sum()
+    )
+
+    assert 90_000 < provider.calls[0]["edit_pixels"] < 360_000
+    assert 350 < output_alpha_px < 1400
+
+
+def test_refined_flower_replacement_covers_old_source_flower_residue(
+    tmp_path, monkeypatch
+):
+    from vulca.layers import redraw as redraw_module
+    import vulca.providers as providers_mod
+
+    provider = RecordingEditProvider(output_rgb=(242, 240, 224))
+    monkeypatch.setattr(
+        providers_mod, "get_image_provider", lambda name, api_key="": provider
+    )
+    artwork = _stage_broad_flower_layer(tmp_path)
+    source_path = tmp_path / "source.png"
+    source = Image.open(source_path).convert("RGB")
+    residue_xy = (42, 58)
+    source.putpixel(residue_xy, (156, 154, 132))
+    source.save(source_path)
+
+    result = _run(
+        redraw_module.redraw_layer(
+            artwork,
+            layer_name="flowers",
+            instruction="small bright white wildflowers with warm yellow centers",
+            provider="openai",
+            artwork_dir=str(tmp_path),
+            route="auto",
+            preserve_alpha=True,
+        )
+    )
+
+    layer = Image.open(result.image_path).convert("RGBA")
+    source_rgba = Image.open(source_path).convert("RGBA")
+    source_rgba.alpha_composite(layer)
+    after = source_rgba.convert("RGB")
+
+    assert layer.getpixel(residue_xy)[3] > 0
+    assert after.getpixel(residue_xy) != (156, 154, 132)
+
+
+def test_flower_replacement_patch_does_not_expose_cleared_background():
+    from vulca.layers import redraw as redraw_module
+
+    source = Image.new("RGB", (50, 40), (35, 92, 43))
+    old_flower_xy = (20, 20)
+    hedge_xy = (30, 20)
+    ImageDraw.Draw(source).ellipse((18, 18, 22, 22), fill=(238, 235, 220))
+
+    cleared = Image.new("RGB", source.size, (78, 91, 44))
+    removal_matte = Image.new("L", source.size, 0)
+    ImageDraw.Draw(removal_matte).rectangle((10, 10, 38, 30), fill=255)
+    generated = Image.new("RGBA", source.size, (0, 0, 0, 0))
+
+    patch = redraw_module._compose_flower_replacement_patch(
+        source,
+        cleared,
+        generated,
+        removal_matte,
+    )
+
+    assert patch.getpixel(old_flower_xy)[3] == 0
+    assert patch.getpixel(hedge_xy)[3] == 0
+
+
+def test_flower_replacement_patch_uses_nearby_generated_paint_for_old_flowers():
+    from vulca.layers import redraw as redraw_module
+
+    source = Image.new("RGB", (50, 40), (35, 92, 43))
+    old_flower_xy = (20, 20)
+    ImageDraw.Draw(source).ellipse((18, 18, 22, 22), fill=(238, 235, 220))
+
+    cleared = Image.new("RGB", source.size, (95, 120, 65))
+    removal_matte = Image.new("L", source.size, 0)
+    ImageDraw.Draw(removal_matte).ellipse((16, 16, 24, 24), fill=255)
+    generated = Image.new("RGBA", source.size, (0, 0, 0, 0))
+    generated.putpixel((25, 20), (242, 240, 224, 255))
+    generated.putpixel((26, 20), (218, 172, 54, 255))
+
+    patch = redraw_module._compose_flower_replacement_patch(
+        source,
+        cleared,
+        generated,
+        removal_matte,
+    )
+
+    old_pixel = patch.getpixel(old_flower_xy)
+
+    assert old_pixel[3] > 0
+    assert old_pixel[:3] != (95, 120, 65)
+    assert old_pixel[0] > 170
+
+
+def test_flower_replacement_patch_does_not_propagate_generated_green_halo():
+    from vulca.layers import redraw as redraw_module
+
+    source = Image.new("RGB", (50, 40), (35, 92, 43))
+    old_flower_xy = (20, 20)
+    ImageDraw.Draw(source).ellipse((18, 18, 22, 22), fill=(238, 235, 220))
+
+    cleared = Image.new("RGB", source.size, (95, 120, 65))
+    removal_matte = Image.new("L", source.size, 0)
+    ImageDraw.Draw(removal_matte).ellipse((16, 16, 24, 24), fill=255)
+    generated = Image.new("RGBA", source.size, (0, 0, 0, 0))
+    generated.putpixel((19, 20), (70, 110, 45, 255))
+    generated.putpixel((25, 20), (242, 240, 224, 255))
+    generated.putpixel((26, 20), (218, 172, 54, 255))
+
+    patch = redraw_module._compose_flower_replacement_patch(
+        source,
+        cleared,
+        generated,
+        removal_matte,
+    )
+
+    old_pixel = patch.getpixel(old_flower_xy)
+
+    assert old_pixel[3] > 0
+    assert old_pixel[0] > 170
+    assert old_pixel[1] > 140
+    assert old_pixel[2] > 100
+
+
+def test_flower_replacement_patch_does_not_fill_distant_old_flowers():
+    from vulca.layers import redraw as redraw_module
+
+    source = Image.new("RGB", (80, 40), (35, 92, 43))
+    old_flower_xy = (20, 20)
+    ImageDraw.Draw(source).ellipse((18, 18, 22, 22), fill=(238, 235, 220))
+
+    cleared = Image.new("RGB", source.size, (95, 120, 65))
+    removal_matte = Image.new("L", source.size, 0)
+    ImageDraw.Draw(removal_matte).ellipse((16, 16, 24, 24), fill=255)
+    generated = Image.new("RGBA", source.size, (0, 0, 0, 0))
+    generated.putpixel((60, 20), (242, 240, 224, 255))
+    generated.putpixel((61, 20), (218, 172, 54, 255))
+
+    patch = redraw_module._compose_flower_replacement_patch(
+        source,
+        cleared,
+        generated,
+        removal_matte,
+    )
+
+    assert patch.getpixel(old_flower_xy)[3] == 0
+
+
+def test_clear_source_crop_uses_surrounding_texture_not_single_fill():
+    from vulca.layers import redraw as redraw_module
+
+    source = Image.new("RGB", (40, 24), (35, 92, 43))
+    for x in range(40):
+        for y in range(24):
+            source.putpixel((x, y), (25 + x, 82 + (y % 5), 38 + (x % 7)))
+    ImageDraw.Draw(source).ellipse((14, 8, 25, 17), fill=(238, 235, 220))
+
+    removal_matte = Image.new("L", source.size, 0)
+    ImageDraw.Draw(removal_matte).rectangle((10, 5, 30, 20), fill=255)
+
+    cleared = redraw_module._clear_source_crop_with_matte(source, removal_matte)
+    cleared_arr = np.asarray(cleared)
+    remove_arr = np.asarray(removal_matte) > 0
+    filled_colors = {
+        tuple(pixel)
+        for pixel in cleared_arr[remove_arr].reshape(-1, 3)
+    }
+
+    assert len(filled_colors) > 8
 
 
 def test_refined_flower_layer_writes_child_artifacts_and_summary(
@@ -399,5 +768,20 @@ def test_refined_flower_layer_writes_child_artifacts_and_summary(
     assert first["status"] == "completed"
     assert first["cost_usd"] == 0.0123
     assert first["usage"] == {"input_tokens": 100, "output_tokens": 200}
-    for key in ("input_path", "mask_path", "raw_path", "patch_path", "pasteback_path"):
+    for key in (
+        "source_crop_path",
+        "removal_matte_path",
+        "cleared_crop_path",
+        "input_path",
+        "mask_path",
+        "raw_path",
+        "patch_path",
+        "pasteback_path",
+    ):
         assert Path(first[key]).exists()
+
+    assert Path(summary["final_source_pasteback_path"]).exists()
+    source_pasteback = Image.open(summary["final_source_pasteback_path"]).convert(
+        "RGBA"
+    )
+    assert source_pasteback.size == (240, 180)

--- a/tests/test_layers_redraw_refinement.py
+++ b/tests/test_layers_redraw_refinement.py
@@ -191,6 +191,68 @@ def test_refined_flower_layer_uses_one_masked_edit_per_child(tmp_path, monkeypat
     )
 
 
+def test_refined_flower_layer_honors_max_refinement_children(tmp_path, monkeypatch):
+    from vulca.layers import redraw as redraw_module
+    import vulca.providers as providers_mod
+
+    provider = RecordingEditProvider()
+    monkeypatch.setattr(
+        providers_mod, "get_image_provider", lambda name, api_key="": provider
+    )
+    artwork = _stage_broad_flower_layer(tmp_path)
+
+    result = _run(
+        redraw_module.redraw_layer(
+            artwork,
+            layer_name="flowers",
+            instruction="small bright white wildflowers with warm yellow centers",
+            provider="openai",
+            artwork_dir=str(tmp_path),
+            route="auto",
+            preserve_alpha=True,
+            max_refinement_children=2,
+        )
+    )
+
+    advisory = getattr(result, "redraw_advisory", {})
+
+    assert len(provider.calls) == 2
+    assert advisory["refined_child_count"] == 2
+    assert advisory["max_refinement_children"] == 2
+
+
+def test_refined_flower_layer_stops_at_redraw_cost_cap(tmp_path, monkeypatch):
+    from vulca.layers import redraw as redraw_module
+    import vulca.providers as providers_mod
+
+    provider = RecordingEditProvider()
+    monkeypatch.setattr(
+        providers_mod, "get_image_provider", lambda name, api_key="": provider
+    )
+    artwork = _stage_broad_flower_layer(tmp_path)
+
+    result = _run(
+        redraw_module.redraw_layer(
+            artwork,
+            layer_name="flowers",
+            instruction="small bright white wildflowers with warm yellow centers",
+            provider="openai",
+            artwork_dir=str(tmp_path),
+            route="auto",
+            preserve_alpha=True,
+            max_redraw_cost_usd=0.0123,
+        )
+    )
+
+    advisory = getattr(result, "redraw_advisory", {})
+
+    assert len(provider.calls) == 1
+    assert advisory["redraw_cost_cap_reached"] is True
+    assert advisory["redraw_cost_cap_usd"] == 0.0123
+    assert advisory["redraw_estimated_cost_usd"] == 0.0123
+    assert advisory["refined_child_count"] == 1
+
+
 def test_auto_redraw_skips_broad_leaf_texture_risk(tmp_path, monkeypatch):
     from vulca.layers import redraw as redraw_module
     import vulca.providers as providers_mod
@@ -428,6 +490,31 @@ def test_flower_output_alpha_removes_neutral_olive_halo_adjacent_to_petals():
     assert arr[10, 10] > 0
     assert arr[10, 11] > 0
     assert arr[10, 12] == 0
+
+
+def test_yellow_flower_output_alpha_rejects_gray_and_olive_scene_context():
+    from vulca.layers import redraw as redraw_module
+
+    patch = Image.new("RGB", (24, 18), (88, 116, 64))
+    patch.putpixel((8, 9), (232, 190, 42))
+    patch.putpixel((9, 9), (238, 206, 72))
+    patch.putpixel((10, 9), (218, 218, 204))
+    patch.putpixel((11, 9), (128, 138, 96))
+    patch.putpixel((12, 9), (236, 235, 226))
+    matte = Image.new("L", patch.size, 255)
+
+    alpha = redraw_module._build_flower_output_alpha(
+        patch,
+        matte,
+        target_palette="yellow",
+    )
+    arr = np.asarray(alpha)
+
+    assert arr[9, 8] > 0
+    assert arr[9, 9] > 0
+    assert arr[9, 10] == 0
+    assert arr[9, 11] == 0
+    assert arr[9, 12] == 0
 
 
 def test_flower_edit_matte_removes_isolated_bright_specks():
@@ -681,6 +768,37 @@ def test_flower_replacement_patch_does_not_propagate_generated_green_halo():
     assert old_pixel[0] > 170
     assert old_pixel[1] > 140
     assert old_pixel[2] > 100
+
+
+def test_yellow_replacement_patch_uses_yellow_paint_not_scene_context():
+    from vulca.layers import redraw as redraw_module
+
+    source = Image.new("RGB", (50, 40), (35, 92, 43))
+    old_flower_xy = (20, 20)
+    ImageDraw.Draw(source).ellipse((18, 18, 22, 22), fill=(232, 190, 42))
+
+    cleared = Image.new("RGB", source.size, (95, 120, 65))
+    removal_matte = Image.new("L", source.size, 0)
+    ImageDraw.Draw(removal_matte).ellipse((16, 16, 24, 24), fill=255)
+    generated = Image.new("RGBA", source.size, (0, 0, 0, 0))
+    generated.putpixel((19, 20), (94, 122, 67, 255))
+    generated.putpixel((25, 20), (232, 190, 42, 255))
+    generated.putpixel((26, 20), (218, 218, 204, 255))
+
+    patch = redraw_module._compose_flower_replacement_patch(
+        source,
+        cleared,
+        generated,
+        removal_matte,
+        target_palette="yellow",
+    )
+
+    old_pixel = patch.getpixel(old_flower_xy)
+
+    assert old_pixel[3] > 0
+    assert old_pixel[0] > 180
+    assert old_pixel[1] > 140
+    assert old_pixel[2] < 120
 
 
 def test_flower_replacement_patch_does_not_fill_distant_old_flowers():

--- a/tests/test_layers_redraw_refinement.py
+++ b/tests/test_layers_redraw_refinement.py
@@ -783,6 +783,38 @@ def test_source_context_generation_rejects_raw_scene_thumbnail():
     assert alpha_px == 0
 
 
+def test_yellow_source_context_output_keeps_source_head_footprint_scale():
+    from vulca.layers import redraw as redraw_module
+
+    raw = Image.new("RGBA", (1024, 1024), (0, 0, 0, 0))
+    ImageDraw.Draw(raw).ellipse((320, 320, 704, 704), fill=(232, 190, 42, 255))
+    provider = StaticRawEditProvider(raw)
+
+    source = Image.new("RGB", (72, 72), (35, 92, 43))
+    edit_matte = Image.new("L", source.size, 0)
+    ImageDraw.Draw(edit_matte).ellipse((31, 31, 41, 41), fill=255)
+    removal_matte = Image.new("L", source.size, 0)
+    ImageDraw.Draw(removal_matte).ellipse((22, 22, 50, 50), fill=255)
+    edit_px = int((np.asarray(edit_matte) > 0).sum())
+
+    crop_out, _result = _run(
+        redraw_module._redraw_source_context_with_edit_matte(
+            source_crop=source,
+            edit_matte=edit_matte,
+            removal_matte=removal_matte,
+            instruction="paint yellow dandelion and buttercup flower heads",
+            provider_inst=provider,
+            tradition="default",
+            target_description="dandelion heads in grass",
+            target_palette="yellow",
+        )
+    )
+
+    alpha_px = int((np.asarray(crop_out.convert("RGBA").split()[-1]) > 0).sum())
+
+    assert alpha_px <= int(edit_px * 1.4)
+
+
 def test_refined_flower_replacement_covers_old_source_flower_residue(
     tmp_path, monkeypatch
 ):

--- a/tests/test_layers_redraw_refinement.py
+++ b/tests/test_layers_redraw_refinement.py
@@ -812,7 +812,7 @@ def test_yellow_replacement_patch_does_not_expand_across_whole_old_head():
     removal_matte = Image.new("L", source.size, 0)
     ImageDraw.Draw(removal_matte).ellipse((14, 14, 30, 26), fill=255)
     generated = Image.new("RGBA", source.size, (0, 0, 0, 0))
-    generated.putpixel((33, 20), (232, 190, 42, 255))
+    generated.putpixel((30, 20), (232, 190, 42, 255))
 
     patch = redraw_module._compose_flower_replacement_patch(
         source,
@@ -823,7 +823,7 @@ def test_yellow_replacement_patch_does_not_expand_across_whole_old_head():
     )
 
     assert patch.getpixel(old_flower_xy)[3] == 0
-    assert patch.getpixel((33, 20))[3] > 0
+    assert patch.getpixel((30, 20))[3] > 0
 
 
 def test_flower_replacement_patch_does_not_fill_distant_old_flowers():

--- a/tests/test_layers_redraw_refinement.py
+++ b/tests/test_layers_redraw_refinement.py
@@ -87,6 +87,39 @@ class RecordingEditProvider:
         raise AssertionError("refinement route must use masked edits")
 
 
+class StaticRawEditProvider(RecordingEditProvider):
+    def __init__(self, output):
+        super().__init__()
+        self.output = output.convert("RGBA")
+
+    async def inpaint_with_mask(self, *, image_path, mask_path, prompt, **kwargs):
+        with Image.open(image_path) as probe:
+            size = probe.size
+        with Image.open(mask_path) as mask_probe:
+            mask_alpha = mask_probe.convert("RGBA").split()[-1]
+            mask_arr = np.asarray(mask_alpha)
+        self.calls.append(
+            {
+                "image_path": image_path,
+                "mask_path": mask_path,
+                "size": size,
+                "prompt": prompt,
+                "edit_pixels": int((mask_arr == 0).sum()),
+                "preserve_pixels": int((mask_arr == 255).sum()),
+            }
+        )
+        raw = self.output.resize(size, Image.Resampling.NEAREST)
+        return type(
+            "Result",
+            (),
+            {
+                "image_b64": _png_b64(raw),
+                "mime": "image/png",
+                "metadata": {"cost_usd": 0.0123, "usage": {}},
+            },
+        )()
+
+
 def _stage_broad_flower_layer(tmp_path: Path):
     size = (240, 180)
     source = Image.new("RGB", size, (35, 92, 43))
@@ -648,6 +681,106 @@ def test_source_context_generation_expands_organic_matte_without_filling_removal
 
     assert 90_000 < provider.calls[0]["edit_pixels"] < 360_000
     assert 350 < output_alpha_px < 1400
+
+
+def test_source_context_generation_uses_micro_botanical_prompt():
+    from vulca.layers import redraw as redraw_module
+
+    provider = RecordingEditProvider(output_rgb=(232, 190, 42))
+    source = Image.new("RGB", (64, 64), (35, 92, 43))
+    edit_matte = Image.new("L", source.size, 0)
+    ImageDraw.Draw(edit_matte).ellipse((27, 27, 37, 37), fill=255)
+
+    _run(
+        redraw_module._redraw_source_context_with_edit_matte(
+            source_crop=source,
+            edit_matte=edit_matte,
+            instruction=(
+                "Preserve grass stems, hedge leaves, white flowers, guardrail, "
+                "sky, vehicles, source lighting, and spatial depth. Make the "
+                "yellow dandelion and buttercup flower heads feel hand-painted "
+                "with warm centers and varied spacing."
+            ),
+            provider_inst=provider,
+            tradition="default",
+            target_description="roadside dandelion heads beside vehicles",
+            target_palette="yellow",
+        )
+    )
+
+    prompt = provider.calls[0]["prompt"].lower()
+
+    assert "only the transparent mask pixels" in prompt
+    assert "yellow dandelion" in prompt
+    assert "flower head" in prompt
+    assert "hand-painted" in prompt
+    assert "guardrail" not in prompt
+    assert "vehicle" not in prompt
+    assert "sky" not in prompt
+    assert "roadside" not in prompt
+
+
+def test_source_context_generation_prompts_child_count_and_scale():
+    from vulca.layers import redraw as redraw_module
+
+    provider = RecordingEditProvider(output_rgb=(232, 190, 42))
+    source = Image.new("RGB", (72, 72), (35, 92, 43))
+    edit_matte = Image.new("L", source.size, 0)
+    draw = ImageDraw.Draw(edit_matte)
+    draw.ellipse((16, 28, 28, 40), fill=255)
+    draw.ellipse((44, 29, 56, 41), fill=255)
+
+    _run(
+        redraw_module._redraw_source_context_with_edit_matte(
+            source_crop=source,
+            edit_matte=edit_matte,
+            instruction="paint yellow dandelion and buttercup flower heads",
+            provider_inst=provider,
+            tradition="default",
+            target_description="dandelion heads in grass",
+            target_palette="yellow",
+        )
+    )
+
+    prompt = provider.calls[0]["prompt"].lower()
+
+    assert "exactly 2" in prompt
+    assert "do not add extra" in prompt
+    assert "match the original head size" in prompt
+
+
+def test_source_context_generation_rejects_raw_scene_thumbnail():
+    from vulca.layers import redraw as redraw_module
+
+    raw_scene = Image.new("RGBA", (1024, 1024), (54, 126, 220, 255))
+    draw = ImageDraw.Draw(raw_scene)
+    draw.rectangle((0, 540, 1024, 1024), fill=(78, 118, 58, 255))
+    draw.rectangle((160, 650, 880, 760), fill=(155, 160, 158, 255))
+    draw.rectangle((250, 455, 760, 620), fill=(170, 24, 35, 255))
+    draw.ellipse((480, 480, 544, 544), fill=(232, 190, 42, 255))
+    for x in range(340, 700, 60):
+        draw.ellipse((x, 720, x + 28, 748), fill=(232, 190, 42, 255))
+    provider = StaticRawEditProvider(raw_scene)
+
+    source = Image.new("RGB", (72, 72), (35, 92, 43))
+    edit_matte = Image.new("L", source.size, 0)
+    ImageDraw.Draw(edit_matte).ellipse((25, 25, 47, 47), fill=255)
+
+    crop_out, _result = _run(
+        redraw_module._redraw_source_context_with_edit_matte(
+            source_crop=source,
+            edit_matte=edit_matte,
+            instruction="paint yellow dandelion and buttercup flower heads",
+            provider_inst=provider,
+            tradition="default",
+            target_description="dandelion heads in grass",
+            target_palette="yellow",
+        )
+    )
+
+    alpha_px = int((np.asarray(crop_out.convert("RGBA").split()[-1]) > 0).sum())
+
+    assert alpha_px == 0
 
 
 def test_refined_flower_replacement_covers_old_source_flower_residue(

--- a/tests/test_mask_refine.py
+++ b/tests/test_mask_refine.py
@@ -193,3 +193,31 @@ def test_refines_yellow_dandelion_heads_without_flower_keyword():
     assert result.strategy == "small_botanical_subject_replacement"
     assert len(result.child_masks) >= 4
     assert result.metrics["refined_coverage_pct"] < 0.25
+
+
+def test_refined_yellow_child_mask_covers_muted_source_head_footprint():
+    source = Image.new("RGB", (140, 100), (76, 112, 52))
+    draw = ImageDraw.Draw(source)
+    draw.ellipse((50, 36, 84, 64), fill=(156, 154, 132))
+    draw.ellipse((60, 43, 74, 57), fill=(232, 190, 31))
+    draw.ellipse((65, 48, 69, 52), fill=(176, 130, 18))
+
+    alpha = Image.new("L", source.size, 0)
+    ImageDraw.Draw(alpha).rectangle((28, 20, 112, 80), fill=255)
+
+    result = refine_mask_for_target(
+        source,
+        alpha,
+        description="roadside dandelion heads in grass",
+        instruction="turn the yellow dots into buttercup flower heads",
+    )
+
+    assert result.applied is True
+    child = result.child_masks[0]
+    child_arr = np.asarray(child)
+    parent_area = int(np.asarray(alpha).astype(bool).sum())
+    child_area = int((child_arr > 0).sum())
+
+    assert child_arr[50, 52] > 0
+    assert child_arr[50, 82] > 0
+    assert child_area < parent_area * 0.2

--- a/tests/test_mask_refine.py
+++ b/tests/test_mask_refine.py
@@ -4,13 +4,13 @@ from PIL import Image, ImageDraw
 from vulca.layers.mask_refine import infer_refinement_profile, refine_mask_for_target
 
 
-def test_infers_bright_small_subject_from_flower_instruction():
+def test_infers_small_botanical_subject_from_flower_instruction():
     profile = infer_refinement_profile(
         description="wildflower cluster on hedge",
         instruction="small bright white wildflowers with warm yellow centers",
     )
     assert profile is not None
-    assert profile.kind == "bright_small_subject"
+    assert profile.kind == "small_botanical_subject_replacement"
 
 
 def test_non_target_layer_is_not_refined():
@@ -54,7 +54,7 @@ def test_refines_broad_flower_mask_into_child_patches():
     )
 
     assert result.applied is True
-    assert result.strategy == "bright_small_subject"
+    assert result.strategy == "small_botanical_subject_replacement"
     assert len(result.child_masks) >= 3
 
     parent_area = int(np.asarray(alpha).astype(bool).sum())
@@ -105,3 +105,91 @@ def test_refined_child_masks_do_not_fill_broad_parent_bbox():
     parent_area = int(np.asarray(alpha).astype(bool).sum())
     child_area = sum(int(np.asarray(child).astype(bool).sum()) for child in result.child_masks)
     assert child_area < parent_area * 0.5
+
+
+def test_refines_dense_connected_flower_evidence_into_bounded_tiles():
+    source = Image.new("RGB", (360, 240), (35, 92, 43))
+    draw = ImageDraw.Draw(source)
+    for x in range(90, 260, 24):
+        for y in range(62, 168, 22):
+            draw.ellipse((x - 12, y - 10, x + 12, y + 10), fill=(238, 235, 220))
+            draw.ellipse((x - 3, y - 3, x + 3, y + 3), fill=(218, 172, 54))
+    for y in range(62, 168, 22):
+        draw.line((90, y, 258, y), fill=(238, 235, 220), width=2)
+
+    alpha = Image.new("L", source.size, 0)
+    ImageDraw.Draw(alpha).rectangle((50, 35, 310, 205), fill=255)
+
+    result = refine_mask_for_target(
+        source,
+        alpha,
+        description="wildflower cluster on hedge",
+        instruction="make small bright white wildflowers with yellow centers",
+        max_children=12,
+    )
+
+    assert result.applied is True
+    assert len(result.child_masks) > 1
+    for child in result.child_masks:
+        ys, xs = np.where(np.asarray(child) > 0)
+        assert int(xs.max() - xs.min() + 1) <= 140
+        assert int(ys.max() - ys.min() + 1) <= 140
+
+
+def test_default_refinement_budget_covers_dense_connected_flower_evidence():
+    source = Image.new("RGB", (480, 260), (35, 92, 43))
+    draw = ImageDraw.Draw(source)
+    for x in range(90, 390, 24):
+        for y in range(62, 190, 22):
+            draw.ellipse((x - 12, y - 10, x + 12, y + 10), fill=(238, 235, 220))
+            draw.ellipse((x - 3, y - 3, x + 3, y + 3), fill=(218, 172, 54))
+    for y in range(62, 190, 22):
+        draw.line((90, y, 388, y), fill=(238, 235, 220), width=2)
+
+    alpha = Image.new("L", source.size, 0)
+    ImageDraw.Draw(alpha).rectangle((50, 35, 430, 225), fill=255)
+
+    result = refine_mask_for_target(
+        source,
+        alpha,
+        description="wildflower cluster on hedge",
+        instruction="make small bright white wildflowers with yellow centers",
+    )
+
+    assert result.applied is True
+    assert len(result.child_masks) > 1
+    assert result.metrics["refined_coverage_pct"] > 0.65
+
+
+def test_refines_yellow_dandelion_heads_without_flower_keyword():
+    source = Image.new("RGB", (320, 220), (76, 112, 52))
+    draw = ImageDraw.Draw(source)
+    centers = (
+        (58, 42),
+        (104, 56),
+        (152, 48),
+        (214, 78),
+        (260, 96),
+        (90, 138),
+        (184, 152),
+        (250, 166),
+    )
+    for cx, cy in centers:
+        draw.line((cx, cy + 5, cx - 4, cy + 34), fill=(64, 105, 48), width=2)
+        draw.ellipse((cx - 7, cy - 6, cx + 7, cy + 6), fill=(232, 190, 31))
+        draw.ellipse((cx - 2, cy - 2, cx + 2, cy + 2), fill=(176, 130, 18))
+
+    alpha = Image.new("L", source.size, 0)
+    ImageDraw.Draw(alpha).rectangle((20, 18, 300, 190), fill=255)
+
+    result = refine_mask_for_target(
+        source,
+        alpha,
+        description="roadside dandelion heads in grass",
+        instruction="turn the yellow dots into buttercup meadow rhythm",
+    )
+
+    assert result.applied is True
+    assert result.strategy == "small_botanical_subject_replacement"
+    assert len(result.child_masks) >= 4
+    assert result.metrics["refined_coverage_pct"] < 0.25


### PR DESCRIPTION
## Summary

- Adds and stabilizes the v0.23 small botanical redraw replacement lane for roadside flower details.
- Tightens yellow/buttercup replacement so muted old flower footprint pixels are included in child masks and covered during pasteback instead of leaving visible source residue.
- Adds an NB2/Gemini masked-edit adapter so `provider="nb2"` can participate in the same redraw contract instead of falling back to unmasked img2img.
- Keeps broad hedge/grass/tree texture redraw outside this strategy through existing broad texture gating and focused small-object tests.

## Root Cause

The yellow flower path constrained output alpha tightly enough to preserve scale, but the original muted flower footprint could sit outside the accepted generated alpha. In pasteback, that made new yellow flower heads appear layered over old source residue. The child mask also needed to include nearby muted flower footprint pixels without treating green-dominant hedge or grass as botanical evidence.

A second issue showed up during NB2 probing: refined small-botanical output could be correct internally, then `_maybe_apply_legacy_color_mask` would re-derive alpha from `dominant_colors` against the whole source image. That reintroduced broad grass/hedge/car texture into the final layer and made pasteback look contaminated. Refinement output now keeps its formal child/edit matte alpha instead of running the legacy color-mask compatibility branch.

## Validation

- `/opt/homebrew/bin/python3.11 -m pytest tests/test_mask_refine.py tests/test_layers_redraw.py tests/test_layers_redraw_crop_pipeline.py tests/test_layers_redraw_mask_aware.py tests/test_layers_redraw_quality_gates.py tests/test_layers_redraw_refinement.py tests/test_layers_redraw_strategy.py tests/test_layers_redraw_wire_contract.py tests/test_layers_v2_redraw.py tests/test_mcp_layers_redraw_advisory.py tests/test_redraw_review_contract.py tests/test_redraw_showcase_review.py tests/test_gemini_image_size.py tests/test_provider_edit_capabilities.py` -> `143 passed, 5 warnings`
- `git diff --check` -> passed
- Real `gpt-image-2` showcase retry used `https://globalai.vip/v1/images/edits`. Auth probe against `/v1/models` returned `200`, but `/v1/images/edits` returned `503 Service Unavailable` on all 3 retries, so no generated artifact was committed.
- Real NB2 masked redraw probe reached the formal path: `route_chosen=inpaint`, `refinement_applied=true`, `provider_requires_mask_for_edits=true`, provider metadata `mode=gemini_mask_adapter`. Before the alpha fix it produced broad pasteback contamination; after the fix contamination was prevented, but that specific NB2 generation was rejected by the raw-scene gate as `raw_scene_thumbnail_leak`, leaving an empty replacement layer rather than unsafe pasteback.

## Notes

This PR intentionally does not expand layered scene reconstruction. The remaining visual risk is provider generation quality: the contract now prevents broad texture contamination, but a provider adapter such as NB2 can still fail to produce an acceptable flower patch and be gated to empty output. Source-layer ownership also remains out of scope: if old flower pixels belong to a broader hedge/grass/source layer, local redraw can reduce but not fully solve that without a separate layered reconstruction workflow.
