### PR TITLE
[codex] Improve NB2 masked edit guidance

### DIFF
--- a/src/vulca/providers/gemini.py
+++ b/src/vulca/providers/gemini.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import io
 import math
 import os
 
@@ -64,6 +65,20 @@ def _detect_mime_type(data: bytes) -> str:
     if data[:4] == b"RIFF" and data[8:12] == b"WEBP":
         return "image/webp"
     return "image/png"
+
+
+def _build_visible_mask_reference(mask_bytes: bytes) -> bytes:
+    """Render an alpha edit mask as visible black/white guidance for Gemini."""
+    from PIL import Image
+
+    with Image.open(io.BytesIO(mask_bytes)) as mask_img:
+        alpha = mask_img.convert("RGBA").split()[-1]
+        visible = alpha.point(lambda value: 255 if value < 128 else 0)
+    rgb = Image.new("RGB", visible.size, (0, 0, 0))
+    rgb.paste((255, 255, 255), mask=visible)
+    buf = io.BytesIO()
+    rgb.save(buf, format="PNG")
+    return buf.getvalue()
 
 
 class GeminiImageProvider:
@@ -279,6 +294,7 @@ class GeminiImageProvider:
             image_bytes = image_fh.read()
         with open(mask_path, "rb") as mask_fh:
             mask_bytes = mask_fh.read()
+        visible_mask_bytes = _build_visible_mask_reference(mask_bytes)
 
         if size and "x" in size:
             try:
@@ -295,11 +311,15 @@ class GeminiImageProvider:
         aspect_ratio = _dims_to_aspect_ratio(width, height)
         full_prompt = (
             f"{prompt}\n\n"
-            "Use the first image as the source crop. Use the second image as an "
-            "RGBA edit mask: transparent mask pixels mark the edit region, and "
-            "opaque mask pixels mark source context that should stay visually "
-            "preserved. Repaint only the transparent mask pixels. Do not create "
-            "a new scene outside the masked replacement area."
+            "Use the first image as the source crop. Use the second image as a "
+            "visible binary edit mask rendered from the original RGBA mask: "
+            "white mask pixels (original transparent mask pixels) mark the edit "
+            "region, and black mask pixels (original opaque mask pixels) mark "
+            "source context that should stay visually preserved. Repaint only "
+            "the white edit region. Do not create a new scene outside the masked "
+            "replacement area. The mask image is not part of the output: do not "
+            "draw the mask, do not copy its white or black shapes, and do not "
+            "leave mask-colored background behind."
         )
         if tradition and tradition != "default":
             full_prompt += (
@@ -314,8 +334,8 @@ class GeminiImageProvider:
                 mime_type=_detect_mime_type(image_bytes),
             ),
             types.Part.from_bytes(
-                data=mask_bytes,
-                mime_type=_detect_mime_type(mask_bytes),
+                data=visible_mask_bytes,
+                mime_type="image/png",
             ),
             full_prompt,
         ]

--- a/tests/test_gemini_image_size.py
+++ b/tests/test_gemini_image_size.py
@@ -202,8 +202,17 @@ class TestGeminiProviderConfig:
         assert recorded["model"] == "gemini-3.1-flash-image-preview"
         assert recorded["contents"][0].mime_type == "image/png"
         assert recorded["contents"][1].mime_type == "image/png"
+        visible_mask = Image.open(io.BytesIO(recorded["contents"][1].data)).convert(
+            "RGB"
+        )
+        assert visible_mask.getpixel((8, 6)) == (255, 255, 255)
+        assert visible_mask.getpixel((0, 0)) == (0, 0, 0)
         assert "transparent mask pixels" in recorded["contents"][2]
         assert "opaque mask pixels" in recorded["contents"][2]
+        assert "white mask pixels" in recorded["contents"][2]
+        assert "black mask pixels" in recorded["contents"][2]
+        assert "do not draw the mask" in recorded["contents"][2].lower()
+        assert "not part of the output" in recorded["contents"][2].lower()
         assert "paint one compact yellow flower head" in recorded["contents"][2]
         assert result.mime == "image/png"
         assert base64.b64decode(result.image_b64).startswith(b"\x89PNG")


### PR DESCRIPTION
## Summary

- Updates the Gemini/NB2 masked edit adapter to render alpha masks as visible black/white reference masks before sending them to Gemini.
- Tightens adapter prompt wording so the visible mask is treated as coordinate guidance, not output content.
- Keeps the formal redraw API contract unchanged: callers still provide source crop + RGBA mask via `inpaint_with_mask`.

## Validation

- `/opt/homebrew/bin/python3.11 -m pytest tests/test_mask_refine.py tests/test_layers_redraw.py tests/test_layers_redraw_crop_pipeline.py tests/test_layers_redraw_mask_aware.py tests/test_layers_redraw_quality_gates.py tests/test_layers_redraw_refinement.py tests/test_layers_redraw_strategy.py tests/test_layers_redraw_wire_contract.py tests/test_layers_v2_redraw.py tests/test_mcp_layers_redraw_advisory.py tests/test_redraw_review_contract.py tests/test_redraw_showcase_review.py tests/test_gemini_image_size.py tests/test_provider_edit_capabilities.py` -> `143 passed, 5 warnings`
- `git diff --check` -> passed
- Secret scan over changed files for Gemini/OpenAI key-shaped tokens -> no matches
- Real NB2 probe on the roadside yellow flower crop reached formal redraw path and improved from gate-to-empty to constrained non-empty output: `route_chosen=inpaint`, `refinement_applied=true`, `provider_requires_mask_for_edits=true`, `raw_scene_rejected=false`, output alpha `0.0249%` of canvas, bbox `(2627, 1484, 2700, 1549)`.

## Visual Risk

This is a provider-adapter quality improvement, not a full visual finish. The latest NB2 output no longer contaminates broad grass/vehicle regions and is localized to the flower footprint, but it can still render a chunky yellow patch because Gemini is not a native alpha-mask edit endpoint. Further work should tune scale/alpha extraction or use a provider with native masked edits for final showcase evidence.

## Readiness Note

PR #42 (`codex/v0-23-redraw-replacement-contract`) merged on 2026-05-05, so the original stacking blocker is gone. This PR is now a focused provider-adapter patch candidate for the next package release after final human review.
