### PR TITLE
[codex] Add case review labeling CLI

### DIFF
--- a/src/vulca/cli.py
+++ b/src/vulca/cli.py
@@ -305,6 +305,34 @@ def main(argv: list[str] | None = None) -> None:
     sessions_list.add_argument("--limit", "-n", type=int, default=20, help="Max sessions to show")
     sessions_list.add_argument("--sort", default="date", choices=["score", "date"], help="Sort order")
 
+    # cases command group
+    cases_p = sub.add_parser("cases", help="Review and label learning-loop case logs")
+    cases_sub = cases_p.add_subparsers(dest="cases_command")
+    cases_review = cases_sub.add_parser("review", help="Apply human review labels to one case")
+    cases_review.add_argument("input", help="Input JSONL case log")
+    cases_review.add_argument("--case-id", required=True, help="Case id to update")
+    cases_review.add_argument(
+        "--human-accept",
+        default=None,
+        help="Human acceptance label: true/false",
+    )
+    cases_review.add_argument("--failure-type", default=None, help="Failure taxonomy label")
+    cases_review.add_argument("--preferred-action", default=None, help="Preferred next action label")
+    cases_review.add_argument("--reviewer", default=None, help="Reviewer id/name")
+    cases_review.add_argument("--reviewed-at", default=None, help="Review timestamp, ISO-8601 UTC recommended")
+    cases_review.add_argument("--notes", default=None, help="Free-form review notes")
+    cases_review.add_argument(
+        "--output",
+        "-o",
+        default="",
+        help="Output reviewed JSONL path (default: INPUT.reviewed.jsonl)",
+    )
+    cases_review.add_argument(
+        "--sidecar-output",
+        default="",
+        help="Optional review-only JSONL sidecar path, appended if provided",
+    )
+
     # resume command
     resume_p = sub.add_parser("resume", help="Resume pipeline from checkpoint")
     resume_p.add_argument("session_id", help="Session ID to resume")
@@ -367,6 +395,11 @@ def main(argv: list[str] | None = None) -> None:
             sessions_p.print_help()
             sys.exit(0)
         _cmd_sessions(args)
+    elif args.command == "cases":
+        if not args.cases_command:
+            cases_p.print_help()
+            sys.exit(0)
+        _cmd_cases(args)
     elif args.command == "resume":
         _cmd_resume(args)
     elif args.command == "tools":
@@ -1565,6 +1598,47 @@ def _cmd_layers(args: argparse.Namespace) -> None:
     else:
         print(f"Unknown layers command: {args.layers_command}", file=sys.stderr)
         sys.exit(1)
+
+
+# ---------------------------------------------------------------------------
+# Cases command group
+# ---------------------------------------------------------------------------
+
+def _cmd_cases(args: argparse.Namespace) -> None:
+    import json as _json
+
+    if args.cases_command != "review":
+        print(f"Unknown cases command: {args.cases_command}", file=sys.stderr)
+        sys.exit(1)
+
+    from vulca.learning.case_review import parse_human_accept, review_case_log
+
+    review_kwargs = {
+        "case_id": args.case_id,
+        "output_path": args.output or None,
+        "failure_type": args.failure_type,
+        "preferred_action": args.preferred_action,
+        "reviewer": args.reviewer,
+        "reviewed_at": args.reviewed_at,
+        "notes": args.notes,
+        "sidecar_output_path": args.sidecar_output or None,
+    }
+    if args.human_accept is not None:
+        try:
+            review_kwargs["human_accept"] = parse_human_accept(args.human_accept)
+        except ValueError as exc:
+            print(f"Error: {exc}", file=sys.stderr)
+            sys.exit(1)
+
+    try:
+        result = review_case_log(args.input, **review_kwargs)
+    except (ValueError, FileNotFoundError, _json.JSONDecodeError) as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"  Reviewed case: {result.case_id} -> {result.output_path}")
+    if result.sidecar_path:
+        print(f"  Review sidecar: {result.sidecar_path}")
 
 
 def _cmd_sessions(args: argparse.Namespace) -> None:

--- a/src/vulca/learning/__init__.py
+++ b/src/vulca/learning/__init__.py
@@ -1,0 +1,1 @@
+"""Learning-loop utilities for case review and labeling."""

--- a/src/vulca/learning/case_review.py
+++ b/src/vulca/learning/case_review.py
@@ -1,0 +1,196 @@
+"""Lightweight review labeling for versioned case JSONL logs."""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Mapping
+
+from vulca.layers.redraw_cases import (
+    CASE_TYPE as REDRAW_CASE_TYPE,
+    utc_now_iso,
+    validate_failure_type as validate_redraw_failure_type,
+    validate_preferred_action as validate_redraw_preferred_action,
+)
+
+
+_UNSET = object()
+
+
+@dataclass(frozen=True)
+class CaseReviewSpec:
+    """Validation hooks for a reviewable case type."""
+
+    case_type: str
+    validate_failure_type: Callable[[str], str]
+    validate_preferred_action: Callable[[str], str]
+
+
+@dataclass(frozen=True)
+class ReviewResult:
+    """Result metadata for a case-log review update."""
+
+    case_id: str
+    output_path: str
+    updated: bool
+    sidecar_path: str = ""
+
+
+CASE_REVIEW_SPECS: dict[str, CaseReviewSpec] = {
+    REDRAW_CASE_TYPE: CaseReviewSpec(
+        case_type=REDRAW_CASE_TYPE,
+        validate_failure_type=validate_redraw_failure_type,
+        validate_preferred_action=validate_redraw_preferred_action,
+    )
+}
+
+
+def load_cases(path: str | Path) -> list[dict[str, Any]]:
+    """Read newline-delimited JSON case records."""
+    case_path = Path(path)
+    records: list[dict[str, Any]] = []
+    with case_path.open("r", encoding="utf-8") as fh:
+        for line_no, line in enumerate(fh, start=1):
+            stripped = line.strip()
+            if not stripped:
+                continue
+            value = json.loads(stripped)
+            if not isinstance(value, dict):
+                raise ValueError(f"{case_path}:{line_no}: expected JSON object")
+            records.append(value)
+    return records
+
+
+def write_cases(path: str | Path, cases: list[Mapping[str, Any]]) -> str:
+    """Write newline-delimited JSON case records."""
+    output_path = Path(path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with output_path.open("w", encoding="utf-8") as fh:
+        for record in cases:
+            fh.write(json.dumps(dict(record), sort_keys=True, separators=(",", ":")))
+            fh.write("\n")
+    return str(output_path)
+
+
+def default_review_output_path(input_path: str | Path) -> str:
+    """Return a non-destructive default output path for reviewed case logs."""
+    path = Path(input_path)
+    if path.suffix == ".jsonl":
+        return str(path.with_name(f"{path.stem}.reviewed{path.suffix}"))
+    return str(path.with_name(f"{path.name}.reviewed.jsonl"))
+
+
+def parse_human_accept(value: str) -> bool:
+    """Parse a CLI boolean for human_accept."""
+    normalized = value.strip().lower()
+    if normalized in {"1", "true", "yes", "y", "accept", "accepted"}:
+        return True
+    if normalized in {"0", "false", "no", "n", "reject", "rejected"}:
+        return False
+    raise ValueError("human_accept must be true/false")
+
+
+def review_case_log(
+    input_path: str | Path,
+    *,
+    case_id: str,
+    output_path: str | Path | None = None,
+    human_accept: bool | object = _UNSET,
+    failure_type: str | None = None,
+    preferred_action: str | None = None,
+    reviewer: str | None = None,
+    reviewed_at: str | None = None,
+    notes: str | None = None,
+    sidecar_output_path: str | Path | None = None,
+) -> ReviewResult:
+    """Update one case review block and write reviewed JSONL.
+
+    Original record fields are preserved. Only the nested ``review`` object on
+    the matching ``case_id`` is merged with supplied labels.
+    """
+    if not case_id:
+        raise ValueError("case_id is required")
+
+    cases = load_cases(input_path)
+    output = str(output_path or default_review_output_path(input_path))
+    found = False
+    sidecar_record: dict[str, Any] | None = None
+
+    for record in cases:
+        if str(record.get("case_id", "")) != case_id:
+            continue
+
+        found = True
+        spec = _spec_for_record(record)
+        review = dict(record.get("review", {}) or {})
+        changed = False
+
+        if human_accept is not _UNSET:
+            review["human_accept"] = bool(human_accept)
+            changed = True
+        if failure_type is not None:
+            review["failure_type"] = spec.validate_failure_type(str(failure_type))
+            changed = True
+        if preferred_action is not None:
+            review["preferred_action"] = spec.validate_preferred_action(
+                str(preferred_action)
+            )
+            changed = True
+        if reviewer is not None:
+            review["reviewer"] = str(reviewer)
+            changed = True
+        if notes is not None:
+            review["notes"] = str(notes)
+            changed = True
+        if reviewed_at is not None:
+            review["reviewed_at"] = str(reviewed_at)
+            changed = True
+        elif changed:
+            review["reviewed_at"] = str(review.get("reviewed_at") or utc_now_iso())
+
+        record["review"] = review
+        sidecar_record = {
+            "case_id": case_id,
+            "case_type": str(record.get("case_type", "")),
+            "review": review,
+        }
+        break
+
+    if not found:
+        raise ValueError(f"case_id {case_id!r} not found in {input_path}")
+
+    write_cases(output, cases)
+    sidecar_path = ""
+    if sidecar_output_path:
+        sidecar_path = _write_review_sidecar(sidecar_output_path, sidecar_record)
+    return ReviewResult(
+        case_id=case_id,
+        output_path=output,
+        updated=True,
+        sidecar_path=sidecar_path,
+    )
+
+
+def _spec_for_record(record: Mapping[str, Any]) -> CaseReviewSpec:
+    case_type = str(record.get("case_type", ""))
+    spec = CASE_REVIEW_SPECS.get(case_type)
+    if spec is None:
+        supported = sorted(CASE_REVIEW_SPECS)
+        raise ValueError(
+            f"unsupported case_type {case_type!r}; expected one of {supported}"
+        )
+    return spec
+
+
+def _write_review_sidecar(
+    sidecar_output_path: str | Path,
+    record: Mapping[str, Any] | None,
+) -> str:
+    if record is None:
+        raise ValueError("cannot write sidecar without a reviewed case")
+    path = Path(sidecar_output_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(dict(record), sort_keys=True, separators=(",", ":")))
+        fh.write("\n")
+    return str(path)

--- a/tests/test_case_review.py
+++ b/tests/test_case_review.py
@@ -1,0 +1,217 @@
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parent.parent
+CLI_ENV = dict(
+    os.environ,
+    PYTHONPATH=str(ROOT / "src") + os.pathsep + os.environ.get("PYTHONPATH", ""),
+)
+
+
+def _write_jsonl(path: Path, records: list[dict]) -> None:
+    path.write_text(
+        "\n".join(json.dumps(record, sort_keys=True) for record in records) + "\n",
+        encoding="utf-8",
+    )
+
+
+def test_review_case_log_updates_target_case_without_dropping_fields(tmp_path):
+    from vulca.learning.case_review import load_cases, review_case_log
+
+    input_path = tmp_path / "cases.jsonl"
+    output_path = tmp_path / "reviewed.jsonl"
+    original_target = {
+        "schema_version": 1,
+        "case_type": "redraw_case",
+        "case_id": "redraw_a",
+        "provider": "openai",
+        "nested": {"keep": True},
+        "review": {"human_accept": None, "failure_type": "", "preferred_action": ""},
+    }
+    untouched = {
+        "schema_version": 1,
+        "case_type": "redraw_case",
+        "case_id": "redraw_b",
+        "provider": "nb2",
+        "review": {"human_accept": None},
+    }
+    _write_jsonl(input_path, [original_target, untouched])
+
+    result = review_case_log(
+        input_path,
+        case_id="redraw_a",
+        output_path=output_path,
+        human_accept=False,
+        failure_type="mask_too_broad",
+        preferred_action="adjust_mask",
+        reviewer="alice",
+        reviewed_at="2026-05-05T12:34:56Z",
+        notes="mask included broad hedge texture",
+    )
+
+    reread = load_cases(output_path)
+    assert result.updated is True
+    assert result.case_id == "redraw_a"
+    assert result.output_path == str(output_path)
+    assert len(reread) == 2
+    assert reread[0]["case_id"] == "redraw_a"
+    assert reread[0]["provider"] == "openai"
+    assert reread[0]["nested"] == {"keep": True}
+    assert reread[0]["review"] == {
+        "human_accept": False,
+        "failure_type": "mask_too_broad",
+        "preferred_action": "adjust_mask",
+        "reviewer": "alice",
+        "reviewed_at": "2026-05-05T12:34:56Z",
+        "notes": "mask included broad hedge texture",
+    }
+    assert reread[1] == untouched
+
+
+def test_review_case_log_rejects_invalid_labels(tmp_path):
+    from vulca.learning.case_review import review_case_log
+
+    input_path = tmp_path / "cases.jsonl"
+    _write_jsonl(
+        input_path,
+        [
+            {
+                "schema_version": 1,
+                "case_type": "redraw_case",
+                "case_id": "redraw_a",
+                "review": {},
+            }
+        ],
+    )
+
+    with pytest.raises(ValueError, match="unsupported redraw failure_type"):
+        review_case_log(
+            input_path,
+            case_id="redraw_a",
+            failure_type="not_a_taxonomy_label",
+        )
+
+    with pytest.raises(ValueError, match="unsupported redraw preferred_action"):
+        review_case_log(
+            input_path,
+            case_id="redraw_a",
+            preferred_action="not_an_action",
+        )
+
+
+def test_review_case_log_can_append_review_sidecar(tmp_path):
+    from vulca.learning.case_review import review_case_log
+
+    input_path = tmp_path / "cases.jsonl"
+    output_path = tmp_path / "reviewed.jsonl"
+    sidecar_path = tmp_path / "reviews.jsonl"
+    _write_jsonl(
+        input_path,
+        [
+            {
+                "schema_version": 1,
+                "case_type": "redraw_case",
+                "case_id": "redraw_a",
+                "review": {},
+            }
+        ],
+    )
+
+    result = review_case_log(
+        input_path,
+        case_id="redraw_a",
+        output_path=output_path,
+        sidecar_output_path=sidecar_path,
+        human_accept=True,
+        failure_type="",
+        preferred_action="accept",
+        reviewed_at="2026-05-05T12:40:00Z",
+    )
+
+    sidecar = [json.loads(line) for line in sidecar_path.read_text().splitlines()]
+    assert result.sidecar_path == str(sidecar_path)
+    assert sidecar == [
+        {
+            "case_id": "redraw_a",
+            "case_type": "redraw_case",
+            "review": {
+                "failure_type": "",
+                "human_accept": True,
+                "preferred_action": "accept",
+                "reviewed_at": "2026-05-05T12:40:00Z",
+            },
+        }
+    ]
+
+
+def test_review_case_log_errors_when_case_id_missing(tmp_path):
+    from vulca.learning.case_review import review_case_log
+
+    input_path = tmp_path / "cases.jsonl"
+    _write_jsonl(
+        input_path,
+        [{"schema_version": 1, "case_type": "redraw_case", "case_id": "redraw_a"}],
+    )
+
+    with pytest.raises(ValueError, match="case_id 'missing' not found"):
+        review_case_log(input_path, case_id="missing")
+
+
+def test_cases_review_cli_writes_reviewed_jsonl(tmp_path):
+    input_path = tmp_path / "cases.jsonl"
+    output_path = tmp_path / "reviewed.jsonl"
+    _write_jsonl(
+        input_path,
+        [
+            {
+                "schema_version": 1,
+                "case_type": "redraw_case",
+                "case_id": "redraw_cli",
+                "review": {},
+            }
+        ],
+    )
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "vulca.cli",
+            "cases",
+            "review",
+            str(input_path),
+            "--case-id",
+            "redraw_cli",
+            "--human-accept",
+            "true",
+            "--failure-type",
+            "texture_leak",
+            "--preferred-action",
+            "adjust_instruction",
+            "--reviewer",
+            "bob",
+            "--reviewed-at",
+            "2026-05-05T13:00:00Z",
+            "--notes",
+            "localized but wrong texture",
+            "--output",
+            str(output_path),
+        ],
+        capture_output=True,
+        text=True,
+        timeout=10,
+        env=CLI_ENV,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "redraw_cli" in result.stdout
+    reviewed = [json.loads(line) for line in output_path.read_text().splitlines()]
+    assert reviewed[0]["review"]["human_accept"] is True
+    assert reviewed[0]["review"]["failure_type"] == "texture_leak"
+    assert reviewed[0]["review"]["preferred_action"] == "adjust_instruction"


### PR DESCRIPTION
## Summary

- Adds `vulca.learning.case_review` for lightweight JSONL case labeling.
- Adds `vulca cases review INPUT.jsonl --case-id ...` to update review labels non-destructively.
- Supports full reviewed JSONL output plus optional review-only sidecar output.

## Validation

- `/opt/homebrew/bin/python3.11 -m pytest tests/test_case_review.py tests/test_redraw_cases.py tests/test_redraw_benchmark_manifest.py tests/test_cli_commands.py` -> `17 passed`
- `git diff --check codex/redraw-learning-base..HEAD` -> passed

## Stacking

Stacked on PR #44 / `codex/redraw-learning-base`. Keep draft until the base learning stack lands or retarget after merge.
