### PR TITLE
[codex] Add redraw learning case logging baseline

### DIFF
--- a/docs/benchmarks/redraw/failure_taxonomy.json
+++ b/docs/benchmarks/redraw/failure_taxonomy.json
@@ -1,0 +1,31 @@
+{
+  "schema_version": 1,
+  "case_type": "redraw_failure_taxonomy",
+  "failure_types": [
+    "color_drift",
+    "shape_collapse",
+    "wrong_subject",
+    "missing_detail",
+    "over_smoothing",
+    "texture_leak",
+    "alpha_expansion",
+    "mask_too_broad",
+    "background_bleed",
+    "large_white_component",
+    "pasteback_mismatch",
+    "route_error",
+    "over_split",
+    "under_split",
+    "uncertain"
+  ],
+  "preferred_actions": [
+    "accept",
+    "rerun",
+    "fallback_to_agent",
+    "fallback_to_original",
+    "manual_review",
+    "adjust_route",
+    "adjust_mask",
+    "adjust_instruction"
+  ]
+}

--- a/docs/benchmarks/redraw/seed_manifest.json
+++ b/docs/benchmarks/redraw/seed_manifest.json
@@ -18,7 +18,7 @@
     },
     {
       "id": "scottish_lantern_multi_instance",
-      "source_artifact": "docs/visual-specs/2026-04-23-scottish-chinese-fusion/source.jpg",
+      "source_artifact": "tests/fixtures/multi_instance/lanterns_6.jpg",
       "failure_type": "mask_too_broad",
       "preferred_action": "adjust_mask",
       "notes": "Multi-instance lantern rows should remain separate enough for targeted redraw."

--- a/docs/benchmarks/redraw/seed_manifest.json
+++ b/docs/benchmarks/redraw/seed_manifest.json
@@ -1,0 +1,48 @@
+{
+  "schema_version": 1,
+  "case_type": "redraw_case_seed",
+  "items": [
+    {
+      "id": "ipad_flower_color_drift",
+      "source_artifact": "docs/visual-specs/2026-04-28-ipad-cartoon-roadside-direct-showcase/source/IMG_6847.jpg",
+      "failure_type": "color_drift",
+      "preferred_action": "adjust_mask",
+      "notes": "Small bright flowers can drift in hue or subject identity without target-aware mask evidence."
+    },
+    {
+      "id": "ipad_full_edit_mask_route",
+      "source_artifact": "docs/visual-specs/2026-04-28-ipad-cartoon-roadside-direct-showcase/source/full_edit_mask_1536x1024.png",
+      "failure_type": "route_error",
+      "preferred_action": "adjust_route",
+      "notes": "Full-canvas edit masks are route evidence, not final product quality evidence."
+    },
+    {
+      "id": "scottish_lantern_multi_instance",
+      "source_artifact": "docs/visual-specs/2026-04-23-scottish-chinese-fusion/source.jpg",
+      "failure_type": "mask_too_broad",
+      "preferred_action": "adjust_mask",
+      "notes": "Multi-instance lantern rows should remain separate enough for targeted redraw."
+    },
+    {
+      "id": "mona_lisa_under_split",
+      "source_artifact": "assets/demo/v2/masters/mona_lisa.jpg",
+      "failure_type": "under_split",
+      "preferred_action": "fallback_to_agent",
+      "notes": "Missed chair/parapet style evidence should route to agent review instead of blind redraw."
+    },
+    {
+      "id": "starry_night_over_split",
+      "source_artifact": "assets/demo/v2/masters/starry_night.jpg",
+      "failure_type": "over_split",
+      "preferred_action": "fallback_to_original",
+      "notes": "Low residual baselines should not be over-split or over-edited."
+    },
+    {
+      "id": "scenario1_pasteback_contract",
+      "source_artifact": "assets/demo/v2/scenario1-redo/original.png",
+      "failure_type": "pasteback_mismatch",
+      "preferred_action": "manual_review",
+      "notes": "Pasteback preview is product evidence separate from isolated layer quality."
+    }
+  ]
+}

--- a/docs/superpowers/plans/2026-05-05-vulca-learning-loop-v0.md
+++ b/docs/superpowers/plans/2026-05-05-vulca-learning-loop-v0.md
@@ -1,0 +1,933 @@
+# Vulca Learning Loop v0 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add optional `redraw_case` JSONL logging for `layers_redraw` so redraw experiments become training and evaluation data without changing default runtime behavior.
+
+**Architecture:** Add a focused `vulca.layers.redraw_cases` module that builds versioned case records and appends JSONL. Integrate it only at CLI/MCP redraw exits, reading existing `LayerInfo`, `redraw_advisory`, output paths, and pasteback preview fields. Keep decomposition and layered generation out of this first implementation; they will get sibling case schemas in separate workstreams.
+
+**Tech Stack:** Python 3.10+, dataclasses-free dictionary records, `json`, `hashlib`, `pathlib`, existing `LayerInfo` / `LayerResult`, pytest.
+
+---
+
+## File Structure
+
+- Create `src/vulca/layers/redraw_cases.py`
+  - Owns `redraw_case` schema construction, failure taxonomy validation, case id generation, environment/path resolution, and JSONL append.
+  - Does not import providers, MCP, CLI, image libraries, or redraw execution code.
+
+- Modify `src/vulca/mcp_server.py`
+  - Adds optional `case_log_path` parameter to `layers_redraw`.
+  - Builds and appends a case record after redraw, pasteback preview, and advisory fields are available.
+  - Returns `case_id` and `case_log_path` only when logging succeeds; returns `case_log_error` when explicitly enabled logging fails.
+
+- Modify `src/vulca/cli.py`
+  - Adds `vulca layers redraw --case-log PATH`.
+  - Appends a case record for single-layer redraw and prints the case id/path.
+  - Leaves default CLI behavior unchanged when the flag/env var is absent.
+
+- Create `tests/test_redraw_cases.py`
+  - Tests schema construction, JSONL append, failure taxonomy validation, and environment path resolution.
+
+- Modify `tests/test_mcp_layers_redraw_advisory.py`
+  - Adds an MCP integration test for case logging.
+
+- Modify `tests/test_cli_commands.py`
+  - Adds a parser/help regression for `--case-log`.
+
+- Create `docs/benchmarks/redraw/failure_taxonomy.json`
+  - Machine-readable copy of the first redraw failure taxonomy.
+
+- Create `docs/benchmarks/redraw/seed_manifest.json`
+  - Small seed manifest of known redraw/decomposition/layered-generation-adjacent case families, explicitly marked as `redraw_case_seed` entries.
+
+- Create `tests/test_redraw_benchmark_manifest.py`
+  - Verifies taxonomy and seed manifest are valid JSON and reference existing local artifacts.
+
+## Task 1: Redraw Case Unit Tests
+
+**Files:**
+- Create: `tests/test_redraw_cases.py`
+- Implementation target: `src/vulca/layers/redraw_cases.py`
+
+- [ ] **Step 1: Write the failing unit tests**
+
+Create `tests/test_redraw_cases.py` with this content:
+
+```python
+import json
+
+import pytest
+
+from vulca.layers.types import LayerInfo
+
+
+def test_build_redraw_case_minimal_schema(tmp_path):
+    from vulca.layers.redraw_cases import build_redraw_case
+
+    layer = LayerInfo(
+        id="layer_fg_001",
+        name="fg",
+        description="foreground object",
+        z_index=1,
+        content_type="subject",
+        semantic_path="subject.object",
+        quality_status="detected",
+        area_pct=1.25,
+    )
+    record = build_redraw_case(
+        artwork_dir=str(tmp_path),
+        source_image="source.png",
+        layer_info=layer,
+        instruction="make it cleaner",
+        provider="openai",
+        model="gpt-image-2",
+        route_requested="auto",
+        source_layer_path=str(tmp_path / "fg.png"),
+        redrawn_layer_path=str(tmp_path / "fg_redrawn.png"),
+        source_pasteback_path=str(tmp_path / "fg_redrawn_on_source.png"),
+        redraw_advisory={
+            "route_chosen": "inpaint",
+            "redraw_route": "sparse_bbox_crop",
+            "geometry_redraw_route": "sparse_bbox_crop",
+            "area_pct": 0.64,
+            "bbox_fill": 1.0,
+            "component_count": 1,
+            "sparse_detected": True,
+            "quality_gate_passed": True,
+            "quality_failures": [],
+            "refinement_applied": False,
+            "refinement_reason": "no_target_profile",
+            "refinement_strategy": "none",
+            "refined_child_count": 0,
+            "mask_granularity_score": 0.0,
+        },
+        created_at="2026-05-05T12:00:00Z",
+    )
+
+    assert record["schema_version"] == 1
+    assert record["case_type"] == "redraw_case"
+    assert record["case_id"].startswith("redraw_20260505T120000Z_")
+    assert record["artwork_dir"] == str(tmp_path)
+    assert record["source_image"] == "source.png"
+    assert record["layer"] == {
+        "id": "layer_fg_001",
+        "name": "fg",
+        "description": "foreground object",
+        "semantic_path": "subject.object",
+        "quality_status": "detected",
+        "area_pct_manifest": 1.25,
+    }
+    assert record["route"]["requested"] == "auto"
+    assert record["route"]["chosen"] == "inpaint"
+    assert record["geometry"]["component_count"] == 1
+    assert record["quality"]["gate_passed"] is True
+    assert record["review"] == {
+        "human_accept": None,
+        "failure_type": "",
+        "preferred_action": "",
+        "reviewer": "",
+        "reviewed_at": "",
+    }
+
+
+def test_append_redraw_case_writes_one_json_line(tmp_path):
+    from vulca.layers.redraw_cases import append_redraw_case
+
+    path = tmp_path / "cases" / "redraw_cases.jsonl"
+    record = {
+        "schema_version": 1,
+        "case_type": "redraw_case",
+        "case_id": "redraw_example",
+    }
+
+    written = append_redraw_case(str(path), record)
+
+    assert written == str(path)
+    lines = path.read_text().splitlines()
+    assert len(lines) == 1
+    assert json.loads(lines[0]) == record
+
+
+def test_validate_failure_type_rejects_unknown_label():
+    from vulca.layers.redraw_cases import validate_failure_type
+
+    assert validate_failure_type("") == ""
+    assert validate_failure_type("mask_too_broad") == "mask_too_broad"
+    with pytest.raises(ValueError, match="unsupported redraw failure_type"):
+        validate_failure_type("bad_label")
+
+
+def test_resolve_case_log_path_supports_env_default(tmp_path, monkeypatch):
+    from vulca.layers.redraw_cases import resolve_case_log_path
+
+    assert resolve_case_log_path("", str(tmp_path)) == ""
+
+    monkeypatch.setenv("VULCA_REDRAW_CASE_LOG", "1")
+    assert resolve_case_log_path("", str(tmp_path)) == str(tmp_path / "redraw_cases.jsonl")
+
+    explicit = tmp_path / "custom.jsonl"
+    assert resolve_case_log_path(str(explicit), str(tmp_path)) == str(explicit)
+
+    monkeypatch.setenv("VULCA_REDRAW_CASE_LOG", str(tmp_path / "env.jsonl"))
+    assert resolve_case_log_path("", str(tmp_path)) == str(tmp_path / "env.jsonl")
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+pytest tests/test_redraw_cases.py -v
+```
+
+Expected: FAIL with `ModuleNotFoundError: No module named 'vulca.layers.redraw_cases'`.
+
+## Task 2: Redraw Case Module
+
+**Files:**
+- Create: `src/vulca/layers/redraw_cases.py`
+- Test: `tests/test_redraw_cases.py`
+
+- [ ] **Step 1: Implement the focused module**
+
+Create `src/vulca/layers/redraw_cases.py` with this content:
+
+```python
+"""Versioned case records for redraw learning loops."""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping
+
+from vulca.layers.types import LayerInfo
+
+CASE_SCHEMA_VERSION = 1
+CASE_TYPE = "redraw_case"
+
+FAILURE_TYPES: frozenset[str] = frozenset(
+    {
+        "color_drift",
+        "shape_collapse",
+        "wrong_subject",
+        "missing_detail",
+        "over_smoothing",
+        "texture_leak",
+        "alpha_expansion",
+        "mask_too_broad",
+        "background_bleed",
+        "large_white_component",
+        "pasteback_mismatch",
+        "route_error",
+        "over_split",
+        "under_split",
+        "uncertain",
+    }
+)
+
+PREFERRED_ACTIONS: frozenset[str] = frozenset(
+    {
+        "",
+        "accept",
+        "rerun",
+        "fallback_to_agent",
+        "fallback_to_original",
+        "manual_review",
+        "adjust_route",
+        "adjust_mask",
+        "adjust_instruction",
+    }
+)
+
+
+def utc_now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def validate_failure_type(value: str) -> str:
+    if value == "":
+        return ""
+    if value not in FAILURE_TYPES:
+        raise ValueError(
+            f"unsupported redraw failure_type {value!r}; expected one of {sorted(FAILURE_TYPES)}"
+        )
+    return value
+
+
+def validate_preferred_action(value: str) -> str:
+    if value not in PREFERRED_ACTIONS:
+        raise ValueError(
+            f"unsupported redraw preferred_action {value!r}; expected one of {sorted(PREFERRED_ACTIONS)}"
+        )
+    return value
+
+
+def resolve_case_log_path(case_log_path: str, artwork_dir: str) -> str:
+    if case_log_path:
+        return str(Path(case_log_path))
+    env_value = os.environ.get("VULCA_REDRAW_CASE_LOG", "").strip()
+    if not env_value:
+        return ""
+    if env_value.lower() in {"1", "true", "yes", "on"}:
+        return str(Path(artwork_dir) / "redraw_cases.jsonl")
+    return str(Path(env_value))
+
+
+def build_redraw_case(
+    *,
+    artwork_dir: str,
+    source_image: str,
+    layer_info: LayerInfo,
+    instruction: str,
+    provider: str,
+    model: str,
+    route_requested: str,
+    source_layer_path: str,
+    redrawn_layer_path: str,
+    source_pasteback_path: str = "",
+    redraw_advisory: Mapping[str, Any] | None = None,
+    debug_summary_path: str = "",
+    created_at: str | None = None,
+    human_accept: bool | None = None,
+    failure_type: str = "",
+    preferred_action: str = "",
+    reviewer: str = "",
+    reviewed_at: str = "",
+) -> dict[str, Any]:
+    advisory = dict(redraw_advisory or {})
+    created = created_at or utc_now_iso()
+    checked_failure_type = validate_failure_type(failure_type)
+    checked_action = validate_preferred_action(preferred_action)
+    case_id = _make_case_id(
+        created_at=created,
+        source_layer_path=source_layer_path,
+        redrawn_layer_path=redrawn_layer_path,
+        instruction=instruction,
+        provider=provider,
+        model=model,
+    )
+
+    return {
+        "schema_version": CASE_SCHEMA_VERSION,
+        "case_type": CASE_TYPE,
+        "case_id": case_id,
+        "created_at": created,
+        "artwork_dir": str(artwork_dir),
+        "source_image": str(source_image or ""),
+        "layer": {
+            "id": str(layer_info.id),
+            "name": str(layer_info.name),
+            "description": str(layer_info.description),
+            "semantic_path": str(layer_info.semantic_path or ""),
+            "quality_status": str(layer_info.quality_status or ""),
+            "area_pct_manifest": float(layer_info.area_pct or 0.0),
+        },
+        "instruction": str(instruction),
+        "provider": str(provider),
+        "model": str(model or advisory.get("model", "")),
+        "route": {
+            "requested": str(route_requested or advisory.get("route_requested", "")),
+            "chosen": str(advisory.get("route_chosen", "")),
+            "redraw_route": str(advisory.get("redraw_route", "")),
+            "geometry_redraw_route": str(advisory.get("geometry_redraw_route", "")),
+        },
+        "geometry": {
+            "area_pct": float(advisory.get("area_pct", 0.0) or 0.0),
+            "bbox_fill": float(advisory.get("bbox_fill", 0.0) or 0.0),
+            "component_count": int(advisory.get("component_count", 0) or 0),
+            "sparse_detected": bool(advisory.get("sparse_detected", False)),
+        },
+        "quality": {
+            "gate_passed": _optional_bool(advisory.get("quality_gate_passed")),
+            "failures": [str(item) for item in advisory.get("quality_failures", [])],
+            "metrics": dict(advisory.get("quality_metrics", {}) or {}),
+        },
+        "refinement": {
+            "applied": bool(advisory.get("refinement_applied", False)),
+            "reason": str(advisory.get("refinement_reason", "")),
+            "strategy": str(advisory.get("refinement_strategy", "")),
+            "child_count": int(advisory.get("refined_child_count", 0) or 0),
+            "mask_granularity_score": float(
+                advisory.get("mask_granularity_score", 0.0) or 0.0
+            ),
+        },
+        "artifacts": {
+            "source_layer_path": str(source_layer_path or ""),
+            "redrawn_layer_path": str(redrawn_layer_path or ""),
+            "source_pasteback_path": str(source_pasteback_path or ""),
+            "debug_summary_path": str(debug_summary_path or ""),
+        },
+        "review": {
+            "human_accept": human_accept,
+            "failure_type": checked_failure_type,
+            "preferred_action": checked_action,
+            "reviewer": str(reviewer or ""),
+            "reviewed_at": str(reviewed_at or ""),
+        },
+    }
+
+
+def append_redraw_case(case_log_path: str, record: Mapping[str, Any]) -> str:
+    if not case_log_path:
+        raise ValueError("case_log_path is required when appending a redraw case")
+    path = Path(case_log_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(dict(record), sort_keys=True, separators=(",", ":")))
+        fh.write("\n")
+    return str(path)
+
+
+def _optional_bool(value: Any) -> bool | None:
+    if isinstance(value, bool):
+        return value
+    return None
+
+
+def _make_case_id(
+    *,
+    created_at: str,
+    source_layer_path: str,
+    redrawn_layer_path: str,
+    instruction: str,
+    provider: str,
+    model: str,
+) -> str:
+    stamp = (
+        created_at.replace("-", "")
+        .replace(":", "")
+        .replace(".", "")
+        .replace("+", "")
+    )
+    seed = "\n".join(
+        [
+            created_at,
+            source_layer_path,
+            redrawn_layer_path,
+            instruction,
+            provider,
+            model,
+        ]
+    )
+    digest = hashlib.sha256(seed.encode("utf-8")).hexdigest()[:12]
+    return f"redraw_{stamp}_{digest}"
+```
+
+- [ ] **Step 2: Run the unit tests**
+
+Run:
+
+```bash
+pytest tests/test_redraw_cases.py -v
+```
+
+Expected: PASS, 4 tests passed.
+
+- [ ] **Step 3: Commit the module and unit tests**
+
+Run:
+
+```bash
+git add src/vulca/layers/redraw_cases.py tests/test_redraw_cases.py
+git commit -m "feat(redraw): add redraw case records"
+```
+
+## Task 3: MCP Redraw Case Logging
+
+**Files:**
+- Modify: `tests/test_mcp_layers_redraw_advisory.py`
+- Modify: `src/vulca/mcp_server.py`
+
+- [ ] **Step 1: Add the failing MCP integration test**
+
+Append this test to `tests/test_mcp_layers_redraw_advisory.py`:
+
+```python
+def test_layers_redraw_appends_case_log_when_enabled(tmp_path, monkeypatch):
+    _install_fastmcp_stub(monkeypatch)
+
+    from vulca.mcp_server import layers_redraw
+    import vulca.providers as providers_mod
+
+    provider = RecordingEditProvider()
+    monkeypatch.setattr(
+        providers_mod, "get_image_provider", lambda name, api_key="": provider
+    )
+    _stage_artwork(tmp_path)
+    case_log = tmp_path / "redraw_cases.jsonl"
+
+    result = _run(
+        layers_redraw(
+            artwork_dir=str(tmp_path),
+            layer="fg",
+            instruction="make it cleaner",
+            provider="openai",
+            route="auto",
+            preserve_alpha=True,
+            case_log_path=str(case_log),
+        )
+    )
+
+    assert result["case_log_path"] == str(case_log)
+    assert result["case_id"].startswith("redraw_")
+    lines = case_log.read_text().splitlines()
+    assert len(lines) == 1
+
+    import json
+
+    record = json.loads(lines[0])
+    assert record["case_id"] == result["case_id"]
+    assert record["layer"]["name"] == "fg"
+    assert record["instruction"] == "make it cleaner"
+    assert record["provider"] == "openai"
+    assert record["model"] == ""
+    assert record["route"]["chosen"] == "inpaint"
+    assert record["artifacts"]["source_pasteback_path"].endswith("_on_source.png")
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run:
+
+```bash
+pytest tests/test_mcp_layers_redraw_advisory.py::test_layers_redraw_appends_case_log_when_enabled -v
+```
+
+Expected: FAIL with `TypeError` because `layers_redraw()` does not accept `case_log_path`.
+
+- [ ] **Step 3: Modify the MCP tool signature and docstring**
+
+In `src/vulca/mcp_server.py`, update the `layers_redraw` signature around the current `output_format` parameter:
+
+```python
+    output_format: str = "",
+    case_log_path: str = "",
+) -> dict:
+```
+
+In the same docstring, add this argument description after the `route` description:
+
+```python
+        case_log_path: Optional JSONL path for Learning Loop v0 redraw case
+            logging. Empty means disabled unless VULCA_REDRAW_CASE_LOG is set.
+            Logging is best-effort and never invalidates the redraw result.
+```
+
+- [ ] **Step 4: Add MCP logging after payload/advisory construction**
+
+In `src/vulca/mcp_server.py`, replace the final lines:
+
+```python
+    payload.update(getattr(result, "redraw_advisory", {}) or {})
+    return payload
+```
+
+with:
+
+```python
+    payload.update(getattr(result, "redraw_advisory", {}) or {})
+
+    from vulca.layers.redraw_cases import (
+        append_redraw_case,
+        build_redraw_case,
+        resolve_case_log_path,
+    )
+
+    resolved_case_log_path = resolve_case_log_path(case_log_path, artwork_dir)
+    if resolved_case_log_path:
+        if merge or not layer:
+            payload["case_log_error"] = (
+                "redraw case logging supports only single-layer redraw in v0"
+            )
+        else:
+            try:
+                source_layer = next(
+                    (lr for lr in artwork.layers if lr.info.name == layer),
+                    None,
+                )
+                if source_layer is None:
+                    raise ValueError(f"layer {layer!r} not found in artwork")
+                record = build_redraw_case(
+                    artwork_dir=artwork_dir,
+                    source_image=artwork.source_image,
+                    layer_info=source_layer.info,
+                    instruction=instruction,
+                    provider=provider,
+                    model=model,
+                    route_requested=route,
+                    source_layer_path=source_layer.image_path,
+                    redrawn_layer_path=result.image_path,
+                    source_pasteback_path=payload.get("source_pasteback_path", ""),
+                    redraw_advisory=payload,
+                )
+                payload["case_log_path"] = append_redraw_case(
+                    resolved_case_log_path,
+                    record,
+                )
+                payload["case_id"] = record["case_id"]
+            except Exception as exc:
+                payload["case_log_error"] = str(exc)
+    return payload
+```
+
+- [ ] **Step 5: Run MCP advisory tests**
+
+Run:
+
+```bash
+pytest tests/test_mcp_layers_redraw_advisory.py -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit MCP integration**
+
+Run:
+
+```bash
+git add src/vulca/mcp_server.py tests/test_mcp_layers_redraw_advisory.py
+git commit -m "feat(mcp): log redraw cases"
+```
+
+## Task 4: CLI Case Logging Flag
+
+**Files:**
+- Modify: `tests/test_cli_commands.py`
+- Modify: `src/vulca/cli.py`
+
+- [ ] **Step 1: Add the failing CLI help test**
+
+Append this method inside `TestCLICommands` in `tests/test_cli_commands.py`:
+
+```python
+    def test_layers_redraw_help_mentions_case_log(self):
+        result = subprocess.run(
+            VULCA + ["layers", "redraw", "--help"],
+            capture_output=True, text=True, timeout=10,
+        )
+        assert result.returncode == 0
+        assert "--case-log" in result.stdout
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run:
+
+```bash
+pytest tests/test_cli_commands.py::TestCLICommands::test_layers_redraw_help_mentions_case_log -v
+```
+
+Expected: FAIL because `--case-log` is not present in help output.
+
+- [ ] **Step 3: Add the CLI parser flag**
+
+In `src/vulca/cli.py`, after the existing `layers_redraw.add_argument("--re-split", ...)` block, add:
+
+```python
+    layers_redraw.add_argument(
+        "--case-log",
+        default="",
+        help=(
+            "Append a Learning Loop v0 redraw case JSONL record to this path. "
+            "If omitted, VULCA_REDRAW_CASE_LOG can enable logging."
+        ),
+    )
+```
+
+- [ ] **Step 4: Add CLI logging for single-layer redraw**
+
+In `src/vulca/cli.py`, replace the single-layer redraw branch:
+
+```python
+            result = loop.run_until_complete(
+                redraw_layer(artwork, layer_name=args.layer,
+                             instruction=args.instruction, provider=args.provider,
+                             tradition=args.tradition, artwork_dir=args.artwork_dir)
+            )
+            print(f"  Redrawn: {result.info.name} -> {result.image_path}")
+```
+
+with:
+
+```python
+            source_layer = next(
+                (lr for lr in artwork.layers if lr.info.name == args.layer),
+                None,
+            )
+            result = loop.run_until_complete(
+                redraw_layer(artwork, layer_name=args.layer,
+                             instruction=args.instruction, provider=args.provider,
+                             tradition=args.tradition, artwork_dir=args.artwork_dir)
+            )
+            print(f"  Redrawn: {result.info.name} -> {result.image_path}")
+            from vulca.layers.redraw_cases import (
+                append_redraw_case,
+                build_redraw_case,
+                resolve_case_log_path,
+            )
+            resolved_case_log_path = resolve_case_log_path(
+                getattr(args, "case_log", ""),
+                args.artwork_dir,
+            )
+            if resolved_case_log_path:
+                try:
+                    if source_layer is None:
+                        raise ValueError(f"layer {args.layer!r} not found in artwork")
+                    advisory = getattr(result, "redraw_advisory", {}) or {}
+                    record = build_redraw_case(
+                        artwork_dir=args.artwork_dir,
+                        source_image=artwork.source_image,
+                        layer_info=source_layer.info,
+                        instruction=args.instruction,
+                        provider=args.provider,
+                        model="",
+                        route_requested=str(advisory.get("route_requested", "")),
+                        source_layer_path=source_layer.image_path,
+                        redrawn_layer_path=result.image_path,
+                        redraw_advisory=advisory,
+                    )
+                    written_case_log_path = append_redraw_case(
+                        resolved_case_log_path,
+                        record,
+                    )
+                    print(f"  Case log: {record['case_id']} -> {written_case_log_path}")
+                except Exception as exc:
+                    print(f"  Case log error: {exc}", file=sys.stderr)
+```
+
+- [ ] **Step 5: Run CLI tests**
+
+Run:
+
+```bash
+pytest tests/test_cli_commands.py::TestCLICommands::test_layers_redraw_help_mentions_case_log -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit CLI integration**
+
+Run:
+
+```bash
+git add src/vulca/cli.py tests/test_cli_commands.py
+git commit -m "feat(cli): expose redraw case logging"
+```
+
+## Task 5: Benchmark Taxonomy And Seed Manifest
+
+**Files:**
+- Create: `docs/benchmarks/redraw/failure_taxonomy.json`
+- Create: `docs/benchmarks/redraw/seed_manifest.json`
+- Create: `tests/test_redraw_benchmark_manifest.py`
+
+- [ ] **Step 1: Write failing benchmark manifest tests**
+
+Create `tests/test_redraw_benchmark_manifest.py` with this content:
+
+```python
+import json
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+def test_redraw_failure_taxonomy_matches_seed_manifest():
+    taxonomy_path = ROOT / "docs" / "benchmarks" / "redraw" / "failure_taxonomy.json"
+    manifest_path = ROOT / "docs" / "benchmarks" / "redraw" / "seed_manifest.json"
+
+    taxonomy = json.loads(taxonomy_path.read_text())
+    manifest = json.loads(manifest_path.read_text())
+
+    allowed = set(taxonomy["failure_types"])
+    assert "mask_too_broad" in allowed
+    assert manifest["case_type"] == "redraw_case_seed"
+    assert manifest["schema_version"] == 1
+    assert manifest["items"]
+    for item in manifest["items"]:
+        assert item["failure_type"] in allowed
+        artifact = ROOT / item["source_artifact"]
+        assert artifact.exists(), item["source_artifact"]
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run:
+
+```bash
+pytest tests/test_redraw_benchmark_manifest.py -v
+```
+
+Expected: FAIL because the JSON files do not exist.
+
+- [ ] **Step 3: Add the failure taxonomy JSON**
+
+Create `docs/benchmarks/redraw/failure_taxonomy.json` with this content:
+
+```json
+{
+  "schema_version": 1,
+  "case_type": "redraw_failure_taxonomy",
+  "failure_types": [
+    "color_drift",
+    "shape_collapse",
+    "wrong_subject",
+    "missing_detail",
+    "over_smoothing",
+    "texture_leak",
+    "alpha_expansion",
+    "mask_too_broad",
+    "background_bleed",
+    "large_white_component",
+    "pasteback_mismatch",
+    "route_error",
+    "over_split",
+    "under_split",
+    "uncertain"
+  ],
+  "preferred_actions": [
+    "accept",
+    "rerun",
+    "fallback_to_agent",
+    "fallback_to_original",
+    "manual_review",
+    "adjust_route",
+    "adjust_mask",
+    "adjust_instruction"
+  ]
+}
+```
+
+- [ ] **Step 4: Add the seed manifest JSON**
+
+Create `docs/benchmarks/redraw/seed_manifest.json` with this content:
+
+```json
+{
+  "schema_version": 1,
+  "case_type": "redraw_case_seed",
+  "items": [
+    {
+      "id": "ipad_flower_color_drift",
+      "source_artifact": "docs/visual-specs/2026-04-28-ipad-cartoon-roadside-direct-showcase/source/IMG_6847.jpg",
+      "failure_type": "color_drift",
+      "preferred_action": "adjust_mask",
+      "notes": "Small bright flowers can drift in hue or subject identity without target-aware mask evidence."
+    },
+    {
+      "id": "ipad_full_edit_mask_route",
+      "source_artifact": "docs/visual-specs/2026-04-28-ipad-cartoon-roadside-direct-showcase/source/full_edit_mask_1536x1024.png",
+      "failure_type": "route_error",
+      "preferred_action": "adjust_route",
+      "notes": "Full-canvas edit masks are route evidence, not final product quality evidence."
+    },
+    {
+      "id": "scottish_lantern_multi_instance",
+      "source_artifact": "docs/visual-specs/2026-04-23-scottish-chinese-fusion/source.jpg",
+      "failure_type": "mask_too_broad",
+      "preferred_action": "adjust_mask",
+      "notes": "Multi-instance lantern rows should remain separate enough for targeted redraw."
+    },
+    {
+      "id": "mona_lisa_under_split",
+      "source_artifact": "assets/demo/v2/masters/mona_lisa.jpg",
+      "failure_type": "under_split",
+      "preferred_action": "fallback_to_agent",
+      "notes": "Missed chair/parapet style evidence should route to agent review instead of blind redraw."
+    },
+    {
+      "id": "starry_night_over_split",
+      "source_artifact": "assets/demo/v2/masters/starry_night.jpg",
+      "failure_type": "over_split",
+      "preferred_action": "fallback_to_original",
+      "notes": "Low residual baselines should not be over-split or over-edited."
+    },
+    {
+      "id": "scenario1_pasteback_contract",
+      "source_artifact": "assets/demo/v2/scenario1-redo/original.png",
+      "failure_type": "pasteback_mismatch",
+      "preferred_action": "manual_review",
+      "notes": "Pasteback preview is product evidence separate from isolated layer quality."
+    }
+  ]
+}
+```
+
+- [ ] **Step 5: Run benchmark tests**
+
+Run:
+
+```bash
+pytest tests/test_redraw_benchmark_manifest.py -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit benchmark docs**
+
+Run:
+
+```bash
+git add docs/benchmarks/redraw/failure_taxonomy.json docs/benchmarks/redraw/seed_manifest.json tests/test_redraw_benchmark_manifest.py
+git commit -m "docs(redraw): seed learning benchmark"
+```
+
+## Task 6: Focused Regression Sweep
+
+**Files:**
+- Uses files modified in Tasks 1-5.
+
+- [ ] **Step 1: Run the new focused test suite**
+
+Run:
+
+```bash
+pytest tests/test_redraw_cases.py tests/test_mcp_layers_redraw_advisory.py tests/test_cli_commands.py::TestCLICommands::test_layers_redraw_help_mentions_case_log tests/test_redraw_benchmark_manifest.py -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run existing redraw regression tests touched by the integration**
+
+Run:
+
+```bash
+pytest tests/test_layers_redraw_strategy.py tests/test_layers_redraw_quality_gates.py tests/test_redraw_review_contract.py tests/test_mcp_layers_redraw_advisory.py -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Check repository status**
+
+Run:
+
+```bash
+git status --short
+```
+
+Expected: only unrelated pre-existing untracked dogfood/demo files remain. No modified tracked files should remain after the task commits.
+
+- [ ] **Step 4: Final implementation note**
+
+Record in the final handoff that Learning Loop v0 implemented only `redraw_case`. Decomposition case records and layered-generation case records remain distinct sibling schemas and should not be shoehorned into `redraw_case`.
+
+## Self-Review
+
+Spec coverage:
+- Versioned `redraw_case` schema: Task 1 and Task 2.
+- Optional case logging from `layers_redraw`: Task 3 and Task 4.
+- CLI/MCP visibility: Task 3 and Task 4.
+- Failure taxonomy and benchmark seed manifest: Task 5.
+- No model training or heavy dependencies: all tasks use only standard library plus existing Vulca types.
+- Decomposition vs layered generation distinction: File Structure and Task 6 final note keep sibling schemas separate.
+
+Placeholder scan:
+- The plan contains no forbidden planning markers, no unspecified test commands, and no unspecified files.
+
+Type consistency:
+- `case_log_path`, `case_id`, `case_log_error`, `redraw_advisory`, and `source_pasteback_path` names match the implementation snippets and tests.

--- a/docs/superpowers/specs/2026-05-05-decompose-case-design.md
+++ b/docs/superpowers/specs/2026-05-05-decompose-case-design.md
@@ -1,0 +1,328 @@
+# Decompose Case Learning Schema Design
+
+Date: 2026-05-05
+Status: approved-for-implementation
+
+## Purpose
+
+`decompose_case` is the Learning Loop case type for one whole image split job:
+an existing source image is decomposed into semantic RGBA layers, a manifest,
+residual evidence, and debug artifacts. It captures whether the split is good
+enough for editing and what a future tiny model or tiny agent should do next
+when it is not.
+
+This case type is a sibling of `redraw_case` and future `layer_generate_case`.
+It must not be implemented by overloading `src/vulca/layers/redraw_cases.py`.
+The future implementation should live in a separate decompose-focused
+module/schema and only read existing split/decompose outputs.
+
+## Boundary
+
+`decompose_case` records `existing image -> semantic layer split`.
+
+It is not a redraw case. It does not carry redraw instructions, edited layer
+outputs, source pasteback previews, or per-layer redraw routes. The record is
+about the quality of the split job as a whole, with per-layer evidence where
+needed.
+
+It is not layered generation. There is no intent-to-new-layer generation step.
+`target_layer_hints` guide segmentation of the existing pixels; they are not
+prompts to synthesize new layer imagery. Layer assets should preserve source
+image pixels under alpha masks, with residual and composite artifacts used as
+evidence for coverage and leakage.
+
+## Case Record
+
+Each record is a local-path JSON object. Paths are strings; images and masks
+are never embedded as base64.
+
+```json
+{
+  "schema_version": 1,
+  "case_type": "decompose_case",
+  "case_id": "decompose_20260505T120000Z_a1b2c3d4e5f6",
+  "created_at": "2026-05-05T12:00:00Z",
+  "input": {
+    "source_image": "assets/showcase/originals/starry-night.jpg",
+    "requested": {
+      "mode": "orchestrated",
+      "provider": "",
+      "model": "",
+      "tradition": "post_impressionist_painting"
+    },
+    "target_layer_hints": [
+      {
+        "name": "sky",
+        "label": "swirling blue sky with yellow stars and moon",
+        "semantic_path": "background.sky",
+        "detector": "sam_bbox",
+        "bbox_hint_pct": [0.0, 0.0, 1.0, 0.6],
+        "multi_instance": false,
+        "threshold": null
+      }
+    ]
+  },
+  "output": {
+    "output_dir": "assets/showcase/layers_v2/starry-night",
+    "manifest_path": "assets/showcase/layers_v2/starry-night/manifest.json",
+    "manifest_version": 5,
+    "split_mode": "claude_orchestrated",
+    "status": "ok",
+    "layers": [
+      {
+        "id": "layer_b4168030",
+        "name": "sky",
+        "semantic_path": "background.sky",
+        "file": "assets/showcase/layers_v2/starry-night/sky.png",
+        "z_index": 10,
+        "quality_status": "detected",
+        "area_pct": 51.55,
+        "bbox": [0, 0, 1279, 608],
+        "parent_layer_id": null
+      }
+    ],
+    "residual_path": "assets/showcase/layers_v2/starry-night/residual.png",
+    "composite_path": "",
+    "detection_report": {
+      "requested": 5,
+      "detected": 5,
+      "suspect": 0,
+      "missed": 0,
+      "success_rate": 1.0
+    },
+    "debug_artifacts": {
+      "qa_contact_sheet_path": "assets/showcase/layers_v2/starry-night/qa_contact_sheet.jpg",
+      "qa_prompt_path": "assets/showcase/layers_v2/starry-night/qa_prompt.md",
+      "mask_overlay_paths": [],
+      "log_path": ""
+    }
+  },
+  "quality": {
+    "quality_score": null,
+    "layer_coverage": {
+      "claimed_pct": 85.45,
+      "residual_pct": 14.55,
+      "missed_hint_count": 0,
+      "suspect_hint_count": 0
+    },
+    "alpha_quality": {
+      "mean_edge_softness": null,
+      "hard_edge_ratio": null,
+      "empty_layer_count": 0,
+      "opaque_noise_ratio": null
+    },
+    "over_split": {
+      "score": null,
+      "evidence": []
+    },
+    "under_split": {
+      "score": null,
+      "evidence": []
+    },
+    "semantic_mismatch": {
+      "score": null,
+      "evidence": []
+    },
+    "residual_leakage": {
+      "score": null,
+      "residual_pct": 14.55,
+      "evidence": []
+    }
+  },
+  "review": {
+    "human_accept": null,
+    "failure_type": "",
+    "preferred_action": "",
+    "reviewer": "",
+    "reviewed_at": "",
+    "notes": ""
+  }
+}
+```
+
+`case_id` should be stable enough for logs but not globally meaningful. The
+recommended form is timestamp plus a short hash over source image, requested
+mode/provider/model, tradition, target hints, manifest path, and output dir.
+
+## Inputs
+
+- `source_image`: original flat image used for decomposition. This is required
+  and is the causal source of all layer assets.
+- `requested.mode`: split/decompose route requested by the caller, such as
+  `extract`, `vlm`, `sam3`, or `orchestrated`.
+- `requested.provider`: provider requested for modes that need one. Empty
+  string is valid for detector/SAM-based paths that do not call an image
+  provider.
+- `requested.model`: provider or segmentation model identifier when known.
+  Empty string means unavailable, not guessed.
+- `requested.tradition`: tradition/domain context used to plan or interpret
+  the split. This may come from the caller, manifest, or decompose plan.
+- `target_layer_hints`: normalized hints that describe what should be split
+  from the existing image. For orchestrated plans this maps from plan entities:
+  `name`, `label`, `semantic_path`, `detector`, `bbox_hint_pct`,
+  `multi_instance`, `threshold`, `order`, and related split thresholds.
+
+## Outputs
+
+- `manifest_path`, `output_dir`, `manifest_version`, `split_mode`, and `status`
+  identify the concrete decomposition output.
+- `layers` records the produced layer assets and enough manifest metadata for
+  later learning: `id`, `name`, `semantic_path`, `file`, `z_index`,
+  `quality_status`, `area_pct`, `bbox`, and `parent_layer_id`.
+- `residual_path` records the residual layer when present. Residual is an
+  honesty artifact for pixels not explained by named hints; it is not a normal
+  target layer.
+- `composite_path` is optional. It should point to a recomposed output only
+  when the pipeline produced one or a caller generated one as quality evidence.
+- `detection_report` preserves existing detector/SAM/plan observability:
+  requested/detected/suspect/missed counts, per-entity statuses, quality flags,
+  scores, bbox fill, inside ratio, and success rate when available.
+- `debug_artifacts` preserves review aids such as QA contact sheets, QA prompts,
+  mask overlays, sidecar logs, or provider/debug summaries.
+
+## Quality Metrics
+
+Quality metrics should be numeric when deterministic evidence exists and `null`
+when the implementation does not yet compute a metric. Do not invent values.
+
+- `layer_coverage`: measures whether target hints and output layers explain the
+  source image. Existing signals include `area_pct`, residual percentage,
+  `detection_report.detected`, `suspect`, `missed`, and per-entity status.
+- `alpha_quality`: measures whether layer alpha is useful for editing. Evidence
+  may include empty masks, hard-edge ratios, edge softness, noisy opaque pixels,
+  excessive holes, or alpha artifacts from VLM/SAM/keying paths.
+- `over_split`: measures redundant or overly fine fragments, such as many
+  sibling layers that should be merged, duplicate multi-instance masks, or face
+  parts that create no useful editing control.
+- `under_split`: measures coarse or missing decomposition, such as a whole
+  person captured as one layer when face/hair/clothing are expected, or a large
+  residual holding recognizable target concepts.
+- `semantic_mismatch`: measures whether a layer captures the wrong concept,
+  wrong instance, wrong region, or semantically unrelated source pixels.
+- `residual_leakage`: measures source pixels that should belong to named layers
+  but remain in residual, plus named layer pixels that leak into residual-like
+  catch-all/background regions.
+
+The first bounded `quality_score` should be a 0.0-1.0 reviewer/model target:
+`1.0` means editable, semantically correct, and low residual leakage; `0.0`
+means unusable split output. It is a learning label, not a hard runtime gate.
+
+## Review Labels
+
+Review labels are sparse at case creation and filled by a human reviewer,
+large-agent teacher, or later review queue.
+
+- `human_accept`: `true`, `false`, or `null`.
+- `failure_type`: one decompose-specific label or empty string before review.
+- `preferred_action`: one decompose-specific next action or empty string before
+  review.
+- `reviewer`, `reviewed_at`, `notes`: optional provenance and short rationale.
+
+Initial `failure_type` enum:
+
+- `over_split`
+- `under_split`
+- `semantic_mismatch`
+- `alpha_bad`
+- `residual_leakage`
+- `missed_concept`
+- `wrong_instance`
+- `empty_layer`
+- `duplicate_layer`
+- `debug_artifact_missing`
+- `route_error`
+- `uncertain`
+
+Initial `preferred_action` enum:
+
+- `rerun_split`
+- `adjust_hints`
+- `merge_layers`
+- `split_layer_further`
+- `fallback_to_manual`
+- `fallback_to_agent`
+- `accept`
+
+## Tiny Model Targets
+
+The tiny model should learn narrow judgments from the case record, not perform
+open-ended planning.
+
+1. Predict `failure_type` from source/hint/output/quality evidence.
+2. Predict a bounded `quality_score` in `[0.0, 1.0]`.
+3. Optionally predict binary accept/reject/uncertain from `quality_score`,
+   confidence, and failure evidence.
+
+Training features should prioritize compact evidence already available in the
+case: requested route, provider/model, tradition, hint count, semantic paths,
+detector choices, bbox hints, layer count, residual percentage, detection
+statuses, per-layer area percentages, alpha metrics, and review labels.
+
+## Tiny Agent Targets
+
+The tiny agent should learn the next action for split repair:
+
+- `rerun_split`: use when the route is plausible but stochastic/provider/model
+  output is weak, debug artifacts exist, and hints do not obviously need edits.
+- `adjust_hints`: use when concepts are missed, residual is high, bbox hints
+  are loose/wrong, thresholds are poor, or detector choice is wrong.
+- `merge_layers`: use when over-split fragments duplicate each other or create
+  more layers than useful editing control.
+- `split_layer_further`: use when a coarse layer contains multiple editable
+  concepts that should be independently addressable.
+- `fallback_to_manual`: use when masks need human-grade precision or repeated
+  exact-mask failures make automatic recovery inefficient.
+- `fallback_to_agent`: use when the plan/hints need semantic reasoning,
+  tradition-aware judgment, or visual inspection beyond deterministic routing.
+
+Action rubric:
+
+| Evidence | Preferred action |
+|---|---|
+| High residual percentage with recognizable missed concepts | `adjust_hints` |
+| `detection_report.missed > 0` or many suspect entities | `adjust_hints` |
+| Many tiny sibling layers with overlapping/duplicated semantics | `merge_layers` |
+| One large subject layer hides expected subparts | `split_layer_further` |
+| Repeated route failure with stable hints | `rerun_split` once, then `fallback_to_agent` |
+| Alpha edges unusable despite correct semantics | `fallback_to_manual` or `fallback_to_agent` |
+| Missing contact sheet/debug evidence for review | `fallback_to_agent` |
+
+## Data Flow
+
+```text
+layers_split / decompose workflow
+  -> source image + requested mode/provider/tradition + target hints
+  -> manifest.json + layer PNGs + residual/composite/debug artifacts
+  -> decompose_cases.build_decompose_case(...)
+  -> optional JSONL append when logging is explicitly enabled
+  -> later review fills human_accept, failure_type, preferred_action
+```
+
+The logger should be observational and best-effort, mirroring the Learning Loop
+v0 principle used for redraw logging. Missing optional artifacts should be
+stored as empty strings or empty arrays. Unknown review labels should use
+`uncertain`, not ad hoc free-form taxonomy values.
+
+## Testing For Future Implementation
+
+Future implementation should add tests for:
+
+- minimal schema construction from an orchestrated manifest and plan
+- path-only artifact recording with no embedded base64
+- residual, manifest, layer assets, detection report, and debug artifacts
+  round-tripping into the case
+- empty optional `composite_path` and debug artifacts represented explicitly
+- rejection of unsupported `failure_type` and `preferred_action`
+- proof that `decompose_case` cannot be written through redraw-case builders
+- logging disabled by default and enabled only through an explicit decompose
+  case log path or decompose-specific environment variable
+
+## Success Criteria
+
+A successful `decompose_case` implementation will let Vulca record one
+decomposition run as training/evaluation evidence for split quality without
+changing split behavior by default. The record must show what existing image was
+split, what hints guided the split, which artifacts were produced, how coverage
+and alpha quality look, what the reviewer accepted or rejected, and what the
+next repair action should be. It must remain separate from redraw and layered
+generation schemas.

--- a/docs/superpowers/specs/2026-05-05-layer-generate-case-design.md
+++ b/docs/superpowers/specs/2026-05-05-layer-generate-case-design.md
@@ -1,0 +1,304 @@
+# Layer Generate Case Design
+
+Date: 2026-05-05
+Status: approved-for-planning
+
+## Purpose
+
+`layer_generate_case` is the Learning Loop sibling schema for runs that start
+from user intent, visual planning artifacts, and prompt stacks, then produce a
+new multi-layer Vulca artifact. The record captures enough evidence for future
+tiny models and tiny agents to learn failure classification, quality scoring,
+generation route recommendation, and next-action policy without changing the
+current runtime.
+
+This design extends the Learning Loop v0 direction documented in
+`docs/superpowers/specs/2026-05-05-vulca-learning-loop-v0-design.md`.
+`src/vulca/layers/redraw_cases.py` is a precedent for versioned case records,
+stable case IDs, enumerable review labels, and JSONL append behavior. It is not
+the implementation template for this schema.
+
+## Sibling Case Boundary
+
+The three case types are separate causal records:
+
+| Case type | Input | Output | Learning question |
+| --- | --- | --- | --- |
+| `redraw_case` | Existing layer or artifact plus edit instruction | Edited layer and pasteback preview | Did an edit improve an existing layer? |
+| `decompose_case` | Existing image | Extracted semantic layers, masks, residuals, and manifest | Did extraction produce useful editable layers? |
+| `layer_generate_case` | Intent, visual plan, layer plan, and prompt stack | Generated layered artifact with manifest, layers, composite, and preview | Did plan-to-layer generation create the intended layered artwork? |
+
+`layer_generate_case` must not reuse `redraw_case` fields named `route`,
+`geometry`, or `refinement`, because those fields describe editing an existing
+layer. It must not embed decomposition extraction provenance such as detector
+choice, segmentation mask confidence, residual extraction status, or source
+image splitting decisions. If a generated layer is later edited, that later
+operation is a separate `redraw_case`. If a generated composite is later split
+from an image, that later operation is a separate `decompose_case`.
+
+## Record Schema
+
+Each record represents one attempt to generate a layered artifact from one
+intent and prompt stack. Generated paths remain local path strings. Image bytes
+are never embedded in the case record.
+
+```json
+{
+  "schema_version": 1,
+  "case_type": "layer_generate_case",
+  "case_id": "layer_generate_20260505T120000Z_...",
+  "created_at": "2026-05-05T12:00:00Z",
+  "inputs": {
+    "user_intent": "Create a layered roadside botanical scene.",
+    "tradition": "ipad_cartoon_showcase",
+    "style_constraints": {
+      "positive": ["clean readable layers", "consistent daylight"],
+      "negative": ["flat single-image output", "merged flower and hedge detail"],
+      "palette": ["blue sky", "green hedge", "white flowers", "yellow flowers"],
+      "composition": ["roadside guardrail above flower bank"],
+      "required_motifs": ["sky", "trees", "vehicles", "guardrail", "flower bank"],
+      "prohibited_motifs": []
+    },
+    "layer_plan": {
+      "source": "visual_plan",
+      "desired_layer_count": 8,
+      "layers": [
+        {
+          "semantic_path": "background.sky",
+          "display_name": "Sky",
+          "role": "background",
+          "z_index": 0,
+          "generation_prompt_ref": "prompts/layers/background.sky.txt",
+          "alpha_strategy": "opaque_full_canvas",
+          "required": true
+        }
+      ]
+    },
+    "prompt_stack": {
+      "system_prompt_path": "prompts/system.txt",
+      "plan_prompt_path": "prompts/plan.txt",
+      "layer_prompt_refs": [
+        {
+          "semantic_path": "background.sky",
+          "prompt_path": "prompts/layers/background.sky.txt",
+          "prompt_text_hash": "sha256:..."
+        }
+      ],
+      "negative_prompt_path": "prompts/negative.txt",
+      "provider_request": {
+        "size": "1024x1024",
+        "quality": "high",
+        "output_format": "png"
+      }
+    },
+    "provider": "openai",
+    "model": "gpt-image-2"
+  },
+  "decisions": {
+    "layer_count": {
+      "planned": 8,
+      "generated": 8,
+      "accepted": 7
+    },
+    "semantic_roles": [
+      {
+        "semantic_path": "background.sky",
+        "role": "background",
+        "required": true
+      }
+    ],
+    "z_index": [
+      {
+        "semantic_path": "background.sky",
+        "z_index": 0,
+        "reason": "sky is the farthest full-canvas background"
+      }
+    ],
+    "mask_alpha_strategy": {
+      "canvas_mode": "full_canvas_rgba_layers",
+      "composite_blend_order": "ascending_z_index",
+      "per_layer": [
+        {
+          "semantic_path": "background.sky",
+          "alpha_strategy": "opaque_full_canvas",
+          "mask_source": "none"
+        }
+      ]
+    },
+    "fallback_decisions": [
+      {
+        "stage": "layer_generation",
+        "affected_layers": ["foreground.flowers"],
+        "reason": "provider returned merged hedge and flowers",
+        "chosen_action": "split_layer"
+      }
+    ]
+  },
+  "outputs": {
+    "artifact_dir": "runs/layered/roadside_001",
+    "layer_manifest_path": "runs/layered/roadside_001/manifest.json",
+    "layers": [
+      {
+        "semantic_path": "background.sky",
+        "asset_path": "runs/layered/roadside_001/background.sky.png",
+        "mask_path": "",
+        "alpha_path": "",
+        "visible": true,
+        "locked": false,
+        "status": "generated"
+      }
+    ],
+    "composite_path": "runs/layered/roadside_001/composite.png",
+    "preview_path": "runs/layered/roadside_001/preview.png"
+  },
+  "learning_targets": {
+    "tiny_model": {
+      "failure_classification": "",
+      "quality_score": null,
+      "route_recommendation": ""
+    },
+    "tiny_agent": {
+      "next_action_policy": ""
+    }
+  },
+  "review": {
+    "human_accept": null,
+    "failure_type": "",
+    "preferred_action": "",
+    "reviewer": "",
+    "reviewed_at": ""
+  }
+}
+```
+
+## Field Semantics
+
+- `inputs.user_intent` is the user-facing goal before system decomposition into
+  layers.
+- `inputs.tradition` records the visual tradition, style family, or workflow
+  tradition used by Vulca planning.
+- `inputs.style_constraints` records positive and negative constraints that
+  affect prompt construction.
+- `inputs.layer_plan` records planned semantic layers before provider calls.
+  `desired_layer_count` is the intended count, not the generated count.
+- `inputs.prompt_stack` records prompt paths and text hashes. The case stores
+  hashes and paths so training data can join to prompt text when the artifact
+  bundle is available.
+- `decisions.layer_count.generated` counts layers written by the generation
+  run. `decisions.layer_count.accepted` counts layers accepted by automated or
+  human review.
+- `decisions.semantic_roles` records layer roles after planning, including
+  required status.
+- `decisions.z_index` records ordering decisions with concise reasons.
+- `decisions.mask_alpha_strategy` records how transparent layers, full-canvas
+  layers, blend order, alpha channels, and generated masks were handled.
+- `decisions.fallback_decisions` records generation-time fallbacks such as
+  `adjust_prompt`, `split_layer`, `merge_layers`, or `fallback_to_agent`.
+- `outputs.layer_manifest_path` points to the Vulca manifest for the generated
+  layered artifact.
+- `outputs.layers[].asset_path` points to the generated layer asset for one
+  semantic path.
+- `outputs.composite_path` points to the generated full composite.
+- `outputs.preview_path` points to the review-sized preview for humans or
+  training review tooling.
+
+## Review Labels
+
+The review object is the authoritative human label surface:
+
+- `human_accept`: `true`, `false`, or `null` when unlabeled.
+- `failure_type`: empty string when unlabeled, otherwise one value from the
+  generation failure taxonomy.
+- `preferred_action`: empty string when unlabeled, otherwise one value from the
+  generation action taxonomy.
+- `reviewer`: stable reviewer identifier or empty string.
+- `reviewed_at`: UTC timestamp or empty string.
+
+`learning_targets.tiny_model` and `learning_targets.tiny_agent` are derived
+training views over the same review evidence. They are included so dataset
+builders can read target labels without inferring task intent from free-form
+review fields.
+
+## Failure And Action Taxonomy
+
+Generation-specific `failure_type` values:
+
+- `layer_mismatch`: generated layers do not match the requested layer plan.
+- `missing_layer`: a required planned layer is absent.
+- `wrong_semantic_role`: a layer exists but represents the wrong role.
+- `z_order_error`: the manifest order or composite order is wrong.
+- `style_drift`: output violates tradition or style constraints.
+- `prompt_conflict`: prompts create contradictory layer instructions.
+- `alpha_failure`: transparent/opaque boundaries make the layer unusable.
+- `composite_mismatch`: individual layers are acceptable but composite quality
+  is poor.
+- `provider_failure`: provider failed, returned invalid assets, or returned
+  incomplete assets.
+- `uncertain`: reviewer cannot assign a more specific label.
+
+Generation-specific `preferred_action` values:
+
+- `accept`
+- `rerun_layer`
+- `adjust_prompt`
+- `merge_layers`
+- `split_layer`
+- `adjust_alpha_strategy`
+- `fallback_to_agent`
+- `manual_review`
+
+Redraw-only labels such as `pasteback_mismatch`, `mask_too_broad`, and
+`large_white_component` are excluded from `layer_generate_case`. A future schema
+revision must define an explicit mapping before any redraw-only label enters
+the generation taxonomy.
+
+## Learning Targets
+
+Tiny model targets:
+
+- `failure_classification`: predict the generation failure taxonomy value from
+  inputs, decisions, and output summaries.
+- `quality_score`: predict a scalar quality score for the generated layered
+  artifact using review and acceptance data.
+- `route_recommendation`: recommend a generation workflow route, such as direct
+  generation, prompt adjustment, per-layer rerun, merge/split repair, alpha
+  repair, or fallback to a larger agent.
+
+Tiny agent target:
+
+- `next_action_policy`: choose one action from the generation action taxonomy
+  after seeing the case inputs, decisions, outputs, and validator summaries.
+
+The large agent remains the teacher and reviewer for open-ended diagnosis. The
+case record supplies compact evidence for narrow learners and small routing
+policies.
+
+## Data Rules
+
+- `schema_version` is numeric `1`.
+- `case_type` is exactly `layer_generate_case`.
+- `case_id` starts with `layer_generate_` and uses a timestamp plus short hash
+  over user intent, tradition, layer plan, prompt stack, provider, model, and
+  manifest path.
+- Paths are local strings. Base64 image data is not stored.
+- Empty strings represent missing optional paths or unlabeled enum fields.
+- `null` is used only for tri-state labels and numeric labels that are not
+  reviewed yet.
+- One record describes one generated layered artifact attempt. Repair attempts
+  are separate cases or separate `redraw_case` records, depending on causal
+  direction.
+
+## Non-Goals
+
+- This design does not implement `layer_generate_case` logging.
+- This design does not modify `redraw_case`, `decompose_case`, provider code,
+  CLI commands, MCP tools, or runtime generation behavior.
+- This design does not add model training, review UI, JSON schema validators,
+  benchmark manifests, or new dependencies.
+
+## Success Criteria
+
+The design is complete when an implementer can create a future
+`layer_generate_case` builder without deciding the causal boundary, core record
+shape, input/output fields, intermediate decision fields, review labels, tiny
+model targets, tiny agent targets, or first failure/action taxonomy.

--- a/docs/superpowers/specs/2026-05-05-tiny-router-baseline-design.md
+++ b/docs/superpowers/specs/2026-05-05-tiny-router-baseline-design.md
@@ -1,0 +1,213 @@
+# Tiny Router Baseline Design
+
+Date: 2026-05-05
+Status: approved-for-spec
+
+## Purpose
+
+Tiny router baseline v0 defines a deterministic, provider-free policy for
+answering one question from existing and future redraw case records:
+
+```json
+{
+  "recommended_action": "adjust_mask"
+}
+```
+
+This baseline is not a model and not a runtime agent. It is an evaluation
+control group for future tiny models and tiny agents. It should make current
+case records immediately useful for benchmark scoring without calling image
+providers, training models, generating images, or changing redraw execution.
+
+## Inputs And Output
+
+The input is a `redraw_case` record from Learning Loop v0, plus the advisory
+and review fields already embedded in that record:
+
+- case context: `schema_version`, `case_type`, `case_id`, `layer`,
+  `instruction`, `provider`, `model`, `artifacts`
+- route/advisory signals: `route.requested`, `route.chosen`,
+  `route.redraw_route`, `route.geometry_redraw_route`
+- geometry signals: `geometry.area_pct`, `geometry.bbox_fill`,
+  `geometry.component_count`, `geometry.sparse_detected`
+- quality signals: `quality.gate_passed`, `quality.failures`,
+  `quality.metrics`
+- refinement signals: `refinement.applied`, `refinement.reason`,
+  `refinement.strategy`, `refinement.child_count`,
+  `refinement.mask_granularity_score`
+- human review labels: `review.human_accept`, `review.failure_type`,
+  `review.preferred_action`
+
+The required prediction output is:
+
+```json
+{
+  "recommended_action": "accept"
+}
+```
+
+`recommended_action` must use the existing `preferred_actions` vocabulary from
+`docs/benchmarks/redraw/failure_taxonomy.json`:
+
+- `accept`
+- `rerun`
+- `fallback_to_agent`
+- `fallback_to_original`
+- `manual_review`
+- `adjust_route`
+- `adjust_mask`
+- `adjust_instruction`
+
+Future evaluators may add non-label diagnostics such as `policy_name`,
+`failure_hint`, `accept_prediction`, and `rule_reason`, but the benchmarked
+action field is `recommended_action`.
+
+## Baseline Policies
+
+Tiny router v0 has two explicit rule policies. They answer different benchmark
+questions and must not be mixed in aggregate reports.
+
+### `label_oracle`
+
+`label_oracle` is an offline upper-bound policy. It may read
+`review.human_accept`, `review.failure_type`, and `review.preferred_action`.
+It is useful for validating the action vocabulary and measuring how much of the
+benchmark can be solved once the failure label is known.
+
+Precedence:
+
+1. If `review.human_accept` is `true`, recommend `accept`.
+2. If `review.preferred_action` is non-empty, recommend that action.
+3. Otherwise map `review.failure_type` to an action.
+4. If no review label is present, recommend `manual_review`.
+
+Required v0 mappings:
+
+| Failure type | `recommended_action` |
+| --- | --- |
+| `mask_too_broad` | `adjust_mask` |
+| `route_error` | `adjust_route` |
+| `pasteback_mismatch` | `manual_review` |
+| `over_split` | `fallback_to_original` |
+| `under_split` | `fallback_to_agent` |
+
+Default failure mappings:
+
+| Failure type | `recommended_action` |
+| --- | --- |
+| `alpha_expansion` | `adjust_mask` |
+| `background_bleed` | `adjust_mask` |
+| `large_white_component` | `adjust_mask` |
+| `wrong_subject` | `adjust_instruction` |
+| `missing_detail` | `adjust_instruction` |
+| `color_drift` | `rerun` |
+| `shape_collapse` | `rerun` |
+| `over_smoothing` | `rerun` |
+| `texture_leak` | `rerun` |
+| `uncertain` | `manual_review` |
+
+### `observable_signal`
+
+`observable_signal` is the deployable-style baseline. It must never read
+`review.*`. It uses only the case record, route/advisory, geometry, quality,
+refinement, artifact, and pasteback/review-state signals that would be
+available before a human label exists.
+
+Precedence:
+
+1. If a source pasteback error exists, or pasteback is expected but missing,
+   recommend `manual_review`.
+2. If route fields disagree in a way that indicates the requested or chosen
+   route did not match geometry, recommend `adjust_route`.
+3. If quality failures or metrics show broad, expanded, or bleeding alpha,
+   recommend `adjust_mask`.
+4. If target-aware refinement was expected but not applied, or child count is
+   zero for a broad small-target mask, recommend `adjust_mask`.
+5. If `quality.gate_passed` is `true` and `artifacts.source_pasteback_path` is
+   present, recommend `accept`.
+6. If `quality.gate_passed` is `false` but there is no clear mask or route
+   cause, recommend `rerun`.
+7. If quality is missing or signals are inconclusive, recommend
+   `manual_review`.
+
+Signal aliases should normalize implementation-level quality names into the
+taxonomy before routing:
+
+| Observable signal | Failure hint | `recommended_action` |
+| --- | --- | --- |
+| `mask_too_broad_for_target` | `mask_too_broad` | `adjust_mask` |
+| `alpha_bbox_expanded` | `alpha_expansion` | `adjust_mask` |
+| `background_bleed` | `background_bleed` | `adjust_mask` |
+| `large_white_component` | `large_white_component` | `adjust_mask` |
+| route/requested/chosen mismatch | `route_error` | `adjust_route` |
+| missing or failed pasteback preview | `pasteback_mismatch` | `manual_review` |
+
+The signal baseline is intentionally conservative. It should prefer
+`manual_review` over pretending that weak evidence is a confident accept.
+
+## Tiny Model And Tiny Agent Boundary
+
+Tiny models will learn narrow judgments from case records and labels:
+
+- classify failure
+- predict accept/reject
+- recommend next action
+
+Tiny agents will make sequential tool decisions after those judgments exist:
+
+- choose the tool/action sequence
+- decide whether to rerun, adjust prompt, adjust mask, split, merge, fallback,
+  or escalate
+- stop before provider calls unless the caller explicitly runs an execution
+  workflow
+
+The baseline does not perform agent planning. It emits one recommended next
+action so future tiny models and agents have a stable rule-based comparison.
+
+## Benchmark And Eval Plan
+
+Primary data sources:
+
+- JSONL files containing `redraw_case` records from Learning Loop v0.
+- `docs/benchmarks/redraw/seed_manifest.json` for small seeded cases and
+  taxonomy coverage.
+- `docs/benchmarks/redraw/failure_taxonomy.json` as the authoritative enum
+  source for allowed failures and actions.
+
+Evaluation splits:
+
+- Seed manifest sanity set: small, hand-readable, used for contract tests.
+- Reviewed case set: records with `review.human_accept`,
+  `review.failure_type`, or `review.preferred_action`.
+- Unreviewed case set: records without labels, used only for coverage and
+  routing distribution checks.
+
+Required metrics:
+
+- action accuracy against `review.preferred_action` when present
+- accept/reject accuracy against `review.human_accept` when present
+- failure classification accuracy and macro F1 when a policy emits
+  `failure_hint`
+- confusion matrix by failure type and recommended action
+- policy coverage: fraction of cases with a non-empty `recommended_action`
+- `manual_review` rate and escalation rate
+- leakage check: `observable_signal` evaluation must fail if any `review.*`
+  field is accessed
+
+Provider and training constraints:
+
+- Do not call image providers.
+- Do not generate images.
+- Do not train models.
+- Do not add CLIP, DINO, VLM, LightGBM, or other ML dependencies for this
+  baseline.
+- Do not change redraw, decomposition, layered generation, CLI, or MCP runtime
+  behavior.
+
+## Success Criteria
+
+A successful v0 baseline spec lets a future implementation score deterministic
+router policies against existing `redraw_case` JSONL records, compare those
+policies with future tiny models, and keep oracle-label evaluation separate
+from deployable signal-only evaluation. The first implementation should be a
+small offline benchmark harness, not a provider-facing runtime change.

--- a/docs/superpowers/specs/2026-05-05-vulca-learning-loop-v0-design.md
+++ b/docs/superpowers/specs/2026-05-05-vulca-learning-loop-v0-design.md
@@ -1,0 +1,188 @@
+# Vulca Learning Loop v0 Design
+
+Date: 2026-05-05
+Status: approved-for-planning
+
+## Purpose
+
+Vulca is already evolving along several parallel workstreams: redraw hardening, decomposition/layer quality, provider SDK/MCP surfaces, and future specialist models. These should not be collapsed into one implementation branch or one model project. Learning Loop v0 creates a thin data layer underneath those workstreams so each redraw or layer-edit experiment can become training and evaluation evidence.
+
+The first milestone is not model training. It is a stable `redraw_case` record, optional case logging, and a small benchmark seed set. This gives future tiny models and tiny agents a factual substrate without changing existing runtime behavior.
+
+## Positioning
+
+The system should be layered by responsibility and by maturity:
+
+- Level 0: deterministic validators and contracts
+- Level 1: tool execution and artifact generation
+- Level 2: case logging and benchmark data
+- Level 3: tiny specialist models for narrow judgments
+- Level 4: tiny agents/state machines for routing and retries
+- Level 5: large agent/VLM teacher for open-ended planning, labeling, and failure review
+
+Current redraw and decomposition branches can continue independently at Levels 0-1. Learning Loop v0 sits at Level 2 and observes their output. It must not block or rewrite those branches.
+
+## Scope
+
+Learning Loop v0 adds:
+
+- A versioned `redraw_case` JSON schema.
+- A focused `src/vulca/layers/redraw_cases.py` module for case construction and JSONL append.
+- Optional case logging from `layers_redraw`, disabled by default.
+- CLI/MCP visibility for `case_id` and `case_log_path` when logging is enabled.
+- A documented failure taxonomy and a small benchmark seed manifest.
+
+Learning Loop v0 does not add:
+
+- model training
+- CLIP, DINO, SmolVLM, LightGBM, or other ML dependencies
+- a UI review queue
+- a rewrite of `redraw.py`
+- agent calls in the redraw runtime loop
+- changes to decomposition execution logic
+
+## Redraw Case Record
+
+Each record should be self-contained enough to train or evaluate `Vulca-FD v0` later:
+
+```json
+{
+  "schema_version": 1,
+  "case_id": "redraw_...",
+  "created_at": "2026-05-05T00:00:00Z",
+  "artwork_dir": "...",
+  "source_image": "...",
+  "layer": {
+    "id": "...",
+    "name": "...",
+    "description": "...",
+    "semantic_path": "...",
+    "quality_status": "...",
+    "area_pct_manifest": 0.0
+  },
+  "instruction": "...",
+  "provider": "openai",
+  "model": "gpt-image-2",
+  "route": {
+    "requested": "auto",
+    "chosen": "inpaint",
+    "redraw_route": "sparse_bbox_crop",
+    "geometry_redraw_route": "sparse_bbox_crop"
+  },
+  "geometry": {
+    "area_pct": 0.0,
+    "bbox_fill": 0.0,
+    "component_count": 1,
+    "sparse_detected": true
+  },
+  "quality": {
+    "gate_passed": true,
+    "failures": [],
+    "metrics": {}
+  },
+  "refinement": {
+    "applied": false,
+    "reason": "no_target_profile",
+    "strategy": "none",
+    "child_count": 0,
+    "mask_granularity_score": 0.0
+  },
+  "artifacts": {
+    "source_layer_path": "...",
+    "redrawn_layer_path": "...",
+    "source_pasteback_path": "...",
+    "debug_summary_path": ""
+  },
+  "review": {
+    "human_accept": null,
+    "failure_type": "",
+    "preferred_action": "",
+    "reviewer": "",
+    "reviewed_at": ""
+  }
+}
+```
+
+Paths should remain local path strings, not embedded base64. A stable `case_id` can be derived from timestamp plus a short hash over source path, layer name, instruction, provider, model, and output path.
+
+## Failure Taxonomy
+
+The first taxonomy should stay small and redraw-focused:
+
+- `color_drift`
+- `shape_collapse`
+- `wrong_subject`
+- `missing_detail`
+- `over_smoothing`
+- `texture_leak`
+- `alpha_expansion`
+- `mask_too_broad`
+- `background_bleed`
+- `large_white_component`
+- `pasteback_mismatch`
+- `route_error`
+- `over_split`
+- `under_split`
+- `uncertain`
+
+The taxonomy is allowed to grow, but only through explicit schema updates. Free-form notes can be added later, but the model label should stay enumerable.
+
+## Data Flow
+
+```text
+layers_redraw
+  -> redraw result + redraw_advisory + source pasteback preview
+  -> redraw_cases.build_redraw_case(...)
+  -> optional append_jsonl(...)
+  -> MCP/CLI returns case_id and case_log_path when enabled
+```
+
+The logger should be best-effort but not silent. If logging is explicitly enabled and writing fails, the caller should receive `case_log_error` in the result payload while the redraw result remains usable.
+
+## Branch And Workstream Boundaries
+
+Parallel redraw optimization branches should continue to modify route selection, mask refinement, quality gates, and provider behavior. Parallel decomposition branches should continue to improve semantic paths, bbox hints, masks, residuals, and manifest quality.
+
+Learning Loop v0 should avoid direct conflict with those branches by using a new module and reading existing outputs instead of moving logic. Its integration points should be narrow:
+
+- read `LayerInfo` and manifest metadata
+- read `redraw_advisory`
+- read MCP pasteback result fields
+- append JSONL only when enabled
+
+This makes the logger a shared observation layer across experiments rather than another competing redraw implementation.
+
+## Tiny Model And Tiny Agent Roadmap
+
+After enough cases exist, the next stages are:
+
+1. `Vulca-FD v0`: predict `accept/reject/uncertain` and `failure_type`.
+2. `Vulca-Route v0`: predict route or fallback action from geometry, instruction, and prior failures.
+3. `Vulca-Ranker v0`: rank multiple redraw candidates.
+4. Tiny agent/state machine: use model confidence plus validators to decide `accept`, `rerun`, `fallback_to_agent`, or `fallback_to_original`.
+
+The large agent remains the teacher and reviewer. It should not be placed in the high-frequency redraw runtime loop.
+
+## Error Handling
+
+- Logging disabled: no behavior change and no new output fields.
+- Logging enabled and succeeds: return `case_id` and `case_log_path`.
+- Logging enabled and fails: return `case_log_error`; do not fail the redraw.
+- Missing optional artifacts: record empty strings, not guessed paths.
+- Unknown failure type during manual review: use `uncertain`.
+
+## Testing
+
+Tests should cover:
+
+- schema construction from a minimal redraw payload
+- JSONL append creates one valid line
+- logging is disabled by default
+- logging failure does not fail redraw
+- MCP response includes `case_id` and `case_log_path` only when enabled
+- quality failures and route advisory fields round-trip into the case record
+- taxonomy rejects unsupported failure types in benchmark manifests
+
+## Success Criteria
+
+A successful implementation lets a caller run one redraw and, when logging is enabled, receive a valid JSONL case containing the source layer, redrawn output, pasteback preview, route geometry, quality gate state, provider/model metadata, and empty review labels. Existing redraw, decomposition, and provider behavior remain unchanged by default.

--- a/docs/superpowers/specs/2026-05-05-vulca-learning-loop-v0-design.md
+++ b/docs/superpowers/specs/2026-05-05-vulca-learning-loop-v0-design.md
@@ -5,7 +5,7 @@ Status: approved-for-planning
 
 ## Purpose
 
-Vulca is already evolving along several parallel workstreams: redraw hardening, decomposition/layer quality, provider SDK/MCP surfaces, and future specialist models. These should not be collapsed into one implementation branch or one model project. Learning Loop v0 creates a thin data layer underneath those workstreams so each redraw or layer-edit experiment can become training and evaluation evidence.
+Vulca is already evolving along several parallel workstreams: redraw hardening, decomposition/layer quality, layered generation quality, provider SDK/MCP surfaces, and future specialist models. These should not be collapsed into one implementation branch or one model project. Learning Loop v0 creates a thin data layer underneath those workstreams so each redraw or layer-edit experiment can become training and evaluation evidence.
 
 The first milestone is not model training. It is a stable `redraw_case` record, optional case logging, and a small benchmark seed set. This gives future tiny models and tiny agents a factual substrate without changing existing runtime behavior.
 
@@ -20,7 +20,9 @@ The system should be layered by responsibility and by maturity:
 - Level 4: tiny agents/state machines for routing and retries
 - Level 5: large agent/VLM teacher for open-ended planning, labeling, and failure review
 
-Current redraw and decomposition branches can continue independently at Levels 0-1. Learning Loop v0 sits at Level 2 and observes their output. It must not block or rewrite those branches.
+Current redraw, decomposition, and layered-generation branches can continue independently at Levels 0-1. Learning Loop v0 sits at Level 2 and observes their output. It must not block or rewrite those branches.
+
+Decomposition and layered generation are separate workstreams. Decomposition starts from an existing image and splits it into semantic layers, masks, residuals, and manifest records. Layered generation starts from an intent or plan and creates multiple coordinated layers as the output. They share artifact vocabulary, but the causal direction is different. Learning Loop v0 should not blur those two tasks or use one schema for both.
 
 ## Scope
 
@@ -40,6 +42,7 @@ Learning Loop v0 does not add:
 - a rewrite of `redraw.py`
 - agent calls in the redraw runtime loop
 - changes to decomposition execution logic
+- changes to layered generation execution logic
 
 ## Redraw Case Record
 
@@ -141,7 +144,7 @@ The logger should be best-effort but not silent. If logging is explicitly enable
 
 ## Branch And Workstream Boundaries
 
-Parallel redraw optimization branches should continue to modify route selection, mask refinement, quality gates, and provider behavior. Parallel decomposition branches should continue to improve semantic paths, bbox hints, masks, residuals, and manifest quality.
+Parallel redraw optimization branches should continue to modify route selection, mask refinement, quality gates, and provider behavior. Parallel decomposition branches should continue to improve semantic paths, bbox hints, masks, residuals, and manifest quality. Parallel layered-generation branches should continue to improve plan-to-layer generation, layer coordination, per-layer prompts, composites, and generation manifests.
 
 Learning Loop v0 should avoid direct conflict with those branches by using a new module and reading existing outputs instead of moving logic. Its integration points should be narrow:
 
@@ -151,6 +154,14 @@ Learning Loop v0 should avoid direct conflict with those branches by using a new
 - append JSONL only when enabled
 
 This makes the logger a shared observation layer across experiments rather than another competing redraw implementation.
+
+Future case types should be separate records, not overloads of `redraw_case`:
+
+- `decompose_case`: existing image -> semantic layer split
+- `layer_generate_case`: plan/intent -> generated layered artifact
+- `redraw_case`: existing layer/artifact -> edited layer and pasteback preview
+
+Learning Loop v0 implements only `redraw_case`, but the module and docs should leave room for sibling case schemas later.
 
 ## Tiny Model And Tiny Agent Roadmap
 

--- a/scripts/redraw_router_baseline_eval.py
+++ b/scripts/redraw_router_baseline_eval.py
@@ -1,0 +1,43 @@
+"""Offline benchmark entrypoint for redraw tiny-router baselines."""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from typing import Sequence
+
+from vulca.layers.redraw_router_baseline import (
+    POLICIES,
+    evaluate_records,
+    load_jsonl_many,
+)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Score provider-free redraw router baseline policies on JSONL case records."
+    )
+    parser.add_argument("case_logs", nargs="+", help="Path(s) to redraw_case JSONL logs.")
+    parser.add_argument(
+        "--policy",
+        default="observable_signal",
+        choices=sorted(POLICIES),
+        help="Baseline policy to evaluate.",
+    )
+    parser.add_argument(
+        "--pretty",
+        action="store_true",
+        help="Pretty-print JSON output.",
+    )
+    args = parser.parse_args(argv)
+
+    records = load_jsonl_many(args.case_logs)
+    report = evaluate_records(records, policy_name=args.policy)
+    indent = 2 if args.pretty else None
+    sys.stdout.write(json.dumps(report, sort_keys=True, indent=indent))
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/vulca/cli.py
+++ b/src/vulca/cli.py
@@ -195,6 +195,14 @@ def main(argv: list[str] | None = None) -> None:
     layers_redraw.add_argument("--tradition", "-t", default="default", help="Cultural tradition")
     layers_redraw.add_argument("--re-split", action="store_true",
                                help="After merge+redraw, re-analyze and split back")
+    layers_redraw.add_argument(
+        "--case-log",
+        default="",
+        help=(
+            "Append a Learning Loop v0 redraw case JSONL record to this path. "
+            "If omitted, VULCA_REDRAW_CASE_LOG can enable logging."
+        ),
+    )
 
     layers_composite = layers_sub.add_parser("composite", help="Composite layers into flat image")
     layers_composite.add_argument("artwork_dir", help="Directory with layer PNGs + manifest")
@@ -1324,12 +1332,49 @@ def _cmd_layers(args: argparse.Namespace) -> None:
             else:
                 print(f"  Merged redraw: {result.info.name} -> {result.image_path}")
         elif args.layer:
+            source_layer = next(
+                (lr for lr in artwork.layers if lr.info.name == args.layer),
+                None,
+            )
             result = loop.run_until_complete(
                 redraw_layer(artwork, layer_name=args.layer,
                              instruction=args.instruction, provider=args.provider,
                              tradition=args.tradition, artwork_dir=args.artwork_dir)
             )
             print(f"  Redrawn: {result.info.name} -> {result.image_path}")
+            from vulca.layers.redraw_cases import (
+                append_redraw_case,
+                build_redraw_case,
+                resolve_case_log_path,
+            )
+            resolved_case_log_path = resolve_case_log_path(
+                getattr(args, "case_log", ""),
+                args.artwork_dir,
+            )
+            if resolved_case_log_path:
+                try:
+                    if source_layer is None:
+                        raise ValueError(f"layer {args.layer!r} not found in artwork")
+                    advisory = getattr(result, "redraw_advisory", {}) or {}
+                    record = build_redraw_case(
+                        artwork_dir=args.artwork_dir,
+                        source_image=artwork.source_image,
+                        layer_info=source_layer.info,
+                        instruction=args.instruction,
+                        provider=args.provider,
+                        model="",
+                        route_requested=str(advisory.get("route_requested", "")),
+                        source_layer_path=source_layer.image_path,
+                        redrawn_layer_path=result.image_path,
+                        redraw_advisory=advisory,
+                    )
+                    written_case_log_path = append_redraw_case(
+                        resolved_case_log_path,
+                        record,
+                    )
+                    print(f"Case log: {record['case_id']} -> {written_case_log_path}")
+                except Exception as exc:
+                    print(f"Case log error: {exc}", file=sys.stderr)
         else:
             print("  Error: specify --layer or --layers with --merge", file=sys.stderr)
             sys.exit(1)

--- a/src/vulca/cli.py
+++ b/src/vulca/cli.py
@@ -1372,9 +1372,9 @@ def _cmd_layers(args: argparse.Namespace) -> None:
                         resolved_case_log_path,
                         record,
                     )
-                    print(f"Case log: {record['case_id']} -> {written_case_log_path}")
+                    print(f"  Case log: {record['case_id']} -> {written_case_log_path}")
                 except Exception as exc:
-                    print(f"Case log error: {exc}", file=sys.stderr)
+                    print(f"  Case log error: {exc}", file=sys.stderr)
         else:
             print("  Error: specify --layer or --layers with --merge", file=sys.stderr)
             sys.exit(1)

--- a/src/vulca/layers/redraw_cases.py
+++ b/src/vulca/layers/redraw_cases.py
@@ -1,0 +1,221 @@
+"""Versioned case records for redraw learning loops."""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping
+
+from vulca.layers.types import LayerInfo
+
+CASE_SCHEMA_VERSION = 1
+CASE_TYPE = "redraw_case"
+
+FAILURE_TYPES: frozenset[str] = frozenset(
+    {
+        "color_drift",
+        "shape_collapse",
+        "wrong_subject",
+        "missing_detail",
+        "over_smoothing",
+        "texture_leak",
+        "alpha_expansion",
+        "mask_too_broad",
+        "background_bleed",
+        "large_white_component",
+        "pasteback_mismatch",
+        "route_error",
+        "over_split",
+        "under_split",
+        "uncertain",
+    }
+)
+
+PREFERRED_ACTIONS: frozenset[str] = frozenset(
+    {
+        "",
+        "accept",
+        "rerun",
+        "fallback_to_agent",
+        "fallback_to_original",
+        "manual_review",
+        "adjust_route",
+        "adjust_mask",
+        "adjust_instruction",
+    }
+)
+
+
+def utc_now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def validate_failure_type(value: str) -> str:
+    if value == "":
+        return ""
+    if value not in FAILURE_TYPES:
+        raise ValueError(
+            f"unsupported redraw failure_type {value!r}; expected one of {sorted(FAILURE_TYPES)}"
+        )
+    return value
+
+
+def validate_preferred_action(value: str) -> str:
+    if value not in PREFERRED_ACTIONS:
+        raise ValueError(
+            f"unsupported redraw preferred_action {value!r}; expected one of {sorted(PREFERRED_ACTIONS)}"
+        )
+    return value
+
+
+def resolve_case_log_path(case_log_path: str, artwork_dir: str) -> str:
+    if case_log_path:
+        return str(Path(case_log_path))
+    env_value = os.environ.get("VULCA_REDRAW_CASE_LOG", "").strip()
+    if not env_value:
+        return ""
+    if env_value.lower() in {"1", "true", "yes", "on"}:
+        return str(Path(artwork_dir) / "redraw_cases.jsonl")
+    return str(Path(env_value))
+
+
+def build_redraw_case(
+    *,
+    artwork_dir: str,
+    source_image: str,
+    layer_info: LayerInfo,
+    instruction: str,
+    provider: str,
+    model: str,
+    route_requested: str,
+    source_layer_path: str,
+    redrawn_layer_path: str,
+    source_pasteback_path: str = "",
+    redraw_advisory: Mapping[str, Any] | None = None,
+    debug_summary_path: str = "",
+    created_at: str | None = None,
+    human_accept: bool | None = None,
+    failure_type: str = "",
+    preferred_action: str = "",
+    reviewer: str = "",
+    reviewed_at: str = "",
+) -> dict[str, Any]:
+    advisory = dict(redraw_advisory or {})
+    created = created_at or utc_now_iso()
+    checked_failure_type = validate_failure_type(failure_type)
+    checked_action = validate_preferred_action(preferred_action)
+    case_id = _make_case_id(
+        created_at=created,
+        source_layer_path=source_layer_path,
+        redrawn_layer_path=redrawn_layer_path,
+        instruction=instruction,
+        provider=provider,
+        model=model,
+    )
+
+    return {
+        "schema_version": CASE_SCHEMA_VERSION,
+        "case_type": CASE_TYPE,
+        "case_id": case_id,
+        "created_at": created,
+        "artwork_dir": str(artwork_dir),
+        "source_image": str(source_image or ""),
+        "layer": {
+            "id": str(layer_info.id),
+            "name": str(layer_info.name),
+            "description": str(layer_info.description),
+            "semantic_path": str(layer_info.semantic_path or ""),
+            "quality_status": str(layer_info.quality_status or ""),
+            "area_pct_manifest": float(layer_info.area_pct or 0.0),
+        },
+        "instruction": str(instruction),
+        "provider": str(provider),
+        "model": str(model or advisory.get("model", "")),
+        "route": {
+            "requested": str(route_requested or advisory.get("route_requested", "")),
+            "chosen": str(advisory.get("route_chosen", "")),
+            "redraw_route": str(advisory.get("redraw_route", "")),
+            "geometry_redraw_route": str(advisory.get("geometry_redraw_route", "")),
+        },
+        "geometry": {
+            "area_pct": float(advisory.get("area_pct", 0.0) or 0.0),
+            "bbox_fill": float(advisory.get("bbox_fill", 0.0) or 0.0),
+            "component_count": int(advisory.get("component_count", 0) or 0),
+            "sparse_detected": bool(advisory.get("sparse_detected", False)),
+        },
+        "quality": {
+            "gate_passed": _optional_bool(advisory.get("quality_gate_passed")),
+            "failures": [str(item) for item in advisory.get("quality_failures", [])],
+            "metrics": dict(advisory.get("quality_metrics", {}) or {}),
+        },
+        "refinement": {
+            "applied": bool(advisory.get("refinement_applied", False)),
+            "reason": str(advisory.get("refinement_reason", "")),
+            "strategy": str(advisory.get("refinement_strategy", "")),
+            "child_count": int(advisory.get("refined_child_count", 0) or 0),
+            "mask_granularity_score": float(
+                advisory.get("mask_granularity_score", 0.0) or 0.0
+            ),
+        },
+        "artifacts": {
+            "source_layer_path": str(source_layer_path or ""),
+            "redrawn_layer_path": str(redrawn_layer_path or ""),
+            "source_pasteback_path": str(source_pasteback_path or ""),
+            "debug_summary_path": str(debug_summary_path or ""),
+        },
+        "review": {
+            "human_accept": human_accept,
+            "failure_type": checked_failure_type,
+            "preferred_action": checked_action,
+            "reviewer": str(reviewer or ""),
+            "reviewed_at": str(reviewed_at or ""),
+        },
+    }
+
+
+def append_redraw_case(case_log_path: str, record: Mapping[str, Any]) -> str:
+    if not case_log_path:
+        raise ValueError("case_log_path is required when appending a redraw case")
+    path = Path(case_log_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(dict(record), sort_keys=True, separators=(",", ":")))
+        fh.write("\n")
+    return str(path)
+
+
+def _optional_bool(value: Any) -> bool | None:
+    if isinstance(value, bool):
+        return value
+    return None
+
+
+def _make_case_id(
+    *,
+    created_at: str,
+    source_layer_path: str,
+    redrawn_layer_path: str,
+    instruction: str,
+    provider: str,
+    model: str,
+) -> str:
+    stamp = (
+        created_at.replace("-", "")
+        .replace(":", "")
+        .replace(".", "")
+        .replace("+", "")
+    )
+    seed = "\n".join(
+        [
+            created_at,
+            source_layer_path,
+            redrawn_layer_path,
+            instruction,
+            provider,
+            model,
+        ]
+    )
+    digest = hashlib.sha256(seed.encode("utf-8")).hexdigest()[:12]
+    return f"redraw_{stamp}_{digest}"

--- a/src/vulca/layers/redraw_router_baseline.py
+++ b/src/vulca/layers/redraw_router_baseline.py
@@ -1,0 +1,445 @@
+"""Rule-based tiny router baselines for redraw case records."""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable, Mapping, Sequence
+
+from vulca.layers.redraw_cases import FAILURE_TYPES, PREFERRED_ACTIONS
+
+POLICY_LABEL_ORACLE = "label_oracle"
+POLICY_OBSERVABLE_SIGNAL = "observable_signal"
+POLICIES: frozenset[str] = frozenset({POLICY_LABEL_ORACLE, POLICY_OBSERVABLE_SIGNAL})
+
+ESCALATION_ACTIONS: frozenset[str] = frozenset(
+    {"manual_review", "fallback_to_agent", "fallback_to_original"}
+)
+
+LABEL_ORACLE_FAILURE_ACTIONS: dict[str, str] = {
+    "mask_too_broad": "adjust_mask",
+    "route_error": "adjust_route",
+    "pasteback_mismatch": "manual_review",
+    "over_split": "fallback_to_original",
+    "under_split": "fallback_to_agent",
+    "alpha_expansion": "adjust_mask",
+    "background_bleed": "adjust_mask",
+    "large_white_component": "adjust_mask",
+    "wrong_subject": "adjust_instruction",
+    "missing_detail": "adjust_instruction",
+    "color_drift": "rerun",
+    "shape_collapse": "rerun",
+    "over_smoothing": "rerun",
+    "texture_leak": "rerun",
+    "uncertain": "manual_review",
+}
+
+QUALITY_FAILURE_ALIASES: dict[str, tuple[str, str]] = {
+    "mask_too_broad": ("mask_too_broad", "adjust_mask"),
+    "mask_too_broad_for_target": ("mask_too_broad", "adjust_mask"),
+    "alpha_expansion": ("alpha_expansion", "adjust_mask"),
+    "alpha_bbox_expanded": ("alpha_expansion", "adjust_mask"),
+    "background_bleed": ("background_bleed", "adjust_mask"),
+    "large_white_component": ("large_white_component", "adjust_mask"),
+    "route_error": ("route_error", "adjust_route"),
+    "pasteback_mismatch": ("pasteback_mismatch", "manual_review"),
+}
+
+
+@dataclass(frozen=True)
+class RouterRecommendation:
+    policy_name: str
+    recommended_action: str
+    failure_hint: str = ""
+    accept_prediction: bool | None = None
+    rule_reason: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "policy_name": self.policy_name,
+            "recommended_action": self.recommended_action,
+            "failure_hint": self.failure_hint,
+            "accept_prediction": self.accept_prediction,
+            "rule_reason": self.rule_reason,
+        }
+
+
+def recommend_action(
+    record: Mapping[str, Any],
+    *,
+    policy_name: str = POLICY_OBSERVABLE_SIGNAL,
+) -> RouterRecommendation:
+    if policy_name == POLICY_LABEL_ORACLE:
+        return _recommend_label_oracle(record)
+    if policy_name == POLICY_OBSERVABLE_SIGNAL:
+        return _recommend_observable_signal(record)
+    raise ValueError(
+        f"unsupported router baseline policy {policy_name!r}; expected one of {sorted(POLICIES)}"
+    )
+
+
+def evaluate_records(
+    records: Iterable[Mapping[str, Any]],
+    *,
+    policy_name: str = POLICY_OBSERVABLE_SIGNAL,
+) -> dict[str, Any]:
+    items = list(records)
+    recommendations = [recommend_action(item, policy_name=policy_name) for item in items]
+
+    action_total = 0
+    action_correct = 0
+    accept_total = 0
+    accept_correct = 0
+    failure_total = 0
+    failure_correct = 0
+    y_true_failure: list[str] = []
+    y_pred_failure: list[str] = []
+    confusion_by_failure: dict[str, dict[str, int]] = {}
+    confusion_by_action: dict[str, dict[str, int]] = {}
+
+    for record, recommendation in zip(items, recommendations, strict=True):
+        review = _mapping(record.get("review"))
+        target_action = str(review.get("preferred_action") or "")
+        if target_action:
+            action_total += 1
+            action_correct += int(recommendation.recommended_action == target_action)
+
+        human_accept = review.get("human_accept")
+        if isinstance(human_accept, bool) and recommendation.accept_prediction is not None:
+            accept_total += 1
+            accept_correct += int(recommendation.accept_prediction is human_accept)
+
+        target_failure = str(review.get("failure_type") or "")
+        if target_failure:
+            failure_total += 1
+            predicted_failure = recommendation.failure_hint or "none"
+            y_true_failure.append(target_failure)
+            y_pred_failure.append(predicted_failure)
+            failure_correct += int(predicted_failure == target_failure)
+            _increment_nested(
+                confusion_by_failure,
+                target_failure,
+                recommendation.recommended_action,
+            )
+            _increment_nested(
+                confusion_by_action,
+                recommendation.recommended_action,
+                target_failure,
+            )
+
+    case_count = len(items)
+    covered_count = sum(1 for item in recommendations if item.recommended_action)
+    manual_review_count = sum(
+        1 for item in recommendations if item.recommended_action == "manual_review"
+    )
+    escalation_count = sum(
+        1 for item in recommendations if item.recommended_action in ESCALATION_ACTIONS
+    )
+
+    return {
+        "policy_name": policy_name,
+        "case_count": case_count,
+        "covered_count": covered_count,
+        "coverage": _ratio(covered_count, case_count),
+        "action_labeled_count": action_total,
+        "action_accuracy": _ratio(action_correct, action_total),
+        "accept_labeled_count": accept_total,
+        "accept_reject_accuracy": _ratio(accept_correct, accept_total),
+        "failure_labeled_count": failure_total,
+        "failure_classification_accuracy": _ratio(failure_correct, failure_total),
+        "failure_macro_f1": _macro_f1(y_true_failure, y_pred_failure),
+        "manual_review_rate": _ratio(manual_review_count, case_count),
+        "escalation_rate": _ratio(escalation_count, case_count),
+        "confusion_by_failure": confusion_by_failure,
+        "confusion_by_action": confusion_by_action,
+        "recommendations": [item.to_dict() for item in recommendations],
+    }
+
+
+def load_jsonl(path: str | Path) -> list[dict[str, Any]]:
+    records: list[dict[str, Any]] = []
+    with Path(path).open("r", encoding="utf-8") as fh:
+        for line_number, line in enumerate(fh, start=1):
+            stripped = line.strip()
+            if not stripped:
+                continue
+            value = json.loads(stripped)
+            if not isinstance(value, dict):
+                raise ValueError(f"{path}:{line_number} is not a JSON object")
+            records.append(value)
+    return records
+
+
+def load_jsonl_many(paths: Sequence[str | Path]) -> list[dict[str, Any]]:
+    records: list[dict[str, Any]] = []
+    for path in paths:
+        records.extend(load_jsonl(path))
+    return records
+
+
+def _recommend_label_oracle(record: Mapping[str, Any]) -> RouterRecommendation:
+    review = _mapping(record.get("review"))
+
+    if review.get("human_accept") is True:
+        return _recommend(
+            POLICY_LABEL_ORACLE,
+            "accept",
+            "",
+            "human_accept_true",
+        )
+
+    preferred_action = str(review.get("preferred_action") or "")
+    if preferred_action:
+        _validate_action(preferred_action)
+        failure_type = str(review.get("failure_type") or "")
+        return _recommend(
+            POLICY_LABEL_ORACLE,
+            preferred_action,
+            _valid_failure_hint(failure_type),
+            "preferred_action_label",
+        )
+
+    failure_type = str(review.get("failure_type") or "")
+    if failure_type:
+        _validate_failure(failure_type)
+        action = LABEL_ORACLE_FAILURE_ACTIONS.get(failure_type, "manual_review")
+        return _recommend(
+            POLICY_LABEL_ORACLE,
+            action,
+            failure_type,
+            f"failure_type:{failure_type}",
+        )
+
+    return _recommend(
+        POLICY_LABEL_ORACLE,
+        "manual_review",
+        "uncertain",
+        "missing_review_label",
+    )
+
+
+def _recommend_observable_signal(record: Mapping[str, Any]) -> RouterRecommendation:
+    route = _mapping(record.get("route"))
+    quality = _mapping(record.get("quality"))
+    metrics = _mapping(quality.get("metrics"))
+    refinement = _mapping(record.get("refinement"))
+    artifacts = _mapping(record.get("artifacts"))
+
+    if _has_pasteback_problem(record, artifacts):
+        return _recommend(
+            POLICY_OBSERVABLE_SIGNAL,
+            "manual_review",
+            "pasteback_mismatch",
+            "pasteback_missing_or_failed",
+        )
+
+    route_failure = _route_failure_hint(route)
+    if route_failure:
+        return _recommend(
+            POLICY_OBSERVABLE_SIGNAL,
+            "adjust_route",
+            route_failure,
+            "route_fields_mismatch",
+        )
+
+    failure_hint, action = _quality_failure_action(_quality_failures(quality), metrics)
+    if action:
+        return _recommend(
+            POLICY_OBSERVABLE_SIGNAL,
+            action,
+            failure_hint,
+            f"quality_signal:{failure_hint}",
+        )
+
+    if _refinement_indicates_broad_mask(refinement, record):
+        return _recommend(
+            POLICY_OBSERVABLE_SIGNAL,
+            "adjust_mask",
+            "mask_too_broad",
+            "refinement_expected_but_not_applied",
+        )
+
+    if quality.get("gate_passed") is True and artifacts.get("source_pasteback_path"):
+        return _recommend(
+            POLICY_OBSERVABLE_SIGNAL,
+            "accept",
+            "",
+            "quality_passed_with_pasteback",
+        )
+
+    if quality.get("gate_passed") is False:
+        return _recommend(
+            POLICY_OBSERVABLE_SIGNAL,
+            "rerun",
+            "uncertain",
+            "quality_failed_without_specific_cause",
+        )
+
+    return _recommend(
+        POLICY_OBSERVABLE_SIGNAL,
+        "manual_review",
+        "uncertain",
+        "inconclusive_observable_signals",
+    )
+
+
+def _recommend(
+    policy_name: str,
+    action: str,
+    failure_hint: str,
+    reason: str,
+) -> RouterRecommendation:
+    _validate_action(action)
+    if failure_hint:
+        _validate_failure(failure_hint)
+    return RouterRecommendation(
+        policy_name=policy_name,
+        recommended_action=action,
+        failure_hint=failure_hint,
+        accept_prediction=action == "accept",
+        rule_reason=reason,
+    )
+
+
+def _has_pasteback_problem(
+    record: Mapping[str, Any],
+    artifacts: Mapping[str, Any],
+) -> bool:
+    if record.get("source_pasteback_error") or artifacts.get("source_pasteback_error"):
+        return True
+    if artifacts.get("source_pasteback_path"):
+        return False
+    quality = _mapping(record.get("quality"))
+    return quality.get("gate_passed") is True
+
+
+def _route_failure_hint(route: Mapping[str, Any]) -> str:
+    requested = str(route.get("requested") or "")
+    chosen = str(route.get("chosen") or "")
+    redraw_route = str(route.get("redraw_route") or "")
+    geometry_route = str(route.get("geometry_redraw_route") or "")
+    if redraw_route and geometry_route and redraw_route != geometry_route:
+        return "route_error"
+    if requested and requested != "auto" and chosen and requested != chosen:
+        return "route_error"
+    return ""
+
+
+def _quality_failure_action(
+    failures: Sequence[str],
+    metrics: Mapping[str, Any],
+) -> tuple[str, str]:
+    for failure in failures:
+        if failure in QUALITY_FAILURE_ALIASES:
+            return QUALITY_FAILURE_ALIASES[failure]
+
+    metric_aliases = {
+        "alpha_bbox_expanded": "alpha_expansion",
+        "background_bleed": "background_bleed",
+        "large_white_component": "large_white_component",
+    }
+    for key, failure_hint in metric_aliases.items():
+        if _metric_positive(metrics.get(key)):
+            return failure_hint, "adjust_mask"
+    if _float(metrics.get("bbox_ratio")) > 2.5:
+        return "alpha_expansion", "adjust_mask"
+    if _float(metrics.get("white_like_pct")) > 85.0:
+        return "large_white_component", "adjust_mask"
+    return "", ""
+
+
+def _refinement_indicates_broad_mask(
+    refinement: Mapping[str, Any],
+    record: Mapping[str, Any],
+) -> bool:
+    if refinement.get("applied") is True:
+        return False
+    reason = str(refinement.get("reason") or "")
+    child_count = _int(refinement.get("child_count"))
+    if reason in {"target_profile_detected", "broad_mask", "candidate_children_missing"}:
+        return child_count <= 0
+    geometry = _mapping(record.get("geometry"))
+    return (
+        _float(geometry.get("area_pct")) > 5.0
+        and _float(refinement.get("mask_granularity_score")) <= 0.0
+        and reason not in {"", "no_target_profile"}
+    )
+
+
+def _quality_failures(quality: Mapping[str, Any]) -> tuple[str, ...]:
+    raw = quality.get("failures") or ()
+    if isinstance(raw, str):
+        return (raw,)
+    if isinstance(raw, Iterable):
+        return tuple(str(item) for item in raw)
+    return ()
+
+
+def _valid_failure_hint(value: str) -> str:
+    if not value:
+        return ""
+    _validate_failure(value)
+    return value
+
+
+def _validate_action(value: str) -> None:
+    if value not in PREFERRED_ACTIONS or not value:
+        raise ValueError(
+            f"unsupported router recommended_action {value!r}; expected one of {sorted(PREFERRED_ACTIONS - {''})}"
+        )
+
+
+def _validate_failure(value: str) -> None:
+    if value not in FAILURE_TYPES:
+        raise ValueError(
+            f"unsupported router failure_hint {value!r}; expected one of {sorted(FAILURE_TYPES)}"
+        )
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    if isinstance(value, Mapping):
+        return value
+    return {}
+
+
+def _metric_positive(value: Any) -> bool:
+    return _float(value) > 0.0
+
+
+def _float(value: Any) -> float:
+    try:
+        return float(value or 0.0)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _int(value: Any) -> int:
+    try:
+        return int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _ratio(numerator: int, denominator: int) -> float | None:
+    if denominator <= 0:
+        return None
+    return numerator / denominator
+
+
+def _increment_nested(table: dict[str, dict[str, int]], key: str, nested_key: str) -> None:
+    nested = table.setdefault(key, {})
+    nested[nested_key] = nested.get(nested_key, 0) + 1
+
+
+def _macro_f1(y_true: Sequence[str], y_pred: Sequence[str]) -> float | None:
+    if not y_true:
+        return None
+    labels = sorted(set(y_true) | set(y_pred))
+    scores: list[float] = []
+    for label in labels:
+        tp = sum(1 for true, pred in zip(y_true, y_pred, strict=True) if true == label and pred == label)
+        fp = sum(1 for true, pred in zip(y_true, y_pred, strict=True) if true != label and pred == label)
+        fn = sum(1 for true, pred in zip(y_true, y_pred, strict=True) if true == label and pred != label)
+        denominator = (2 * tp) + fp + fn
+        scores.append((2 * tp) / denominator if denominator else 0.0)
+    return sum(scores) / len(scores)

--- a/src/vulca/mcp_server.py
+++ b/src/vulca/mcp_server.py
@@ -844,6 +844,7 @@ async def layers_redraw(
     quality: str = "",
     input_fidelity: str = "",
     output_format: str = "",
+    case_log_path: str = "",
 ) -> dict:
     """Redraw a layer via img2img with explicit content/style instructions — targeted layer regeneration.
 
@@ -895,6 +896,9 @@ async def layers_redraw(
             img2img with a warning if provider lacks ``inpaint_with_mask``).
             Ignored on the merge path (``merge=True``) — merged redraw
             retains v0.18 behavior; v0.21 will redesign separately.
+        case_log_path: Optional JSONL path for Learning Loop v0 redraw case
+            logging. Empty means disabled unless VULCA_REDRAW_CASE_LOG is set.
+            Logging is best-effort and never invalidates the redraw result.
 
     Returns:
         name, file, z_index, content_type of the redrawn layer. When the
@@ -957,6 +961,47 @@ async def layers_redraw(
     elif pasteback.get("source_pasteback_error"):
         payload.update(pasteback)
     payload.update(getattr(result, "redraw_advisory", {}) or {})
+
+    from vulca.layers.redraw_cases import (
+        append_redraw_case,
+        build_redraw_case,
+        resolve_case_log_path,
+    )
+
+    resolved_case_log_path = resolve_case_log_path(case_log_path, artwork_dir)
+    if resolved_case_log_path:
+        if merge or not layer:
+            payload["case_log_error"] = (
+                "redraw case logging supports only single-layer redraw in v0"
+            )
+        else:
+            try:
+                source_layer = next(
+                    (lr for lr in artwork.layers if lr.info.name == layer),
+                    None,
+                )
+                if source_layer is None:
+                    raise ValueError(f"layer {layer!r} not found in artwork")
+                record = build_redraw_case(
+                    artwork_dir=artwork_dir,
+                    source_image=artwork.source_image,
+                    layer_info=source_layer.info,
+                    instruction=instruction,
+                    provider=provider,
+                    model=model,
+                    route_requested=route,
+                    source_layer_path=source_layer.image_path,
+                    redrawn_layer_path=result.image_path,
+                    source_pasteback_path=payload.get("source_pasteback_path", ""),
+                    redraw_advisory=payload,
+                )
+                payload["case_log_path"] = append_redraw_case(
+                    resolved_case_log_path,
+                    record,
+                )
+                payload["case_id"] = record["case_id"]
+            except Exception as exc:
+                payload["case_log_error"] = str(exc)
     return payload
 
 

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -5,41 +5,39 @@ import sys
 
 VULCA = [sys.executable, "-m", "vulca.cli"]
 ROOT = Path(__file__).resolve().parent.parent
-os.environ["PYTHONPATH"] = (
-    str(ROOT / "src")
-    + os.pathsep
-    + os.environ.get("PYTHONPATH", "")
+CLI_ENV = dict(
+    os.environ,
+    PYTHONPATH=(
+        str(ROOT / "src")
+        + os.pathsep
+        + os.environ.get("PYTHONPATH", "")
+    ),
 )
+
+
+def run_vulca(args):
+    return subprocess.run(
+        VULCA + args,
+        capture_output=True, text=True, timeout=10, env=CLI_ENV,
+    )
 
 
 class TestCLICommands:
     def test_studio_help(self):
-        result = subprocess.run(
-            VULCA + ["studio", "--help"],
-            capture_output=True, text=True, timeout=10,
-        )
+        result = run_vulca(["studio", "--help"])
         assert result.returncode == 0
         assert "studio" in result.stdout.lower() or "interactive" in result.stdout.lower()
 
     def test_brief_help(self):
-        result = subprocess.run(
-            VULCA + ["brief", "--help"],
-            capture_output=True, text=True, timeout=10,
-        )
+        result = run_vulca(["brief", "--help"])
         assert result.returncode == 0
 
     def test_brief_update_help(self):
-        result = subprocess.run(
-            VULCA + ["brief-update", "--help"],
-            capture_output=True, text=True, timeout=10,
-        )
+        result = run_vulca(["brief-update", "--help"])
         assert result.returncode == 0
 
     def test_concept_help(self):
-        result = subprocess.run(
-            VULCA + ["concept", "--help"],
-            capture_output=True, text=True, timeout=10,
-        )
+        result = run_vulca(["concept", "--help"])
         assert result.returncode == 0
 
     def test_no_click_import(self):
@@ -49,17 +47,11 @@ class TestCLICommands:
         assert "import click" not in content
 
     def test_existing_evaluate_still_works(self):
-        result = subprocess.run(
-            VULCA + ["evaluate", "--help"],
-            capture_output=True, text=True, timeout=10,
-        )
+        result = run_vulca(["evaluate", "--help"])
         assert result.returncode == 0
         assert "evaluate" in result.stdout.lower() or "artwork" in result.stdout.lower()
 
     def test_layers_redraw_help_mentions_case_log(self):
-        result = subprocess.run(
-            VULCA + ["layers", "redraw", "--help"],
-            capture_output=True, text=True, timeout=10,
-        )
+        result = run_vulca(["layers", "redraw", "--help"])
         assert result.returncode == 0
         assert "--case-log" in result.stdout

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -1,7 +1,15 @@
+import os
+from pathlib import Path
 import subprocess
 import sys
 
 VULCA = [sys.executable, "-m", "vulca.cli"]
+ROOT = Path(__file__).resolve().parent.parent
+os.environ["PYTHONPATH"] = (
+    str(ROOT / "src")
+    + os.pathsep
+    + os.environ.get("PYTHONPATH", "")
+)
 
 
 class TestCLICommands:
@@ -47,3 +55,11 @@ class TestCLICommands:
         )
         assert result.returncode == 0
         assert "evaluate" in result.stdout.lower() or "artwork" in result.stdout.lower()
+
+    def test_layers_redraw_help_mentions_case_log(self):
+        result = subprocess.run(
+            VULCA + ["layers", "redraw", "--help"],
+            capture_output=True, text=True, timeout=10,
+        )
+        assert result.returncode == 0
+        assert "--case-log" in result.stdout

--- a/tests/test_mcp_layers_redraw_advisory.py
+++ b/tests/test_mcp_layers_redraw_advisory.py
@@ -225,3 +225,45 @@ def test_layers_redraw_returns_nonfatal_source_pasteback_error(tmp_path, monkeyp
     assert "source size (900, 900) != layer size (1000, 1000)" in result[
         "source_pasteback_error"
     ]
+
+
+def test_layers_redraw_appends_case_log_when_enabled(tmp_path, monkeypatch):
+    _install_fastmcp_stub(monkeypatch)
+
+    from vulca.mcp_server import layers_redraw
+    import vulca.providers as providers_mod
+
+    provider = RecordingEditProvider()
+    monkeypatch.setattr(
+        providers_mod, "get_image_provider", lambda name, api_key="": provider
+    )
+    _stage_artwork(tmp_path)
+    case_log = tmp_path / "redraw_cases.jsonl"
+
+    result = _run(
+        layers_redraw(
+            artwork_dir=str(tmp_path),
+            layer="fg",
+            instruction="make it cleaner",
+            provider="openai",
+            route="auto",
+            preserve_alpha=True,
+            case_log_path=str(case_log),
+        )
+    )
+
+    assert result["case_log_path"] == str(case_log)
+    assert result["case_id"].startswith("redraw_")
+    lines = case_log.read_text().splitlines()
+    assert len(lines) == 1
+
+    import json
+
+    record = json.loads(lines[0])
+    assert record["case_id"] == result["case_id"]
+    assert record["layer"]["name"] == "fg"
+    assert record["instruction"] == "make it cleaner"
+    assert record["provider"] == "openai"
+    assert record["model"] == ""
+    assert record["route"]["chosen"] == "inpaint"
+    assert record["artifacts"]["source_pasteback_path"].endswith("_on_source.png")

--- a/tests/test_redraw_benchmark_manifest.py
+++ b/tests/test_redraw_benchmark_manifest.py
@@ -1,0 +1,23 @@
+import json
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+def test_redraw_failure_taxonomy_matches_seed_manifest():
+    taxonomy_path = ROOT / "docs" / "benchmarks" / "redraw" / "failure_taxonomy.json"
+    manifest_path = ROOT / "docs" / "benchmarks" / "redraw" / "seed_manifest.json"
+
+    taxonomy = json.loads(taxonomy_path.read_text())
+    manifest = json.loads(manifest_path.read_text())
+
+    allowed = set(taxonomy["failure_types"])
+    assert "mask_too_broad" in allowed
+    assert manifest["case_type"] == "redraw_case_seed"
+    assert manifest["schema_version"] == 1
+    assert manifest["items"]
+    for item in manifest["items"]:
+        assert item["failure_type"] in allowed
+        artifact = ROOT / item["source_artifact"]
+        assert artifact.exists(), item["source_artifact"]

--- a/tests/test_redraw_benchmark_manifest.py
+++ b/tests/test_redraw_benchmark_manifest.py
@@ -1,6 +1,8 @@
 import json
 from pathlib import Path
 
+from vulca.layers.redraw_cases import FAILURE_TYPES, PREFERRED_ACTIONS
+
 
 ROOT = Path(__file__).resolve().parent.parent
 
@@ -12,12 +14,23 @@ def test_redraw_failure_taxonomy_matches_seed_manifest():
     taxonomy = json.loads(taxonomy_path.read_text())
     manifest = json.loads(manifest_path.read_text())
 
-    allowed = set(taxonomy["failure_types"])
-    assert "mask_too_broad" in allowed
+    taxonomy_failure_types = set(taxonomy["failure_types"])
+    taxonomy_preferred_actions = set(taxonomy["preferred_actions"])
+    expected_preferred_actions = PREFERRED_ACTIONS - {""}
+
+    assert taxonomy_failure_types == FAILURE_TYPES
+    assert len(taxonomy["failure_types"]) == len(FAILURE_TYPES)
+    assert taxonomy_preferred_actions == expected_preferred_actions
+    assert len(taxonomy["preferred_actions"]) == len(expected_preferred_actions)
     assert manifest["case_type"] == "redraw_case_seed"
     assert manifest["schema_version"] == 1
     assert manifest["items"]
+    root = ROOT.resolve()
     for item in manifest["items"]:
-        assert item["failure_type"] in allowed
-        artifact = ROOT / item["source_artifact"]
-        assert artifact.exists(), item["source_artifact"]
+        assert item["failure_type"] in taxonomy_failure_types
+        assert item["preferred_action"] in taxonomy_preferred_actions
+        source_artifact = Path(item["source_artifact"])
+        assert not source_artifact.is_absolute(), item["source_artifact"]
+        artifact = (ROOT / source_artifact).resolve()
+        assert artifact.is_relative_to(root), item["source_artifact"]
+        assert artifact.is_file(), item["source_artifact"]

--- a/tests/test_redraw_benchmark_manifest.py
+++ b/tests/test_redraw_benchmark_manifest.py
@@ -1,4 +1,5 @@
 import json
+import subprocess
 from pathlib import Path
 
 from vulca.layers.redraw_cases import FAILURE_TYPES, PREFERRED_ACTIONS
@@ -18,6 +19,8 @@ def test_redraw_failure_taxonomy_matches_seed_manifest():
     taxonomy_preferred_actions = set(taxonomy["preferred_actions"])
     expected_preferred_actions = PREFERRED_ACTIONS - {""}
 
+    assert taxonomy["schema_version"] == 1
+    assert taxonomy["case_type"] == "redraw_failure_taxonomy"
     assert taxonomy_failure_types == FAILURE_TYPES
     assert len(taxonomy["failure_types"]) == len(FAILURE_TYPES)
     assert taxonomy_preferred_actions == expected_preferred_actions
@@ -34,3 +37,16 @@ def test_redraw_failure_taxonomy_matches_seed_manifest():
         artifact = (ROOT / source_artifact).resolve()
         assert artifact.is_relative_to(root), item["source_artifact"]
         assert artifact.is_file(), item["source_artifact"]
+        subprocess.run(
+            [
+                "git",
+                "-C",
+                str(ROOT),
+                "ls-files",
+                "--error-unmatch",
+                item["source_artifact"],
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+        )

--- a/tests/test_redraw_cases.py
+++ b/tests/test_redraw_cases.py
@@ -1,0 +1,116 @@
+import json
+
+import pytest
+
+from vulca.layers.types import LayerInfo
+
+
+def test_build_redraw_case_minimal_schema(tmp_path):
+    from vulca.layers.redraw_cases import build_redraw_case
+
+    layer = LayerInfo(
+        id="layer_fg_001",
+        name="fg",
+        description="foreground object",
+        z_index=1,
+        content_type="subject",
+        semantic_path="subject.object",
+        quality_status="detected",
+        area_pct=1.25,
+    )
+    record = build_redraw_case(
+        artwork_dir=str(tmp_path),
+        source_image="source.png",
+        layer_info=layer,
+        instruction="make it cleaner",
+        provider="openai",
+        model="gpt-image-2",
+        route_requested="auto",
+        source_layer_path=str(tmp_path / "fg.png"),
+        redrawn_layer_path=str(tmp_path / "fg_redrawn.png"),
+        source_pasteback_path=str(tmp_path / "fg_redrawn_on_source.png"),
+        redraw_advisory={
+            "route_chosen": "inpaint",
+            "redraw_route": "sparse_bbox_crop",
+            "geometry_redraw_route": "sparse_bbox_crop",
+            "area_pct": 0.64,
+            "bbox_fill": 1.0,
+            "component_count": 1,
+            "sparse_detected": True,
+            "quality_gate_passed": True,
+            "quality_failures": [],
+            "refinement_applied": False,
+            "refinement_reason": "no_target_profile",
+            "refinement_strategy": "none",
+            "refined_child_count": 0,
+            "mask_granularity_score": 0.0,
+        },
+        created_at="2026-05-05T12:00:00Z",
+    )
+
+    assert record["schema_version"] == 1
+    assert record["case_type"] == "redraw_case"
+    assert record["case_id"].startswith("redraw_20260505T120000Z_")
+    assert record["artwork_dir"] == str(tmp_path)
+    assert record["source_image"] == "source.png"
+    assert record["layer"] == {
+        "id": "layer_fg_001",
+        "name": "fg",
+        "description": "foreground object",
+        "semantic_path": "subject.object",
+        "quality_status": "detected",
+        "area_pct_manifest": 1.25,
+    }
+    assert record["route"]["requested"] == "auto"
+    assert record["route"]["chosen"] == "inpaint"
+    assert record["geometry"]["component_count"] == 1
+    assert record["quality"]["gate_passed"] is True
+    assert record["review"] == {
+        "human_accept": None,
+        "failure_type": "",
+        "preferred_action": "",
+        "reviewer": "",
+        "reviewed_at": "",
+    }
+
+
+def test_append_redraw_case_writes_one_json_line(tmp_path):
+    from vulca.layers.redraw_cases import append_redraw_case
+
+    path = tmp_path / "cases" / "redraw_cases.jsonl"
+    record = {
+        "schema_version": 1,
+        "case_type": "redraw_case",
+        "case_id": "redraw_example",
+    }
+
+    written = append_redraw_case(str(path), record)
+
+    assert written == str(path)
+    lines = path.read_text().splitlines()
+    assert len(lines) == 1
+    assert json.loads(lines[0]) == record
+
+
+def test_validate_failure_type_rejects_unknown_label():
+    from vulca.layers.redraw_cases import validate_failure_type
+
+    assert validate_failure_type("") == ""
+    assert validate_failure_type("mask_too_broad") == "mask_too_broad"
+    with pytest.raises(ValueError, match="unsupported redraw failure_type"):
+        validate_failure_type("bad_label")
+
+
+def test_resolve_case_log_path_supports_env_default(tmp_path, monkeypatch):
+    from vulca.layers.redraw_cases import resolve_case_log_path
+
+    assert resolve_case_log_path("", str(tmp_path)) == ""
+
+    monkeypatch.setenv("VULCA_REDRAW_CASE_LOG", "1")
+    assert resolve_case_log_path("", str(tmp_path)) == str(tmp_path / "redraw_cases.jsonl")
+
+    explicit = tmp_path / "custom.jsonl"
+    assert resolve_case_log_path(str(explicit), str(tmp_path)) == str(explicit)
+
+    monkeypatch.setenv("VULCA_REDRAW_CASE_LOG", str(tmp_path / "env.jsonl"))
+    assert resolve_case_log_path("", str(tmp_path)) == str(tmp_path / "env.jsonl")

--- a/tests/test_redraw_router_baseline.py
+++ b/tests/test_redraw_router_baseline.py
@@ -1,0 +1,234 @@
+import json
+
+
+def _case(**overrides):
+    record = {
+        "case_id": "redraw_example",
+        "case_type": "redraw_case",
+        "route": {
+            "requested": "auto",
+            "chosen": "inpaint",
+            "redraw_route": "sparse_bbox_crop",
+            "geometry_redraw_route": "sparse_bbox_crop",
+        },
+        "geometry": {
+            "area_pct": 0.64,
+            "bbox_fill": 1.0,
+            "component_count": 1,
+            "sparse_detected": True,
+        },
+        "quality": {
+            "gate_passed": True,
+            "failures": [],
+            "metrics": {},
+        },
+        "refinement": {
+            "applied": False,
+            "reason": "no_target_profile",
+            "strategy": "none",
+            "child_count": 0,
+            "mask_granularity_score": 0.0,
+        },
+        "artifacts": {
+            "source_pasteback_path": "/tmp/redraw_on_source.png",
+        },
+        "review": {
+            "human_accept": None,
+            "failure_type": "",
+            "preferred_action": "",
+        },
+    }
+    for key, value in overrides.items():
+        if isinstance(value, dict) and isinstance(record.get(key), dict):
+            nested = dict(record[key])
+            nested.update(value)
+            record[key] = nested
+        else:
+            record[key] = value
+    return record
+
+
+def test_label_oracle_maps_seed_failures_to_required_actions():
+    from vulca.layers.redraw_router_baseline import recommend_action
+
+    expected = {
+        "mask_too_broad": "adjust_mask",
+        "route_error": "adjust_route",
+        "pasteback_mismatch": "manual_review",
+        "over_split": "fallback_to_original",
+        "under_split": "fallback_to_agent",
+    }
+
+    for failure_type, action in expected.items():
+        result = recommend_action(
+            _case(review={"failure_type": failure_type, "preferred_action": ""}),
+            policy_name="label_oracle",
+        )
+        assert result.recommended_action == action
+        assert result.failure_hint == failure_type
+
+
+def test_label_oracle_accepts_human_accept_before_failure_label():
+    from vulca.layers.redraw_router_baseline import recommend_action
+
+    result = recommend_action(
+        _case(
+            review={
+                "human_accept": True,
+                "failure_type": "mask_too_broad",
+                "preferred_action": "adjust_mask",
+            }
+        ),
+        policy_name="label_oracle",
+    )
+
+    assert result.recommended_action == "accept"
+    assert result.accept_prediction is True
+
+
+def test_observable_signal_accepts_passed_quality_with_pasteback():
+    from vulca.layers.redraw_router_baseline import recommend_action
+
+    result = recommend_action(
+        _case(review={"failure_type": "route_error", "preferred_action": "adjust_route"}),
+        policy_name="observable_signal",
+    )
+
+    assert result.recommended_action == "accept"
+    assert result.failure_hint == ""
+    assert result.accept_prediction is True
+
+
+def test_observable_signal_routes_quality_failures_to_mask_adjustment():
+    from vulca.layers.redraw_router_baseline import recommend_action
+
+    result = recommend_action(
+        _case(
+            quality={
+                "gate_passed": False,
+                "failures": ["mask_too_broad_for_target"],
+                "metrics": {},
+            }
+        ),
+        policy_name="observable_signal",
+    )
+
+    assert result.recommended_action == "adjust_mask"
+    assert result.failure_hint == "mask_too_broad"
+    assert result.accept_prediction is False
+
+
+def test_observable_signal_routes_geometry_mismatch_to_route_adjustment():
+    from vulca.layers.redraw_router_baseline import recommend_action
+
+    result = recommend_action(
+        _case(
+            route={
+                "requested": "auto",
+                "chosen": "inpaint",
+                "redraw_route": "dense_full_canvas",
+                "geometry_redraw_route": "sparse_bbox_crop",
+            }
+        ),
+        policy_name="observable_signal",
+    )
+
+    assert result.recommended_action == "adjust_route"
+    assert result.failure_hint == "route_error"
+
+
+def test_observable_signal_does_not_read_review_labels():
+    from vulca.layers.redraw_router_baseline import recommend_action
+
+    class ReviewTrap(dict):
+        def __getitem__(self, key):
+            if key == "review":
+                raise AssertionError("observable_signal must not read review")
+            return super().__getitem__(key)
+
+        def get(self, key, default=None):
+            if key == "review":
+                raise AssertionError("observable_signal must not read review")
+            return super().get(key, default)
+
+    result = recommend_action(
+        ReviewTrap(
+            _case(
+                quality={
+                    "gate_passed": False,
+                    "failures": ["large_white_component"],
+                    "metrics": {},
+                }
+            )
+        ),
+        policy_name="observable_signal",
+    )
+
+    assert result.recommended_action == "adjust_mask"
+    assert result.failure_hint == "large_white_component"
+
+
+def test_evaluate_records_reports_action_accuracy_and_confusion():
+    from vulca.layers.redraw_router_baseline import evaluate_records
+
+    records = [
+        _case(
+            case_id="one",
+            review={
+                "human_accept": False,
+                "failure_type": "mask_too_broad",
+                "preferred_action": "adjust_mask",
+            },
+        ),
+        _case(
+            case_id="two",
+            review={
+                "human_accept": False,
+                "failure_type": "route_error",
+                "preferred_action": "adjust_route",
+            },
+        ),
+    ]
+
+    report = evaluate_records(records, policy_name="label_oracle")
+
+    assert report["policy_name"] == "label_oracle"
+    assert report["case_count"] == 2
+    assert report["coverage"] == 1.0
+    assert report["action_accuracy"] == 1.0
+    assert report["accept_reject_accuracy"] == 1.0
+    assert report["failure_classification_accuracy"] == 1.0
+    assert report["failure_macro_f1"] == 1.0
+    assert report["confusion_by_failure"]["mask_too_broad"]["adjust_mask"] == 1
+    assert report["confusion_by_failure"]["route_error"]["adjust_route"] == 1
+
+
+def test_cli_scores_jsonl_without_provider_calls(tmp_path, capsys):
+    from scripts.redraw_router_baseline_eval import main
+
+    case_log = tmp_path / "redraw_cases.jsonl"
+    case_log.write_text(
+        "\n".join(
+            [
+                json.dumps(
+                    _case(
+                        case_id="one",
+                        review={
+                            "human_accept": False,
+                            "failure_type": "mask_too_broad",
+                            "preferred_action": "adjust_mask",
+                        },
+                    )
+                )
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    assert main([str(case_log), "--policy", "label_oracle"]) == 0
+    output = json.loads(capsys.readouterr().out)
+
+    assert output["policy_name"] == "label_oracle"
+    assert output["case_count"] == 1
+    assert output["action_accuracy"] == 1.0


### PR DESCRIPTION
## Summary

- Adds v0 learning-loop design docs plus redraw case logging schema and append helpers.
- Exposes redraw case logging through CLI/MCP surfaces and adds benchmark seed/taxonomy artifacts.
- Adds a tiny redraw router baseline evaluator for future case-review/model-routing comparisons.

## Diff Hygiene

This branch was rebuilt cleanly from `origin/master`. It intentionally excludes the stale `codex/provider-sdk-tools` drift: no real_brief removals, Seattle artifacts, untracked generated assets, or duplicate v0.23 redraw replacement changes.

## Validation

- `/opt/homebrew/bin/python3.11 -m pytest tests/test_redraw_cases.py tests/test_redraw_benchmark_manifest.py tests/test_redraw_router_baseline.py tests/test_cli_commands.py tests/test_mcp_layers_redraw_advisory.py` -> `24 passed`
- `git diff --check origin/master..HEAD` -> passed
