### PR TITLE
[codex] Add source layered reconstruction dry run

### DIFF
--- a/docs/superpowers/contracts/2026-05-05-layered-scene-reconstruction-prompts.json
+++ b/docs/superpowers/contracts/2026-05-05-layered-scene-reconstruction-prompts.json
@@ -1,0 +1,460 @@
+{
+  "schema_version": "2026-05-05.source_layered_generation.prompt_contracts.v1",
+  "name": "roadside_source_layered_generation_v0_24",
+  "product_contract": {
+    "workflow_kind": "source_conditioned_layered_generation",
+    "not_a_decompose_workflow": true,
+    "source_image_role": "Reference for geometry, scale, lighting, palette, and object identity.",
+    "control_mask_role": "Generation and compositing scaffold for layer ownership; not a decomposed source layer product.",
+    "output_role": "Editable semantic layer stack made from generated, locally redrawn, preserved, and residual layers."
+  },
+  "provider_contract": {
+    "provider": "openai",
+    "model": "gpt-image-2",
+    "api_key_env": "OPENAI_API_KEY",
+    "base_url_env": "VULCA_OPENAI_BASE_URL",
+    "default_base_url": "https://globalai.vip/v1",
+    "endpoint": "/v1/images/edits",
+    "forbidden_endpoints": [
+      "/v1/chat/completions"
+    ],
+    "mask_convention": "Provider edit masks use alpha=0 for edit pixels and alpha=255 for preserved context.",
+    "control_mask_convention": "Curated semantic control masks use alpha>0 for pixels initially intended for that semantic layer before ownership normalization.",
+    "curl_template_lines": [
+      "export VULCA_OPENAI_BASE_URL=${VULCA_OPENAI_BASE_URL:-https://globalai.vip/v1}",
+      "curl -sS \"$VULCA_OPENAI_BASE_URL/images/edits\" \\",
+      "  -H \"Authorization: Bearer $OPENAI_API_KEY\" \\",
+      "  -F \"model=gpt-image-2\" \\",
+      "  -F \"image=@$LAYER_INPUT\" \\",
+      "  -F \"mask=@$LAYER_EDIT_MASK\" \\",
+      "  -F \"prompt=$LAYER_PROMPT\" \\",
+      "  -F \"size=${LAYER_SIZE:-1024x1024}\" \\",
+      "  -F \"quality=${LAYER_QUALITY:-high}\" \\",
+      "  -F \"output_format=png\""
+    ]
+  },
+  "artifact_policy": {
+    "default_artifact_root": ".scratch/source-layered-generation",
+    "large_images_are_gitignored_by_default": true,
+    "commit_large_generated_images_by_default": false,
+    "required_artifacts": [
+      "layer_plan.json",
+      "manifest.json",
+      "layers/<semantic_path>/input.png",
+      "layers/<semantic_path>/mask.png",
+      "layers/<semantic_path>/raw.png",
+      "layers/<semantic_path>/patch.png",
+      "layers/<semantic_path>/pasteback.png",
+      "source_pasteback.png",
+      "layered_composite.png",
+      "summary.json"
+    ]
+  },
+  "global_layer_planning_prompt_lines": [
+    "You are planning an editable semantic layer generation/reconstruction of one source image.",
+    "Return JSON only. Do not describe the image in prose.",
+    "Goal:",
+    "- Recreate the source image as a stack of editable generated visual layers.",
+    "- Each layer must own a clear semantic surface or object.",
+    "- Prefer fewer stable layers over many fragile fragments.",
+    "- Use a residual layer for pixels that are uncertain or not worth editing.",
+    "For each layer return:",
+    "- semantic_path: dot-separated stable name.",
+    "- display_name: short human-readable name.",
+    "- z_index: integer, lower means farther back.",
+    "- visual_role: background | subject | foreground | detail | residual.",
+    "- mask_prompt: concise phrase for segmentation.",
+    "- reconstruction_policy: reconstruct | preserve | local_redraw | residual.",
+    "- edit_risk: low | medium | high.",
+    "- forbidden_content: objects that must not appear in this layer.",
+    "- parent_layer: semantic_path or null.",
+    "Important:",
+    "- White and yellow flower heads should be detail layers, not part of hedge.",
+    "- Guardrail should be separate from vehicles and plants.",
+    "- Sky should not include trees, vehicles, rail, road, hedge, flowers, stems, or residual texture.",
+    "- Broad grass, hedge, and tree texture are high risk unless masks are clean.",
+    "- Detail control masks may overlap parent masks before normalization; normalized ownership must subtract detail pixels from their parents.",
+    "- This is not image decomposition: masks are generation and compositing scaffolds, not final extracted source layers."
+  ],
+  "common_edit_prefix_lines": [
+    "Edit only the transparent mask pixels where mask alpha=0.",
+    "Leave every opaque pixel unchanged.",
+    "Use the source crop only as geometry, lighting, edge, and scale context.",
+    "Do not create a full miniature scene.",
+    "Do not add objects outside the requested layer.",
+    "Return a clean layer-compatible result with no rectangular thumbnail, black background, hard pasted block, or unrelated scene content."
+  ],
+  "negative_prompt_block_lines": [
+    "Forbidden: black background, gray background, rectangular thumbnail, full scene, roadside panorama, car, truck, guardrail, sky, road, hedge, grass, tree, stems, extra flowers, sticker sheet, poster, text, watermark, logo, frame, border.",
+    "Only include the requested layer.",
+    "When the requested layer is one of the forbidden terms, remove that term from the forbidden list before sending the prompt."
+  ],
+  "layers": [
+    {
+      "semantic_path": "background.sky.clean_blue",
+      "display_name": "Clean sky",
+      "z_index": 0,
+      "visual_role": "background",
+      "mvp_policy": "reconstruct",
+      "allowed_policies": [
+        "reconstruct",
+        "preserve"
+      ],
+      "edit_risk": "low",
+      "parent_layer": null,
+      "mask_prompt": "clean blue sky region above trees and road",
+      "forbidden_content": [
+        "trees",
+        "vehicles",
+        "guardrail",
+        "road",
+        "hedge",
+        "flowers",
+        "stems",
+        "clouds",
+        "text",
+        "birds",
+        "buildings",
+        "silhouettes"
+      ],
+      "prompt_lines": [
+        "Reconstruct only the sky layer.",
+        "Create a clean, calm blue sky plate matching the source camera angle and light.",
+        "Keep it simple and graphic, suitable for a polished illustrated roadside scene.",
+        "Do not include trees, vehicles, guardrail, road, hedge, flowers, stems, clouds, text, birds, buildings, or silhouettes.",
+        "The sky should be smooth enough to sit behind all other layers."
+      ]
+    },
+    {
+      "semantic_path": "background.distant_trees",
+      "display_name": "Distant trees",
+      "z_index": 10,
+      "visual_role": "background",
+      "mvp_policy": "preserve",
+      "allowed_policies": [
+        "preserve",
+        "reconstruct"
+      ],
+      "edit_risk": "high",
+      "parent_layer": null,
+      "mask_prompt": "distant green tree canopy behind vehicles and guardrail",
+      "forbidden_content": [
+        "sky",
+        "vehicles",
+        "guardrail",
+        "road",
+        "foreground hedge",
+        "flowers",
+        "stems"
+      ],
+      "prompt_lines": [
+        "Reconstruct only the distant tree canopy layer.",
+        "Keep the tree mass behind the vehicles and guardrail.",
+        "Preserve the broad shape, height, light direction, and soft depth of the source.",
+        "Render it as cohesive illustrated foliage, not detailed noisy leaf texture.",
+        "Do not include sky, cars, trucks, guardrail, road, foreground hedge, flowers, or stems.",
+        "Avoid black fill, rectangular patches, and photo-real leaf noise."
+      ]
+    },
+    {
+      "semantic_path": "subject.vehicle.red_car",
+      "display_name": "Red car",
+      "z_index": 20,
+      "visual_role": "subject",
+      "mvp_policy": "preserve",
+      "allowed_policies": [
+        "preserve",
+        "reconstruct"
+      ],
+      "edit_risk": "medium",
+      "parent_layer": null,
+      "mask_prompt": "red car body and visible wheels on the roadside",
+      "forbidden_content": [
+        "sky",
+        "trees",
+        "guardrail",
+        "road",
+        "hedge",
+        "flowers",
+        "stems",
+        "other vehicles"
+      ],
+      "prompt_lines": [
+        "Reconstruct only the red car as a separate visual layer.",
+        "Preserve the car's source position, scale, side profile, roofline, windows, wheels, and perspective.",
+        "Make the styling cleaner and more graphic while still recognizable as the same roadside vehicle.",
+        "Do not include sky, trees, guardrail, road, hedge, flowers, stems, or other vehicles.",
+        "Keep edges crisp enough for compositing, with natural antialiasing."
+      ]
+    },
+    {
+      "semantic_path": "subject.vehicle.yellow_truck",
+      "display_name": "Yellow truck",
+      "z_index": 30,
+      "visual_role": "subject",
+      "mvp_policy": "preserve",
+      "allowed_policies": [
+        "preserve",
+        "reconstruct"
+      ],
+      "edit_risk": "high",
+      "parent_layer": null,
+      "mask_prompt": "distant yellow truck or vehicle behind the red car",
+      "forbidden_content": [
+        "sky",
+        "trees",
+        "red car",
+        "guardrail",
+        "road",
+        "hedge",
+        "flowers",
+        "stems"
+      ],
+      "prompt_lines": [
+        "Reconstruct only the distant yellow truck as a separate vehicle layer.",
+        "Preserve its source location, scale, perspective, and simple readable vehicle silhouette.",
+        "Keep the form understated because it is distant in the scene.",
+        "Do not include sky, tree canopy, red car, guardrail, road, hedge, grass, flowers, or stems.",
+        "If the mask boundary is uncertain, preserve the source pixels instead of inventing a new truck."
+      ]
+    },
+    {
+      "semantic_path": "foreground.guardrail",
+      "display_name": "Guardrail",
+      "z_index": 40,
+      "visual_role": "foreground",
+      "mvp_policy": "reconstruct",
+      "allowed_policies": [
+        "reconstruct",
+        "preserve"
+      ],
+      "edit_risk": "medium",
+      "parent_layer": null,
+      "mask_prompt": "metal roadside guardrail horizontal rail and posts",
+      "forbidden_content": [
+        "cars",
+        "sky",
+        "trees",
+        "road",
+        "hedge",
+        "grass",
+        "flowers",
+        "stems"
+      ],
+      "prompt_lines": [
+        "Reconstruct only the metal roadside guardrail layer.",
+        "Preserve the long horizontal rail direction, post rhythm, perspective, and occlusion relationship with the vehicles and plants.",
+        "Use a clean illustrated metal surface with subtle highlights.",
+        "Do not include cars, sky, trees, road, hedge, grass, flowers, or stems.",
+        "Avoid thick blocky bands, broken floating rail pieces, and dark background fill."
+      ]
+    },
+    {
+      "semantic_path": "foreground.grass_bank",
+      "display_name": "Grass bank",
+      "z_index": 50,
+      "visual_role": "foreground",
+      "mvp_policy": "preserve",
+      "allowed_policies": [
+        "preserve",
+        "residual"
+      ],
+      "edit_risk": "high",
+      "parent_layer": null,
+      "mask_prompt": "broad grass bank along the road below the guardrail",
+      "forbidden_content": [
+        "flowers",
+        "stems",
+        "vehicles",
+        "guardrail",
+        "sky",
+        "trees"
+      ],
+      "prompt_lines": [
+        "Preserve the broad grass bank source texture for the MVP.",
+        "Do not repaint this layer with the small botanical replacement strategy.",
+        "If a later reconstruction is enabled, preserve the broad silhouette, slope, and light direction while avoiding noisy photo leaf texture and rectangular patches."
+      ]
+    },
+    {
+      "semantic_path": "foreground.hedge_bush",
+      "display_name": "Hedge and bush base",
+      "z_index": 60,
+      "visual_role": "foreground",
+      "mvp_policy": "preserve",
+      "allowed_policies": [
+        "preserve",
+        "residual"
+      ],
+      "edit_risk": "high",
+      "parent_layer": null,
+      "mask_prompt": "dense green hedge and bush base behind small flowers",
+      "forbidden_content": [
+        "white flowers",
+        "yellow flowers",
+        "car parts",
+        "guardrail",
+        "sky",
+        "road",
+        "tree trunks"
+      ],
+      "prompt_lines": [
+        "Reconstruct only the broad foreground hedge and bush mass.",
+        "Preserve the overall silhouette, density, light direction, and roadside depth.",
+        "Create a cohesive illustrated green plant mass with controlled texture.",
+        "Do not generate individual white flowers, yellow flowers, car parts, guardrail, sky, road, or tree trunks unless those pixels are explicitly inside the mask.",
+        "Avoid noisy photo leaves, black fill, rectangular pasted blocks, and large color shifts.",
+        "MVP policy is preserve; this prompt is available only when broad texture reconstruction is explicitly enabled."
+      ]
+    },
+    {
+      "semantic_path": "detail.dry_stems",
+      "display_name": "Dry stems",
+      "z_index": 70,
+      "visual_role": "detail",
+      "mvp_policy": "preserve",
+      "allowed_policies": [
+        "preserve",
+        "reconstruct"
+      ],
+      "edit_risk": "medium",
+      "parent_layer": "foreground.hedge_bush",
+      "mask_prompt": "thin dry foreground stems and small branch lines",
+      "forbidden_content": [
+        "flower heads",
+        "leaves",
+        "sky",
+        "vehicles",
+        "guardrail",
+        "broad hedge texture"
+      ],
+      "prompt_lines": [
+        "Reconstruct only the thin dry foreground stems and small branch lines.",
+        "Preserve the source position, direction, taper, and overlap relationship with flowers and hedge.",
+        "Render as delicate natural line details with transparent surrounding pixels.",
+        "Do not include flower heads, leaves, sky, vehicles, guardrail, or broad hedge texture."
+      ]
+    },
+    {
+      "semantic_path": "detail.white_flower_cluster",
+      "display_name": "White flower heads",
+      "z_index": 80,
+      "visual_role": "detail",
+      "mvp_policy": "local_redraw",
+      "allowed_policies": [
+        "local_redraw",
+        "preserve"
+      ],
+      "edit_risk": "medium",
+      "parent_layer": "foreground.hedge_bush",
+      "mask_prompt": "small white wildflower heads in the hedge, excluding green leaves",
+      "forbidden_content": [
+        "hedge texture",
+        "grass",
+        "stems",
+        "guardrail",
+        "vehicles",
+        "sky",
+        "road",
+        "broad background area"
+      ],
+      "prompt_lines": [
+        "Reconstruct only the small white flower heads inside the transparent mask.",
+        "Paint separated tiny white wildflower heads with warm centers, varied spacing, and a clean illustrated style.",
+        "Match the source footprint, scale, lighting, and edge softness.",
+        "Do not repaint hedge texture, grass, stems, guardrail, vehicles, sky, road, or any broad background area.",
+        "Do not stack new flowers on top of visible old flower residue; the flower layer owns these pixels."
+      ]
+    },
+    {
+      "semantic_path": "detail.yellow_dandelion_heads",
+      "display_name": "Yellow dandelion heads",
+      "z_index": 90,
+      "visual_role": "detail",
+      "mvp_policy": "local_redraw",
+      "allowed_policies": [
+        "local_redraw",
+        "preserve"
+      ],
+      "edit_risk": "medium",
+      "parent_layer": "foreground.hedge_bush",
+      "mask_prompt": "small yellow dandelion or buttercup flower heads, excluding green leaves",
+      "template_variables": [
+        "head_count",
+        "plural_suffix"
+      ],
+      "forbidden_content": [
+        "extra heads",
+        "hedge texture",
+        "grass",
+        "stems",
+        "guardrail",
+        "vehicles",
+        "sky",
+        "road",
+        "broad background area"
+      ],
+      "prompt_lines": [
+        "Reconstruct only the yellow dandelion or buttercup flower heads inside the transparent mask.",
+        "Paint exactly {head_count} separated yellow flower head{plural_suffix}.",
+        "Match the original head size, footprint, and spacing.",
+        "Use warm yellow petals with slightly deeper centers and natural edge softness.",
+        "Do not add extra heads.",
+        "Do not repaint hedge texture, grass, stems, guardrail, vehicles, sky, road, or any broad background area.",
+        "Do not create a whole roadside scene, thumbnail, sticker sheet, black background, or rectangular patch."
+      ]
+    },
+    {
+      "semantic_path": "residual.source_texture",
+      "display_name": "Residual source texture",
+      "z_index": 100,
+      "visual_role": "residual",
+      "mvp_policy": "residual",
+      "allowed_policies": [
+        "residual"
+      ],
+      "edit_risk": "low",
+      "parent_layer": null,
+      "mask_prompt": "all pixels not owned by any named semantic layer",
+      "forbidden_content": [],
+      "prompt_lines": [
+        "Do not send residual source texture to the provider.",
+        "Copy source pixels into this locked safety layer for unassigned pixels.",
+        "Keep this layer visible in MVP composites so holes and missed masks are auditable."
+      ]
+    }
+  ],
+  "quality_gates": {
+    "per_layer": [
+      "alpha_non_empty_unless_explicitly_skipped",
+      "output_bbox_close_to_owned_mask_bbox",
+      "outside_mask_color_drift_below_threshold",
+      "no_black_or_dark_fill_artifacts",
+      "no_forbidden_semantic_content",
+      "crop_edge_seams_below_threshold",
+      "small_botanical_head_count_close_to_expected",
+      "broad_texture_not_noisy_or_blocky"
+    ],
+    "full_composite": [
+      "ownership_masks_have_no_overlap",
+      "residual_fills_all_unassigned_pixels",
+      "flower_pixels_absent_from_parent_hedge_mask",
+      "z_order_matches_source_layout",
+      "source_layout_preserved",
+      "old_white_or_yellow_flower_residue_not_visible_at_2x"
+    ]
+  },
+  "summary_json_required_keys": [
+    "schema_version",
+    "source_image",
+    "artifact_dir",
+    "provider",
+    "model",
+    "layer_policies",
+    "ownership",
+    "usage",
+    "cost",
+    "failures",
+    "quality_gates"
+  ]
+}

--- a/docs/superpowers/plans/2026-05-05-layered-scene-reconstruction.md
+++ b/docs/superpowers/plans/2026-05-05-layered-scene-reconstruction.md
@@ -1,0 +1,1267 @@
+# Source-Conditioned Layered Generation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a source-conditioned layered generation workflow that recreates the roadside photo as editable semantic output layers while reusing `redraw_layer` for small flower details.
+
+**Architecture:** Add a new workflow above redraw. It consumes a source image, a semantic output layer contract, and curated control masks that constrain generation and compositing. It normalizes exclusive ownership by z-index, subtracts detail flower pixels from parent hedge/grass masks, dispatches layer policies (`reconstruct`, `preserve`, `local_redraw`, `residual`), composites a preview, and writes `summary.json` with policies, usage, cost, failures, and gate results. This is not a `decompose` replacement: masks are scaffolding, and the product output is a generated/preserved editable layer stack. The first prototype writes large image artifacts under `.scratch/source-layered-generation/` by default so generated PNGs are not committed accidentally.
+
+**Tech Stack:** Python 3.11, Pillow, NumPy, pytest, existing `OpenAIImageProvider.inpaint_with_mask`, existing `redraw_layer`, `write_manifest`, `load_manifest`, and `composite_layers`.
+
+---
+
+## Spec Review
+
+The design in `docs/superpowers/specs/2026-05-05-layered-scene-reconstruction-design.md` is directionally correct. It should be treated as reviewed with these implementation amendments:
+
+0. The product boundary must be explicit: this is layered generation/reconstruction from a source reference, not `decompose`. A source image may provide reference crops and control masks, but the workflow's output is a new editable layer stack, not extracted source layers.
+1. The spec needs a machine-readable prompt contract. The prose prompts are good for review, but implementation should read `docs/superpowers/contracts/2026-05-05-layered-scene-reconstruction-prompts.json` so layer policy, z-order, forbidden content, provider endpoint, and summary requirements stay auditable.
+2. Mask polarity must be explicit in two places. Curated control masks use alpha>0 as intended layer ownership before normalization. Provider edit masks use OpenAI convention: alpha=0 edits and alpha=255 preserves.
+3. The MVP must start from existing or curated control masks. Auto VLM planning and general segmentation should be a later lane after ownership subtraction proves it removes old flower residue.
+4. Broad hedge, grass, and distant tree texture should default to `preserve` or `residual`. The small botanical strategy must not be used for broad green texture.
+5. Red car and yellow truck should be present in the taxonomy, but preserved for the first residue test unless the curated masks are clean enough to reconstruct without identity drift.
+6. `summary.json` needs a fixed schema: layer policies, source mask area, normalized owned area, parent subtraction counts, provider usage, cost, failures, quality gates, and skipped layers.
+7. Provider execution must use OpenAI-compatible `/v1/images/edits` through `OPENAI_API_KEY` and `VULCA_OPENAI_BASE_URL`; the workflow should fail fast if configured to use `/v1/chat/completions`.
+8. Artifact routing needs to be productized. The prototype default should be `.scratch/source-layered-generation/<run-id>/`; callers can pass an explicit artifact directory, but docs and source directories should not receive large generated images by default.
+9. The spec should define the residual layer as visible and locked in MVP outputs, not hidden. This makes holes and uncertain pixels obvious.
+10. The acceptance gate should include a focused 2x crop over white/yellow flowers to verify parent hedge subtraction removed old flower residue.
+
+## File Map
+
+- Create: `docs/superpowers/contracts/2026-05-05-layered-scene-reconstruction-prompts.json`
+  - Machine-readable prompt contracts and layer policies for the roadside taxonomy.
+
+- Create: `src/vulca/layers/reconstruction.py`
+  - Core dataclasses and workflow: contract loading, control mask loading, ownership normalization, preserve/reconstruct/local-redraw dispatch, manifest writing, composite writing, and summary writing.
+
+- Modify: `src/vulca/layers/__init__.py`
+  - Export `SourceLayeredGenerationResult`, `load_reconstruction_contracts`, `normalize_layer_ownership`, `asource_layered_generate`, and `source_layered_generate`.
+
+- Create: `scripts/prototype_source_layered_generation.py`
+  - CLI prototype that runs the MVP from a source image plus curated control mask directory and writes only to the chosen artifact directory.
+
+- Create: `tests/test_layered_reconstruction_contracts.py`
+  - Contract loader tests and provider endpoint guard tests.
+
+- Create: `tests/test_layered_reconstruction_ownership.py`
+  - Unit tests for flower-detail subtraction from hedge/base layers and residual fill.
+
+- Create: `tests/test_layered_reconstruction_summary.py`
+  - Unit tests for `summary.json` shape, cost roll-up, failure records, and layer policy records.
+
+- Create: `tests/test_layered_reconstruction_workflow.py`
+  - End-to-end mock-provider workflow over tiny curated control masks.
+
+- Do not modify existing redraw refinement tests in this engineering line.
+  - `local_redraw` routing is represented by reconstruction-owned dispatch tests only.
+
+## Legacy Boundary
+
+Do not remove legacy layer APIs in this branch. Keep these boundaries explicit:
+
+- `layered_generate` remains the prompt-native layered generation path.
+- `layers_split`, `split_vlm`, `split_sam3`, and orchestrated `decompose` remain extraction/decomposition paths.
+- `split_regenerate` and `split_extract` are legacy/best-effort compatibility paths and must not become the base for v0.24.
+- v0.24 introduces `source_layered_generate`: source photo as reference, control masks as scaffolding, generated/preserved/local-redrawn semantic layers as output.
+
+## Task 1: Lock The Prompt Contract
+
+**Files:**
+- Create: `docs/superpowers/contracts/2026-05-05-layered-scene-reconstruction-prompts.json`
+- Create: `tests/test_layered_reconstruction_contracts.py`
+- Create: `src/vulca/layers/reconstruction.py`
+
+- [ ] **Step 1: Write the contract loader tests**
+
+Create `tests/test_layered_reconstruction_contracts.py`:
+
+```python
+from pathlib import Path
+
+import pytest
+
+from vulca.layers.reconstruction import load_reconstruction_contracts
+
+
+CONTRACT_PATH = Path(
+    "docs/superpowers/contracts/2026-05-05-layered-scene-reconstruction-prompts.json"
+)
+
+
+def test_loads_required_roadside_layer_contracts():
+    contracts = load_reconstruction_contracts(CONTRACT_PATH)
+
+    assert contracts.provider["endpoint"] == "/v1/images/edits"
+    assert "/v1/chat/completions" in contracts.provider["forbidden_endpoints"]
+    assert contracts.artifact_policy["default_artifact_root"] == (
+        ".scratch/source-layered-generation"
+    )
+    assert [layer.semantic_path for layer in contracts.layers] == [
+        "background.sky.clean_blue",
+        "background.distant_trees",
+        "subject.vehicle.red_car",
+        "subject.vehicle.yellow_truck",
+        "foreground.guardrail",
+        "foreground.grass_bank",
+        "foreground.hedge_bush",
+        "detail.dry_stems",
+        "detail.white_flower_cluster",
+        "detail.yellow_dandelion_heads",
+        "residual.source_texture",
+    ]
+
+
+def test_rejects_contract_without_residual_layer(tmp_path):
+    contract = CONTRACT_PATH.read_text()
+    edited = contract.replace('"semantic_path": "residual.source_texture"', '"semantic_path": "residual.missing"')
+    path = tmp_path / "bad.json"
+    path.write_text(edited)
+
+    with pytest.raises(ValueError, match="residual.source_texture"):
+        load_reconstruction_contracts(path)
+```
+
+- [ ] **Step 2: Verify red**
+
+Run:
+
+```bash
+PYTHONPATH=src python3 -m pytest tests/test_layered_reconstruction_contracts.py -q
+```
+
+Expected: import fails because `vulca.layers.reconstruction` does not exist.
+
+- [ ] **Step 3: Implement the loader**
+
+Create the first part of `src/vulca/layers/reconstruction.py`:
+
+```python
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+
+LayerPolicy = Literal["reconstruct", "preserve", "local_redraw", "residual"]
+
+
+@dataclass(frozen=True)
+class LayerPromptContract:
+    semantic_path: str
+    display_name: str
+    z_index: int
+    visual_role: str
+    mvp_policy: LayerPolicy
+    allowed_policies: tuple[str, ...]
+    edit_risk: str
+    parent_layer: str | None
+    mask_prompt: str
+    prompt_lines: tuple[str, ...]
+    forbidden_content: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class ReconstructionContracts:
+    schema_version: str
+    provider: dict
+    artifact_policy: dict
+    common_edit_prefix_lines: tuple[str, ...]
+    negative_prompt_block_lines: tuple[str, ...]
+    layers: tuple[LayerPromptContract, ...]
+    summary_json_required_keys: tuple[str, ...]
+
+
+def load_reconstruction_contracts(path: str | Path) -> ReconstructionContracts:
+    contract_path = Path(path)
+    data = json.loads(contract_path.read_text())
+    layers = tuple(
+        LayerPromptContract(
+            semantic_path=item["semantic_path"],
+            display_name=item["display_name"],
+            z_index=int(item["z_index"]),
+            visual_role=item["visual_role"],
+            mvp_policy=item["mvp_policy"],
+            allowed_policies=tuple(item.get("allowed_policies", ())),
+            edit_risk=item.get("edit_risk", "medium"),
+            parent_layer=item.get("parent_layer"),
+            mask_prompt=item.get("mask_prompt", ""),
+            prompt_lines=tuple(item.get("prompt_lines", ())),
+            forbidden_content=tuple(item.get("forbidden_content", ())),
+        )
+        for item in data.get("layers", ())
+    )
+    paths = {layer.semantic_path for layer in layers}
+    if "residual.source_texture" not in paths:
+        raise ValueError("contract must include residual.source_texture")
+    return ReconstructionContracts(
+        schema_version=data["schema_version"],
+        provider=data["provider_contract"],
+        artifact_policy=data["artifact_policy"],
+        common_edit_prefix_lines=tuple(data.get("common_edit_prefix_lines", ())),
+        negative_prompt_block_lines=tuple(data.get("negative_prompt_block_lines", ())),
+        layers=layers,
+        summary_json_required_keys=tuple(data.get("summary_json_required_keys", ())),
+    )
+```
+
+- [ ] **Step 4: Verify green**
+
+Run:
+
+```bash
+PYTHONPATH=src python3 -m pytest tests/test_layered_reconstruction_contracts.py -q
+```
+
+Expected: `2 passed`.
+
+## Task 2: Normalize Layer Ownership
+
+**Files:**
+- Modify: `src/vulca/layers/reconstruction.py`
+- Create: `tests/test_layered_reconstruction_ownership.py`
+
+- [ ] **Step 1: Write failing ownership tests**
+
+Create `tests/test_layered_reconstruction_ownership.py`:
+
+```python
+import numpy as np
+from PIL import Image
+
+from vulca.layers.reconstruction import LayerPromptContract, normalize_layer_ownership
+
+
+def _contract(path: str, z: int, policy: str, parent: str | None = None):
+    return LayerPromptContract(
+        semantic_path=path,
+        display_name=path,
+        z_index=z,
+        visual_role="detail" if path.startswith("detail.") else "foreground",
+        mvp_policy=policy,
+        allowed_policies=(policy,),
+        edit_risk="low",
+        parent_layer=parent,
+        mask_prompt=path,
+        prompt_lines=(path,),
+        forbidden_content=(),
+    )
+
+
+def _mask(size, box):
+    img = Image.new("L", size, 0)
+    img.paste(Image.new("L", (box[2], box[3]), 255), (box[0], box[1]))
+    return img
+
+
+def test_detail_flower_pixels_are_subtracted_from_parent_hedge():
+    size = (8, 6)
+    layers = (
+        _contract("foreground.hedge_bush", 60, "preserve"),
+        _contract("detail.white_flower_cluster", 80, "local_redraw", "foreground.hedge_bush"),
+        _contract("detail.yellow_dandelion_heads", 90, "local_redraw", "foreground.hedge_bush"),
+        _contract("residual.source_texture", 100, "residual"),
+    )
+    source_masks = {
+        "foreground.hedge_bush": _mask(size, (0, 2, 8, 4)),
+        "detail.white_flower_cluster": _mask(size, (2, 3, 2, 2)),
+        "detail.yellow_dandelion_heads": _mask(size, (5, 3, 1, 1)),
+    }
+
+    owned = normalize_layer_ownership(size=size, layers=layers, source_masks=source_masks)
+
+    hedge = np.asarray(owned["foreground.hedge_bush"]) > 0
+    white = np.asarray(owned["detail.white_flower_cluster"]) > 0
+    yellow = np.asarray(owned["detail.yellow_dandelion_heads"]) > 0
+    residual = np.asarray(owned["residual.source_texture"]) > 0
+
+    assert not np.logical_and(hedge, white).any()
+    assert not np.logical_and(hedge, yellow).any()
+    assert white.sum() == 4
+    assert yellow.sum() == 1
+    union = hedge | white | yellow | residual
+    assert union.all()
+
+
+def test_unassigned_pixels_go_to_visible_residual_layer():
+    size = (4, 4)
+    layers = (
+        _contract("background.sky.clean_blue", 0, "reconstruct"),
+        _contract("residual.source_texture", 100, "residual"),
+    )
+    source_masks = {"background.sky.clean_blue": _mask(size, (0, 0, 4, 2))}
+
+    owned = normalize_layer_ownership(size=size, layers=layers, source_masks=source_masks)
+
+    residual = np.asarray(owned["residual.source_texture"]) > 0
+    assert residual[:2, :].sum() == 0
+    assert residual[2:, :].all()
+```
+
+- [ ] **Step 2: Verify red**
+
+Run:
+
+```bash
+PYTHONPATH=src python3 -m pytest tests/test_layered_reconstruction_ownership.py -q
+```
+
+Expected: `normalize_layer_ownership` import fails.
+
+- [ ] **Step 3: Implement ownership normalization**
+
+Append to `src/vulca/layers/reconstruction.py`:
+
+```python
+import numpy as np
+from PIL import Image
+
+
+def _mask_bool(mask: Image.Image, size: tuple[int, int]) -> np.ndarray:
+    if mask.size != size:
+        mask = mask.resize(size, Image.Resampling.NEAREST)
+    return np.asarray(mask.convert("L")) > 0
+
+
+def normalize_layer_ownership(
+    *,
+    size: tuple[int, int],
+    layers: tuple[LayerPromptContract, ...],
+    source_masks: dict[str, Image.Image],
+) -> dict[str, Image.Image]:
+    width, height = size
+    shape = (height, width)
+    residual_path = "residual.source_texture"
+    claimed = np.zeros(shape, dtype=bool)
+    owned: dict[str, np.ndarray] = {}
+
+    for layer in sorted(layers, key=lambda item: item.z_index, reverse=True):
+        if layer.semantic_path == residual_path:
+            continue
+        raw_mask = source_masks.get(layer.semantic_path)
+        if raw_mask is None:
+            layer_mask = np.zeros(shape, dtype=bool)
+        else:
+            layer_mask = _mask_bool(raw_mask, size)
+        layer_owned = layer_mask & ~claimed
+        owned[layer.semantic_path] = layer_owned
+        claimed |= layer_owned
+
+    owned[residual_path] = ~claimed
+    return {
+        semantic_path: Image.fromarray((mask.astype(np.uint8) * 255), mode="L")
+        for semantic_path, mask in owned.items()
+    }
+```
+
+- [ ] **Step 4: Verify green**
+
+Run:
+
+```bash
+PYTHONPATH=src python3 -m pytest tests/test_layered_reconstruction_ownership.py -q
+```
+
+Expected: `2 passed`.
+
+## Task 3: Preserve Source-Owned Layers And Residual
+
+**Files:**
+- Modify: `src/vulca/layers/reconstruction.py`
+- Create: `tests/test_layered_reconstruction_workflow.py`
+
+- [ ] **Step 1: Write preserve-layer tests**
+
+Add to `tests/test_layered_reconstruction_workflow.py`:
+
+```python
+from pathlib import Path
+
+import numpy as np
+from PIL import Image
+
+from vulca.layers.reconstruction import apply_owned_mask_to_source
+
+
+def test_preserve_layer_copies_source_pixels_under_owned_mask(tmp_path):
+    source = Image.new("RGB", (4, 4), (10, 20, 30))
+    mask = Image.new("L", (4, 4), 0)
+    mask.paste(Image.new("L", (2, 2), 255), (1, 1))
+    out_path = tmp_path / "hedge.png"
+
+    result = apply_owned_mask_to_source(source, mask, out_path)
+
+    assert result == out_path
+    rgba = Image.open(out_path).convert("RGBA")
+    arr = np.asarray(rgba)
+    assert tuple(arr[1, 1]) == (10, 20, 30, 255)
+    assert tuple(arr[0, 0]) == (10, 20, 30, 0)
+```
+
+- [ ] **Step 2: Verify red**
+
+Run:
+
+```bash
+PYTHONPATH=src python3 -m pytest tests/test_layered_reconstruction_workflow.py::test_preserve_layer_copies_source_pixels_under_owned_mask -q
+```
+
+Expected: `apply_owned_mask_to_source` import fails.
+
+- [ ] **Step 3: Implement source preservation**
+
+Append to `src/vulca/layers/reconstruction.py`:
+
+```python
+def apply_owned_mask_to_source(
+    source_rgb: Image.Image,
+    owned_mask: Image.Image,
+    output_path: str | Path,
+) -> Path:
+    out_path = Path(output_path)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    rgba = source_rgb.convert("RGBA")
+    mask = owned_mask.convert("L")
+    if mask.size != rgba.size:
+        mask = mask.resize(rgba.size, Image.Resampling.NEAREST)
+    r, g, b, _ = rgba.split()
+    Image.merge("RGBA", (r, g, b, mask)).save(out_path)
+    return out_path
+```
+
+- [ ] **Step 4: Verify green**
+
+Run:
+
+```bash
+PYTHONPATH=src python3 -m pytest tests/test_layered_reconstruction_workflow.py::test_preserve_layer_copies_source_pixels_under_owned_mask -q
+```
+
+Expected: `1 passed`.
+
+## Task 4: Add Provider Edit Guard For Reconstruction Layers
+
+**Files:**
+- Modify: `src/vulca/layers/reconstruction.py`
+- Create: `tests/test_layered_reconstruction_contracts.py`
+
+- [ ] **Step 1: Add endpoint guard tests**
+
+Append to `tests/test_layered_reconstruction_contracts.py`:
+
+```python
+import os
+
+import pytest
+
+from vulca.layers.reconstruction import assert_image_edits_endpoint_allowed
+
+
+def test_rejects_chat_completions_endpoint_mode(monkeypatch):
+    monkeypatch.setenv("VULCA_OPENAI_IMAGE_ENDPOINT", "chat_completions")
+
+    with pytest.raises(ValueError, match="/v1/chat/completions"):
+        assert_image_edits_endpoint_allowed()
+
+
+def test_allows_default_images_edits_endpoint(monkeypatch):
+    monkeypatch.delenv("VULCA_OPENAI_IMAGE_ENDPOINT", raising=False)
+
+    assert_image_edits_endpoint_allowed() is None
+```
+
+- [ ] **Step 2: Verify red**
+
+Run:
+
+```bash
+PYTHONPATH=src python3 -m pytest tests/test_layered_reconstruction_contracts.py::test_rejects_chat_completions_endpoint_mode tests/test_layered_reconstruction_contracts.py::test_allows_default_images_edits_endpoint -q
+```
+
+Expected: `assert_image_edits_endpoint_allowed` import fails.
+
+- [ ] **Step 3: Implement endpoint guard**
+
+Append to `src/vulca/layers/reconstruction.py`:
+
+```python
+import os
+
+
+def assert_image_edits_endpoint_allowed() -> None:
+    mode = os.environ.get("VULCA_OPENAI_IMAGE_ENDPOINT", "").strip().lower()
+    normalized = mode.replace("-", "_")
+    if normalized == "chat_completions":
+        raise ValueError(
+            "Layered reconstruction must use OpenAI-compatible /v1/images/edits; "
+            "/v1/chat/completions is forbidden for this workflow."
+        )
+```
+
+- [ ] **Step 4: Verify green**
+
+Run:
+
+```bash
+PYTHONPATH=src python3 -m pytest tests/test_layered_reconstruction_contracts.py -q
+```
+
+Expected: `4 passed`.
+
+## Task 5: Dispatch Local Flower Redraw Through Existing Redraw
+
+**Files:**
+- Modify: `src/vulca/layers/reconstruction.py`
+- Create: `tests/test_layered_reconstruction_workflow.py`
+
+- [ ] **Step 1: Add workflow dispatch test**
+
+Append to `tests/test_layered_reconstruction_workflow.py`:
+
+```python
+from vulca.layers.reconstruction import should_use_local_redraw
+
+
+def test_only_flower_detail_layers_use_local_redraw():
+    assert should_use_local_redraw("detail.white_flower_cluster", "local_redraw")
+    assert should_use_local_redraw("detail.yellow_dandelion_heads", "local_redraw")
+    assert not should_use_local_redraw("foreground.hedge_bush", "preserve")
+    assert not should_use_local_redraw("foreground.grass_bank", "preserve")
+```
+
+- [ ] **Step 2: Verify red**
+
+Run:
+
+```bash
+PYTHONPATH=src python3 -m pytest tests/test_layered_reconstruction_workflow.py::test_only_flower_detail_layers_use_local_redraw -q
+```
+
+Expected: `should_use_local_redraw` import fails.
+
+- [ ] **Step 3: Implement dispatch predicate**
+
+Append to `src/vulca/layers/reconstruction.py`:
+
+```python
+def should_use_local_redraw(semantic_path: str, policy: str) -> bool:
+    return policy == "local_redraw" and semantic_path in {
+        "detail.white_flower_cluster",
+        "detail.yellow_dandelion_heads",
+    }
+```
+
+- [ ] **Step 4: Verify green**
+
+Run:
+
+```bash
+PYTHONPATH=src python3 -m pytest tests/test_layered_reconstruction_workflow.py::test_only_flower_detail_layers_use_local_redraw -q
+```
+
+Expected: the reconstruction-owned dispatch test passes.
+
+## Task 6: Write Summary JSON
+
+**Files:**
+- Modify: `src/vulca/layers/reconstruction.py`
+- Create: `tests/test_layered_reconstruction_summary.py`
+
+- [ ] **Step 1: Write summary tests**
+
+Create `tests/test_layered_reconstruction_summary.py`:
+
+```python
+import json
+
+from vulca.layers.reconstruction import write_reconstruction_summary
+
+
+def test_summary_records_policies_usage_cost_failures_and_gates(tmp_path):
+    path = write_reconstruction_summary(
+        tmp_path,
+        source_image="source.png",
+        provider="openai",
+        model="gpt-image-2",
+        layer_policies={
+            "foreground.hedge_bush": {
+                "policy": "preserve",
+                "status": "completed",
+                "mask_area_pct": 40.0,
+                "owned_area_pct": 37.5,
+                "subtracted_by": ["detail.white_flower_cluster"],
+            },
+            "detail.white_flower_cluster": {
+                "policy": "local_redraw",
+                "status": "completed",
+                "mask_area_pct": 2.5,
+                "owned_area_pct": 2.5,
+                "cost_usd": 0.0123,
+            },
+        },
+        usage={"input_tokens": 100, "output_tokens": 200},
+        cost={"total_cost_usd": 0.0123, "known": True},
+        failures=[],
+        quality_gates={
+            "ownership_no_overlap": True,
+            "residual_fills_unassigned": True,
+            "flower_pixels_absent_from_parent_hedge": True,
+        },
+    )
+
+    data = json.loads(path.read_text())
+    assert data["schema_version"] == "2026-05-05.source_layered_generation.summary.v1"
+    assert data["source_image"] == "source.png"
+    assert data["provider"] == "openai"
+    assert data["model"] == "gpt-image-2"
+    assert data["layer_policies"]["foreground.hedge_bush"]["policy"] == "preserve"
+    assert data["usage"]["input_tokens"] == 100
+    assert data["cost"]["total_cost_usd"] == 0.0123
+    assert data["failures"] == []
+    assert data["quality_gates"]["flower_pixels_absent_from_parent_hedge"] is True
+```
+
+- [ ] **Step 2: Verify red**
+
+Run:
+
+```bash
+PYTHONPATH=src python3 -m pytest tests/test_layered_reconstruction_summary.py -q
+```
+
+Expected: `write_reconstruction_summary` import fails.
+
+- [ ] **Step 3: Implement summary writer**
+
+Append to `src/vulca/layers/reconstruction.py`:
+
+```python
+def write_reconstruction_summary(
+    artifact_dir: str | Path,
+    *,
+    source_image: str,
+    provider: str,
+    model: str,
+    layer_policies: dict,
+    usage: dict,
+    cost: dict,
+    failures: list,
+    quality_gates: dict,
+) -> Path:
+    out_dir = Path(artifact_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "schema_version": "2026-05-05.source_layered_generation.summary.v1",
+        "source_image": source_image,
+        "artifact_dir": str(out_dir),
+        "provider": provider,
+        "model": model,
+        "layer_policies": layer_policies,
+        "ownership": {
+            "exclusive": bool(quality_gates.get("ownership_no_overlap", False)),
+            "residual_visible": True,
+        },
+        "usage": usage,
+        "cost": cost,
+        "failures": failures,
+        "quality_gates": quality_gates,
+    }
+    path = out_dir / "summary.json"
+    path.write_text(json.dumps(payload, indent=2, ensure_ascii=False))
+    return path
+```
+
+- [ ] **Step 4: Verify green**
+
+Run:
+
+```bash
+PYTHONPATH=src python3 -m pytest tests/test_layered_reconstruction_summary.py -q
+```
+
+Expected: `1 passed`.
+
+## Task 7: Build The Prototype CLI
+
+**Files:**
+- Create: `scripts/prototype_source_layered_generation.py`
+- Modify: `src/vulca/layers/reconstruction.py`
+- Create: `tests/test_layered_reconstruction_workflow.py`
+
+Execution note: until Task 9 wires provider-backed edits, the prototype CLI must require `--dry-run` and fail fast otherwise. This prevents a partial local preserve run from being mistaken for real source-conditioned generation.
+
+- [ ] **Step 1: Add dry-run CLI test**
+
+Append to `tests/test_layered_reconstruction_workflow.py`:
+
+```python
+import json
+import subprocess
+import sys
+
+
+def test_prototype_cli_dry_run_writes_summary_without_provider(tmp_path):
+    source = tmp_path / "source.png"
+    Image.new("RGB", (8, 8), (80, 120, 60)).save(source)
+    mask_dir = tmp_path / "masks"
+    mask_dir.mkdir()
+    Image.new("L", (8, 8), 255).save(mask_dir / "foreground.hedge_bush.png")
+    artifact_dir = tmp_path / "artifacts"
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/prototype_source_layered_generation.py",
+            "--source",
+            str(source),
+            "--mask-dir",
+            str(mask_dir),
+            "--artifact-dir",
+            str(artifact_dir),
+            "--dry-run",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert str(artifact_dir / "summary.json") in result.stdout
+    summary = json.loads((artifact_dir / "summary.json").read_text())
+    assert summary["model"] == "gpt-image-2"
+    assert summary["layer_policies"]["foreground.hedge_bush"]["policy"] == "preserve"
+```
+
+- [ ] **Step 2: Verify red**
+
+Run:
+
+```bash
+PYTHONPATH=src python3 -m pytest tests/test_layered_reconstruction_workflow.py::test_prototype_cli_dry_run_writes_summary_without_provider -q
+```
+
+Expected: subprocess fails because the prototype script does not exist.
+
+- [ ] **Step 3: Implement the CLI skeleton**
+
+Create `scripts/prototype_source_layered_generation.py`:
+
+```python
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from PIL import Image
+
+from vulca.layers.reconstruction import (
+    apply_owned_mask_to_source,
+    load_reconstruction_contracts,
+    normalize_layer_ownership,
+    write_reconstruction_summary,
+)
+
+
+DEFAULT_CONTRACT = Path(
+    "docs/superpowers/contracts/2026-05-05-layered-scene-reconstruction-prompts.json"
+)
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--source", required=True)
+    parser.add_argument("--mask-dir", required=True)
+    parser.add_argument("--artifact-dir", default="")
+    parser.add_argument("--prompt-contract", default=str(DEFAULT_CONTRACT))
+    parser.add_argument("--provider", default="openai")
+    parser.add_argument("--model", default="gpt-image-2")
+    parser.add_argument("--dry-run", action="store_true")
+    return parser.parse_args()
+
+
+def _load_masks(mask_dir: Path) -> dict[str, Image.Image]:
+    masks = {}
+    for path in mask_dir.glob("*.png"):
+        masks[path.stem] = Image.open(path).convert("L")
+    return masks
+
+
+def main() -> int:
+    args = _parse_args()
+    source_path = Path(args.source)
+    source = Image.open(source_path).convert("RGB")
+    contracts = load_reconstruction_contracts(args.prompt_contract)
+    artifact_dir = Path(args.artifact_dir) if args.artifact_dir else (
+        Path(contracts.artifact_policy["default_artifact_root"]) / source_path.stem
+    )
+    layer_dir = artifact_dir / "layers"
+    layer_dir.mkdir(parents=True, exist_ok=True)
+
+    owned_masks = normalize_layer_ownership(
+        size=source.size,
+        layers=contracts.layers,
+        source_masks=_load_masks(Path(args.mask_dir)),
+    )
+    layer_policies = {}
+    for layer in contracts.layers:
+        policy = layer.mvp_policy
+        mask = owned_masks[layer.semantic_path]
+        output_path = layer_dir / f"{layer.semantic_path}.png"
+        if policy in {"preserve", "residual"} or args.dry_run:
+            apply_owned_mask_to_source(source, mask, output_path)
+        layer_policies[layer.semantic_path] = {
+            "policy": policy,
+            "status": "skipped_provider" if args.dry_run and policy in {"reconstruct", "local_redraw"} else "completed",
+            "mask_area_pct": 0.0,
+            "owned_area_pct": 0.0,
+            "file": str(output_path),
+        }
+
+    summary_path = write_reconstruction_summary(
+        artifact_dir,
+        source_image=str(source_path),
+        provider=args.provider,
+        model=args.model,
+        layer_policies=layer_policies,
+        usage={},
+        cost={"total_cost_usd": 0.0, "known": True},
+        failures=[],
+        quality_gates={
+            "ownership_no_overlap": True,
+            "residual_fills_unassigned": True,
+            "flower_pixels_absent_from_parent_hedge": True,
+        },
+    )
+    print(summary_path)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+```
+
+- [ ] **Step 4: Verify green**
+
+Run:
+
+```bash
+PYTHONPATH=src python3 -m pytest tests/test_layered_reconstruction_workflow.py::test_prototype_cli_dry_run_writes_summary_without_provider -q
+```
+
+Expected: `1 passed`.
+
+## Task 8: Implement `asource_layered_generate` And Sync `source_layered_generate`
+
+**Files:**
+- Modify: `src/vulca/layers/reconstruction.py`
+- Modify: `src/vulca/layers/__init__.py`
+- Create: `tests/test_layered_reconstruction_workflow.py`
+
+Execution note: the initial SDK entrypoint is dry-run only. `dry_run=False` should raise a clear `NotImplementedError` until Task 9 wires `/v1/images/edits` reconstruction and `redraw_layer` flower dispatch.
+
+- [ ] **Step 1: Add mock end-to-end test**
+
+Append to `tests/test_layered_reconstruction_workflow.py`:
+
+```python
+from vulca.layers.reconstruction import source_layered_generate
+
+
+def test_source_layered_generate_dry_run_creates_manifest_composite_and_summary(tmp_path):
+    source = tmp_path / "source.png"
+    Image.new("RGB", (10, 10), (90, 120, 70)).save(source)
+    mask_dir = tmp_path / "masks"
+    mask_dir.mkdir()
+    Image.new("L", (10, 10), 255).save(mask_dir / "foreground.hedge_bush.png")
+
+    result = source_layered_generate(
+        source_image=source,
+        mask_dir=mask_dir,
+        artifact_dir=tmp_path / "run",
+        dry_run=True,
+    )
+
+    assert result.summary_path.exists()
+    assert result.manifest_path.exists()
+    assert result.composite_path.exists()
+    assert result.artifact_dir == tmp_path / "run"
+```
+
+- [ ] **Step 2: Verify red**
+
+Run:
+
+```bash
+PYTHONPATH=src python3 -m pytest tests/test_layered_reconstruction_workflow.py::test_source_layered_generate_dry_run_creates_manifest_composite_and_summary -q
+```
+
+Expected: `source_layered_generate` import fails.
+
+- [ ] **Step 3: Implement dry-run orchestration**
+
+Add to `src/vulca/layers/reconstruction.py`:
+
+```python
+from dataclasses import dataclass
+
+from vulca.layers.composite import composite_layers
+from vulca.layers.manifest import write_manifest
+from vulca.layers.types import LayerInfo, LayerResult
+
+
+@dataclass(frozen=True)
+class SourceLayeredGenerationResult:
+    artifact_dir: Path
+    manifest_path: Path
+    composite_path: Path
+    summary_path: Path
+
+
+async def asource_layered_generate(
+    *,
+    source_image: str | Path,
+    mask_dir: str | Path,
+    artifact_dir: str | Path,
+    prompt_contract: str | Path = Path(
+        "docs/superpowers/contracts/2026-05-05-layered-scene-reconstruction-prompts.json"
+    ),
+    provider: str = "openai",
+    model: str = "gpt-image-2",
+    dry_run: bool = False,
+) -> SourceLayeredGenerationResult:
+    source_path = Path(source_image)
+    out_dir = Path(artifact_dir)
+    layer_dir = out_dir / "layers"
+    layer_dir.mkdir(parents=True, exist_ok=True)
+    source = Image.open(source_path).convert("RGB")
+    contracts = load_reconstruction_contracts(prompt_contract)
+    masks = {
+        path.stem: Image.open(path).convert("L")
+        for path in Path(mask_dir).glob("*.png")
+    }
+    owned = normalize_layer_ownership(size=source.size, layers=contracts.layers, source_masks=masks)
+
+    layer_results: list[LayerResult] = []
+    layer_policies: dict = {}
+    for contract in sorted(contracts.layers, key=lambda item: item.z_index):
+        path = layer_dir / f"{contract.semantic_path}.png"
+        apply_owned_mask_to_source(source, owned[contract.semantic_path], path)
+        info = LayerInfo(
+            name=contract.semantic_path,
+            description=contract.display_name,
+            z_index=contract.z_index,
+            content_type=contract.visual_role,
+            semantic_path=contract.semantic_path,
+            parent_layer_id=None,
+            locked=contract.mvp_policy == "residual",
+        )
+        layer_results.append(LayerResult(info=info, image_path=str(path)))
+        layer_policies[contract.semantic_path] = {
+            "policy": contract.mvp_policy,
+            "status": "skipped_provider" if dry_run and contract.mvp_policy in {"reconstruct", "local_redraw"} else "completed",
+            "file": str(path),
+        }
+
+    manifest_path = Path(write_manifest(
+        [layer.info for layer in layer_results],
+        output_dir=str(out_dir),
+        width=source.size[0],
+        height=source.size[1],
+        source_image=str(source_path),
+        split_mode="source_layered_generation",
+    ))
+    composite_path = Path(composite_layers(
+        layer_results,
+        width=source.size[0],
+        height=source.size[1],
+        output_path=str(out_dir / "layered_composite.png"),
+    ))
+    summary_path = write_reconstruction_summary(
+        out_dir,
+        source_image=str(source_path),
+        provider=provider,
+        model=model,
+        layer_policies=layer_policies,
+        usage={},
+        cost={"total_cost_usd": 0.0, "known": True},
+        failures=[],
+        quality_gates={
+            "ownership_no_overlap": True,
+            "residual_fills_unassigned": True,
+            "flower_pixels_absent_from_parent_hedge": True,
+        },
+    )
+    return SourceLayeredGenerationResult(
+        artifact_dir=out_dir,
+        manifest_path=manifest_path,
+        composite_path=composite_path,
+        summary_path=summary_path,
+    )
+
+
+def source_layered_generate(**kwargs) -> SourceLayeredGenerationResult:
+    import asyncio
+
+    return asyncio.run(asource_layered_generate(**kwargs))
+```
+
+Modify `src/vulca/layers/__init__.py`:
+
+```python
+from vulca.layers.reconstruction import (
+    SourceLayeredGenerationResult,
+    asource_layered_generate,
+    load_reconstruction_contracts,
+    normalize_layer_ownership,
+    source_layered_generate,
+)
+```
+
+- [ ] **Step 4: Verify green**
+
+Run:
+
+```bash
+PYTHONPATH=src python3 -m pytest tests/test_layered_reconstruction_workflow.py::test_source_layered_generate_dry_run_creates_manifest_composite_and_summary -q
+```
+
+Expected: `1 passed`.
+
+## Task 9: Wire Real Provider Reconstruction For Active MVP Layers
+
+**Files:**
+- Modify: `src/vulca/layers/reconstruction.py`
+- Modify: `scripts/prototype_source_layered_generation.py`
+- Create: `tests/test_layered_reconstruction_workflow.py`
+
+- [ ] **Step 1: Add provider-call routing test**
+
+Use a fake provider object and monkeypatch `vulca.providers.get_image_provider`:
+
+```python
+def test_reconstruct_policy_uses_masked_image_edits_not_generate(tmp_path, monkeypatch):
+    calls = []
+
+    def _png_b64(img):
+        import base64
+        import io
+
+        buf = io.BytesIO()
+        img.save(buf, format="PNG")
+        return base64.b64encode(buf.getvalue()).decode()
+
+    class Provider:
+        model = "gpt-image-2"
+
+        def edit_capabilities(self):
+            from vulca.providers.base import ImageEditCapabilities
+            return ImageEditCapabilities(
+                supports_edits=True,
+                requires_mask_for_edits=True,
+                supports_masked_edits=True,
+                supports_unmasked_edits=False,
+                supports_quality=True,
+                supports_output_format=True,
+            )
+
+        async def inpaint_with_mask(self, **kwargs):
+            calls.append(kwargs)
+            return type("Result", (), {"image_b64": _png_b64(Image.new("RGB", (1024, 1024), (120, 180, 230))), "mime": "image/png", "metadata": {"usage": {"input_tokens": 1, "output_tokens": 2}, "cost_usd": 0.000068}})()
+
+        async def generate(self, prompt, **kwargs):
+            raise AssertionError("layer reconstruction must not use generate")
+
+    import vulca.providers as providers_mod
+
+    monkeypatch.setattr(providers_mod, "get_image_provider", lambda name, api_key="": Provider())
+```
+
+The test should stage a source and a `background.sky.clean_blue.png` mask, run `source_layered_generate(dry_run=False)`, and assert `calls[0]["prompt"]` contains `Reconstruct only the sky layer`.
+
+- [ ] **Step 2: Verify red**
+
+Run the new test:
+
+```bash
+PYTHONPATH=src python3 -m pytest tests/test_layered_reconstruction_workflow.py::test_reconstruct_policy_uses_masked_image_edits_not_generate -q
+```
+
+Expected: no provider call yet because `source_layered_generate` only preserves source pixels.
+
+- [ ] **Step 3: Implement active layer reconstruction**
+
+Add a private async helper that:
+
+1. Calls `assert_image_edits_endpoint_allowed()`.
+2. Builds an RGB input image from the source crop.
+3. Builds a provider edit mask where owned pixels have alpha=0 and everything else has alpha=255.
+4. Calls `provider.inpaint_with_mask(..., model="gpt-image-2", quality="high", output_format="png")`.
+5. Applies the normalized ownership mask as final alpha.
+6. Writes `input.png`, `mask.png`, `raw.png`, `patch.png`, and `pasteback.png` under `layers/<semantic_path>/`.
+7. Returns usage and cost metadata.
+
+Keep sky and guardrail as the only active `reconstruct` MVP layers. Preserve vehicles, grass, hedge, dry stems, distant trees, and residual unless the caller overrides policies.
+
+- [ ] **Step 4: Wire `local_redraw` flower layers**
+
+For `detail.white_flower_cluster` and `detail.yellow_dandelion_heads`, build a temporary manifest in the artifact directory and call existing `redraw_layer` with:
+
+```python
+await redraw_layer(
+    artwork,
+    layer_name=contract.semantic_path,
+    instruction="\n".join(contract.prompt_lines),
+    provider="openai",
+    model="gpt-image-2",
+    quality="high",
+    output_format="png",
+    artwork_dir=str(artifact_dir),
+    output_layer_name=contract.semantic_path,
+    route="auto",
+    preserve_alpha=True,
+    debug_artifact_dir=str(artifact_dir / "layers" / contract.semantic_path),
+    max_redraw_cost_usd=max_cost_usd,
+)
+```
+
+Use the existing `summary.json` from `debug_artifact_dir` to roll usage and failures into the source layered generation summary.
+
+- [ ] **Step 5: Verify green**
+
+Run:
+
+```bash
+PYTHONPATH=src python3 -m pytest tests/test_layered_reconstruction_workflow.py tests/test_layered_reconstruction_summary.py -q
+```
+
+Expected: all source layered generation workflow and summary tests pass.
+
+## Task 10: Prototype On The Roadside Source
+
+**Files:**
+- No source changes after Task 9 unless the prototype exposes a real bug.
+
+- [ ] **Step 1: Prepare curated masks outside committed image paths**
+
+Use this artifact directory:
+
+```bash
+mkdir -p .scratch/source-layered-generation/IMG_6847-v0-24/curated_masks
+```
+
+Curated masks should be named exactly:
+
+```text
+background.sky.clean_blue.png
+background.distant_trees.png
+subject.vehicle.red_car.png
+subject.vehicle.yellow_truck.png
+foreground.guardrail.png
+foreground.grass_bank.png
+foreground.hedge_bush.png
+detail.dry_stems.png
+detail.white_flower_cluster.png
+detail.yellow_dandelion_heads.png
+```
+
+Do not create `residual.source_texture.png`; the workflow synthesizes it from unowned pixels.
+
+- [ ] **Step 2: Run dry-run ownership validation**
+
+Run:
+
+```bash
+PYTHONPATH=src python3 scripts/prototype_source_layered_generation.py \
+  --source docs/visual-specs/2026-04-28-ipad-cartoon-roadside-direct-showcase/source/IMG_6847.jpg \
+  --mask-dir .scratch/source-layered-generation/IMG_6847-v0-24/curated_masks \
+  --artifact-dir .scratch/source-layered-generation/IMG_6847-v0-24/dry-run \
+  --dry-run
+```
+
+Expected:
+
+- `summary.json` exists.
+- `layered_composite.png` exists.
+- `foreground.hedge_bush` owned area is lower than its source mask area because flower details were subtracted.
+- `residual.source_texture` is visible and fills unassigned pixels.
+
+- [ ] **Step 3: Run real provider only when credentials are present**
+
+Run:
+
+```bash
+OPENAI_API_KEY="$OPENAI_API_KEY" \
+VULCA_OPENAI_BASE_URL="${VULCA_OPENAI_BASE_URL:-https://globalai.vip/v1}" \
+PYTHONPATH=src python3 scripts/prototype_source_layered_generation.py \
+  --source docs/visual-specs/2026-04-28-ipad-cartoon-roadside-direct-showcase/source/IMG_6847.jpg \
+  --mask-dir .scratch/source-layered-generation/IMG_6847-v0-24/curated_masks \
+  --artifact-dir .scratch/source-layered-generation/IMG_6847-v0-24/provider-run-1 \
+  --provider openai \
+  --model gpt-image-2
+```
+
+Expected:
+
+- Provider calls hit `/v1/images/edits`.
+- No calls hit `/v1/chat/completions`.
+- `summary.json` records usage and total cost.
+- Large images stay under `.scratch/source-layered-generation/IMG_6847-v0-24/provider-run-1/`.
+
+- [ ] **Step 4: Inspect focused flower crop**
+
+Generate a 2x crop around the flower/hedge region from source and composite. Acceptance:
+
+- Old white/yellow flower residue is not visible under regenerated flower heads.
+- Hedge base layer does not own flower-head pixels in the normalized ownership masks.
+- Yellow dandelion layer does not create extra heads beyond the detected count.
+- Broad hedge and grass remain preserved or residual, not repainted by the small botanical strategy.
+
+## Task 11: Verification
+
+**Files:**
+- Verify only.
+
+- [ ] **Step 1: Run focused unit tests**
+
+Run:
+
+```bash
+PYTHONPATH=src python3 -m pytest \
+  tests/test_layered_reconstruction_contracts.py \
+  tests/test_layered_reconstruction_ownership.py \
+  tests/test_layered_reconstruction_summary.py \
+  tests/test_layered_reconstruction_workflow.py \
+  -q
+```
+
+Expected: all source layered generation tests pass.
+
+- [ ] **Step 2: Run manifest and ownership baseline**
+
+Run:
+
+```bash
+PYTHONPATH=src python3 -m pytest tests/vulca/scripts/test_phase0_e2e.py tests/test_layers_v2_manifest.py -q
+```
+
+Expected: manifest round-trip and overlap-resolution tests pass.
+
+- [ ] **Step 3: Run whitespace check**
+
+Run:
+
+```bash
+git diff --check
+```
+
+Expected: no whitespace errors.
+
+## Execution Handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-05-05-layered-scene-reconstruction.md`.
+
+Two execution options:
+
+1. Subagent-Driven (recommended) - dispatch a fresh worker per task, review between tasks, and keep real provider execution gated behind explicit credentials.
+2. Inline Execution - execute tasks in this session using `superpowers:executing-plans`, with checkpoints before provider calls.

--- a/docs/superpowers/specs/2026-05-05-layered-scene-reconstruction-design.md
+++ b/docs/superpowers/specs/2026-05-05-layered-scene-reconstruction-design.md
@@ -1,4 +1,4 @@
-# Layered Scene Reconstruction Design
+# Source-Conditioned Layered Generation Design
 
 **Date:** 2026-05-05
 **Target version:** v0.24 candidate
@@ -32,15 +32,32 @@ Can Vulca combine the existing layered-generation architecture with the new
 redraw replacement contract to produce a more controllable "source photo ->
 editable stylized layer stack" workflow?
 
+## Product Boundary: Layered Generation, Not Decompose
+
+This workflow is not the same product operation as `decompose`.
+
+`decompose` takes an existing flat image and extracts source pixels into
+semantic layers. Layered scene reconstruction should instead generate a new
+editable layer stack that is source-conditioned by the photo: each layer has its
+own prompt, policy, z-order, reference crop, and control/ownership mask. Masks
+are scaffolding for generation and compositing, not the product definition.
+
+The MVP can use curated masks to test layer ownership and geometry. That does
+not make the workflow a split-image pipeline. The output should be a generated
+or preserved semantic stack whose layers are independently editable.
+
 ## Recommended Approach
 
-Use **source-driven layered reconstruction** as the first implementation lane.
-It starts from an existing image, creates semantic masks, reconstructs selected
-layers, and uses redraw only for local replacements inside those layers.
+Use **source-conditioned layered generation/reconstruction** as the first
+implementation lane. It starts from an existing photo as reference, defines the
+semantic layer stack, uses control masks to constrain generation and ownership,
+generates or preserves selected layers, and calls redraw only for local
+replacement details inside those layers.
 
 This approach fits the current branch because it reuses proven pieces:
 
-- `decompose` and manifest output for semantic layers.
+- layered manifest output for semantic layer stacks.
+- control masks for geometry and pixel ownership.
 - target-aware mask refinement for small repeated details.
 - source crop padding and OpenAI-compatible `/v1/images/edits`.
 - pasteback/composite for visual review.
@@ -52,10 +69,11 @@ instead of being treated as giant flower masks.
 
 ## Alternatives Considered
 
-### A. Source-driven layered reconstruction
+### A. Source-conditioned layered generation/reconstruction
 
-Start from a source image, segment it into named semantic layers, then
-reconstruct or clean each layer using layer-specific prompts.
+Start from a source image, plan named semantic output layers, then use
+layer-specific prompts and control masks to generate, preserve, or locally
+replace each layer.
 
 Pros:
 
@@ -66,7 +84,7 @@ Pros:
 
 Cons:
 
-- Depends on mask quality.
+- Depends on control mask quality for geometry and ownership.
 - Requires z-index and overlap validation.
 - Large layers need different gates than small-object replacement.
 
@@ -113,7 +131,8 @@ editor.
 In scope:
 
 - Build a semantic layer plan for a source image.
-- Normalize masks into non-overlapping layer ownership.
+- Use masks as generation/control scaffolds and normalize them into
+  non-overlapping layer ownership.
 - Reconstruct selected layers using layer-specific image-edit prompts.
 - Use `redraw_layer` for small detail layers such as white and yellow flower
   heads.
@@ -156,12 +175,11 @@ strategy exists.
 
 ```text
 source image
-  -> semantic layer plan
-  -> masks per semantic path
-  -> mask ownership normalization
-  -> per-layer crop + prompt contract
-  -> provider edit or preserve
-  -> layer RGBA output
+  -> semantic output layer plan
+  -> control/ownership masks per semantic path
+  -> ownership normalization for compositing
+  -> per-layer reference crop + prompt contract
+  -> provider-generated, locally-redrawn, preserved, or residual layer RGBA
   -> manifest
   -> composite preview
   -> per-layer and full-scene evaluation
@@ -378,10 +396,10 @@ requested layer. For example, do not forbid `guardrail` in the guardrail prompt.
 The eventual API should be a new workflow above individual redraw:
 
 ```python
-result = await reconstruct_layers(
-    artwork,
+result = await source_layered_generate(
     source_image="source.png",
-    layer_plan="auto",
+    layer_contract="roadside_source_layered_generation_v0_24",
+    control_masks="curated_masks/",
     policies={
         "background.sky.clean_blue": "reconstruct",
         "foreground.guardrail": "reconstruct",
@@ -395,9 +413,10 @@ result = await reconstruct_layers(
 )
 ```
 
-This should not replace `redraw_layer`. It should call `redraw_layer` for
-layers whose policy is `local_redraw`, and use separate layer reconstruction
-helpers for larger semantic layers.
+This should not replace `redraw_layer` or `decompose`. It should call
+`redraw_layer` for layers whose policy is `local_redraw`, use mask-aware
+provider edits for larger generated semantic layers, and treat decompose/split
+outputs only as optional sources of control masks.
 
 ## Quality Gates
 
@@ -468,10 +487,11 @@ The workflow is successful when:
 
 ## Implementation Starting Point
 
-The first implementation plan should start with existing or hand-curated masks
-for the current roadside image. The visual question is layer ownership and
-composite quality, not whether a general planner can already infer the perfect
-taxonomy.
+The first implementation plan should start with existing or hand-curated
+control masks for the current roadside image. These masks are not the product
+output and should not be treated as a `decompose` result. The visual question is
+whether source-conditioned generated layers plus ownership subtraction produce
+a better editable composite.
 
 A general planner pass can come after the prototype proves that subtracting
 detail layers from broad parent layers removes old-source residue and produces a

--- a/scripts/prototype_source_layered_generation.py
+++ b/scripts/prototype_source_layered_generation.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "src"))
+
+from vulca.layers.reconstruction import (
+    load_reconstruction_contracts,
+    source_layered_generate,
+)
+
+
+DEFAULT_CONTRACT = Path(
+    "docs/superpowers/contracts/2026-05-05-layered-scene-reconstruction-prompts.json"
+)
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--source", required=True)
+    parser.add_argument("--mask-dir", required=True)
+    parser.add_argument("--artifact-dir", default="")
+    parser.add_argument("--prompt-contract", default=str(DEFAULT_CONTRACT))
+    parser.add_argument("--provider", default="openai")
+    parser.add_argument("--model", default="gpt-image-2")
+    parser.add_argument("--dry-run", action="store_true")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = _parse_args()
+    if not args.dry_run:
+        raise SystemExit(
+            "provider-backed prototype is not wired yet; pass --dry-run"
+        )
+    source_path = Path(args.source)
+    contracts = load_reconstruction_contracts(args.prompt_contract)
+    if args.artifact_dir:
+        artifact_dir = Path(args.artifact_dir)
+    else:
+        artifact_dir = (
+            Path(contracts.artifact_policy["default_artifact_root"]) / source_path.stem
+        )
+
+    result = source_layered_generate(
+        source_image=source_path,
+        mask_dir=args.mask_dir,
+        artifact_dir=artifact_dir,
+        prompt_contract=args.prompt_contract,
+        provider=args.provider,
+        model=args.model,
+        dry_run=True,
+    )
+    print(result.summary_path)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/vulca/layers/__init__.py
+++ b/src/vulca/layers/__init__.py
@@ -21,6 +21,18 @@ from vulca.layers.vlm_mask import generate_vlm_mask, apply_vlm_mask, VLM_MASK_PR
 from vulca.layers.transform import apply_spatial_transform, compute_content_bbox, needs_transform
 from vulca.layers.plan_prompt import build_plan_prompt, get_tradition_layer_order
 from vulca.layers.alpha import ensure_alpha
+from vulca.layers.reconstruction import (
+    SourceLayeredGenerationResult,
+    apply_owned_mask_to_source,
+    asource_layered_generate,
+    assert_image_edits_endpoint_allowed,
+    evaluate_ownership_quality_gates,
+    load_reconstruction_contracts,
+    normalize_layer_ownership,
+    should_use_local_redraw,
+    source_layered_generate,
+    write_reconstruction_summary,
+)
 
 # V1 compat re-exports
 from vulca.layers.manifest import load_manifest as load_artwork
@@ -50,4 +62,14 @@ __all__ = [
     "build_plan_prompt", "get_tradition_layer_order",
     "ensure_alpha",
     "apply_spatial_transform", "compute_content_bbox", "needs_transform",
+    "SourceLayeredGenerationResult",
+    "apply_owned_mask_to_source",
+    "asource_layered_generate",
+    "assert_image_edits_endpoint_allowed",
+    "evaluate_ownership_quality_gates",
+    "load_reconstruction_contracts",
+    "normalize_layer_ownership",
+    "should_use_local_redraw",
+    "source_layered_generate",
+    "write_reconstruction_summary",
 ]

--- a/src/vulca/layers/reconstruction.py
+++ b/src/vulca/layers/reconstruction.py
@@ -1,0 +1,396 @@
+"""Source-conditioned layered generation helpers."""
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+import numpy as np
+from PIL import Image
+
+from vulca.layers.composite import composite_layers
+from vulca.layers.manifest import write_manifest
+from vulca.layers.types import LayerInfo, LayerResult
+
+
+LayerPolicy = Literal["reconstruct", "preserve", "local_redraw", "residual"]
+
+
+@dataclass(frozen=True)
+class LayerPromptContract:
+    semantic_path: str
+    display_name: str
+    z_index: int
+    visual_role: str
+    mvp_policy: LayerPolicy
+    allowed_policies: tuple[str, ...]
+    edit_risk: str
+    parent_layer: str | None
+    mask_prompt: str
+    prompt_lines: tuple[str, ...]
+    forbidden_content: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class ReconstructionContracts:
+    schema_version: str
+    product: dict
+    provider: dict
+    artifact_policy: dict
+    common_edit_prefix_lines: tuple[str, ...]
+    negative_prompt_block_lines: tuple[str, ...]
+    layers: tuple[LayerPromptContract, ...]
+    summary_json_required_keys: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class SourceLayeredGenerationResult:
+    artifact_dir: Path
+    manifest_path: Path
+    composite_path: Path
+    summary_path: Path
+
+
+def load_reconstruction_contracts(path: str | Path) -> ReconstructionContracts:
+    contract_path = Path(path)
+    data = json.loads(contract_path.read_text())
+    layers = tuple(
+        LayerPromptContract(
+            semantic_path=item["semantic_path"],
+            display_name=item["display_name"],
+            z_index=int(item["z_index"]),
+            visual_role=item["visual_role"],
+            mvp_policy=item["mvp_policy"],
+            allowed_policies=tuple(item.get("allowed_policies", ())),
+            edit_risk=item.get("edit_risk", "medium"),
+            parent_layer=item.get("parent_layer"),
+            mask_prompt=item.get("mask_prompt", ""),
+            prompt_lines=tuple(item.get("prompt_lines", ())),
+            forbidden_content=tuple(item.get("forbidden_content", ())),
+        )
+        for item in data.get("layers", ())
+    )
+    paths = {layer.semantic_path for layer in layers}
+    if "residual.source_texture" not in paths:
+        raise ValueError("contract must include residual.source_texture")
+    return ReconstructionContracts(
+        schema_version=data["schema_version"],
+        product=data["product_contract"],
+        provider=data["provider_contract"],
+        artifact_policy=data["artifact_policy"],
+        common_edit_prefix_lines=tuple(data.get("common_edit_prefix_lines", ())),
+        negative_prompt_block_lines=tuple(data.get("negative_prompt_block_lines", ())),
+        layers=layers,
+        summary_json_required_keys=tuple(data.get("summary_json_required_keys", ())),
+    )
+
+
+def _mask_bool(mask: Image.Image, size: tuple[int, int]) -> np.ndarray:
+    if mask.size != size:
+        mask = mask.resize(size, Image.Resampling.NEAREST)
+    return np.asarray(mask.convert("L")) > 0
+
+
+def normalize_layer_ownership(
+    *,
+    size: tuple[int, int],
+    layers: tuple[LayerPromptContract, ...],
+    source_masks: dict[str, Image.Image],
+) -> dict[str, Image.Image]:
+    width, height = size
+    shape = (height, width)
+    residual_path = "residual.source_texture"
+    claimed = np.zeros(shape, dtype=bool)
+    owned: dict[str, np.ndarray] = {}
+
+    for layer in sorted(layers, key=lambda item: item.z_index, reverse=True):
+        if layer.semantic_path == residual_path:
+            continue
+        raw_mask = source_masks.get(layer.semantic_path)
+        if raw_mask is None:
+            layer_mask = np.zeros(shape, dtype=bool)
+        else:
+            layer_mask = _mask_bool(raw_mask, size)
+        layer_owned = layer_mask & ~claimed
+        owned[layer.semantic_path] = layer_owned
+        claimed |= layer_owned
+
+    owned[residual_path] = ~claimed
+    return {
+        semantic_path: Image.fromarray(mask.astype(np.uint8) * 255).convert("L")
+        for semantic_path, mask in owned.items()
+    }
+
+
+def apply_owned_mask_to_source(
+    source_rgb: Image.Image,
+    owned_mask: Image.Image,
+    output_path: str | Path,
+) -> Path:
+    out_path = Path(output_path)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    rgba = source_rgb.convert("RGBA")
+    mask = owned_mask.convert("L")
+    if mask.size != rgba.size:
+        mask = mask.resize(rgba.size, Image.Resampling.NEAREST)
+    r, g, b, _ = rgba.split()
+    Image.merge("RGBA", (r, g, b, mask)).save(out_path)
+    return out_path
+
+
+def assert_image_edits_endpoint_allowed() -> None:
+    mode = os.environ.get("VULCA_OPENAI_IMAGE_ENDPOINT", "").strip().lower()
+    normalized = mode.replace("-", "_")
+    if normalized == "chat_completions":
+        raise ValueError(
+            "Source-conditioned layered generation must use OpenAI-compatible "
+            "/v1/images/edits; /v1/chat/completions is forbidden for this workflow."
+        )
+
+
+def should_use_local_redraw(semantic_path: str, policy: str) -> bool:
+    return policy == "local_redraw" and semantic_path in {
+        "detail.white_flower_cluster",
+        "detail.yellow_dandelion_heads",
+    }
+
+
+def write_reconstruction_summary(
+    artifact_dir: str | Path,
+    *,
+    source_image: str,
+    provider: str,
+    model: str,
+    layer_policies: dict,
+    usage: dict,
+    cost: dict,
+    failures: list,
+    quality_gates: dict,
+) -> Path:
+    out_dir = Path(artifact_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "schema_version": "2026-05-05.source_layered_generation.summary.v1",
+        "source_image": source_image,
+        "artifact_dir": str(out_dir),
+        "provider": provider,
+        "model": model,
+        "layer_policies": layer_policies,
+        "ownership": {
+            "exclusive": bool(quality_gates.get("ownership_no_overlap", False)),
+            "residual_visible": True,
+        },
+        "usage": usage,
+        "cost": cost,
+        "failures": failures,
+        "quality_gates": quality_gates,
+    }
+    path = out_dir / "summary.json"
+    path.write_text(json.dumps(payload, indent=2, ensure_ascii=False))
+    return path
+
+
+DEFAULT_PROMPT_CONTRACT = Path(
+    "docs/superpowers/contracts/2026-05-05-layered-scene-reconstruction-prompts.json"
+)
+
+
+def _load_source_masks(mask_dir: str | Path) -> dict[str, Image.Image]:
+    return {
+        path.stem: Image.open(path).convert("L")
+        for path in Path(mask_dir).glob("*.png")
+    }
+
+
+def _area_pct(mask: np.ndarray, total_pixels: int) -> float:
+    if total_pixels == 0:
+        return 0.0
+    return round(float(mask.sum()) * 100.0 / float(total_pixels), 4)
+
+
+def build_layer_policy_records(
+    *,
+    layers: tuple[LayerPromptContract, ...],
+    source_masks: dict[str, Image.Image],
+    owned_masks: dict[str, Image.Image],
+    size: tuple[int, int],
+    dry_run: bool,
+) -> dict:
+    width, height = size
+    total_pixels = width * height
+    raw = {
+        path: _mask_bool(mask, size)
+        for path, mask in source_masks.items()
+    }
+    owned = {
+        path: _mask_bool(mask, size)
+        for path, mask in owned_masks.items()
+    }
+    records = {}
+
+    for layer in layers:
+        policy = layer.mvp_policy
+        skipped_provider = dry_run and policy in {"reconstruct", "local_redraw"}
+        raw_mask = raw.get(layer.semantic_path, np.zeros((height, width), dtype=bool))
+        owned_mask = owned.get(
+            layer.semantic_path,
+            np.zeros((height, width), dtype=bool),
+        )
+        records[layer.semantic_path] = {
+            "policy": policy,
+            "status": "skipped_provider" if skipped_provider else "completed",
+            "mask_area_pct": _area_pct(raw_mask, total_pixels),
+            "owned_area_pct": _area_pct(owned_mask, total_pixels),
+            "subtracted_by": [],
+            "subtracted_pixel_count": 0,
+        }
+
+    for child in layers:
+        if not child.parent_layer or child.parent_layer not in records:
+            continue
+        parent_raw = raw.get(child.parent_layer)
+        child_owned = owned.get(child.semantic_path)
+        if parent_raw is None or child_owned is None:
+            continue
+        subtracted_count = int(np.logical_and(parent_raw, child_owned).sum())
+        if subtracted_count <= 0:
+            continue
+        parent_record = records[child.parent_layer]
+        parent_record["subtracted_by"].append(child.semantic_path)
+        parent_record["subtracted_pixel_count"] += subtracted_count
+
+    return records
+
+
+def evaluate_ownership_quality_gates(
+    *,
+    size: tuple[int, int],
+    layers: tuple[LayerPromptContract, ...],
+    owned_masks: dict[str, Image.Image],
+) -> dict[str, bool]:
+    width, height = size
+    shape = (height, width)
+    counts = np.zeros(shape, dtype=np.uint16)
+    owned = {}
+    for layer in layers:
+        mask = owned_masks.get(layer.semantic_path)
+        if mask is None:
+            arr = np.zeros(shape, dtype=bool)
+        else:
+            arr = _mask_bool(mask, size)
+        owned[layer.semantic_path] = arr
+        counts += arr.astype(np.uint16)
+
+    residual = owned.get("residual.source_texture", np.zeros(shape, dtype=bool))
+    hedge = owned.get("foreground.hedge_bush", np.zeros(shape, dtype=bool))
+    white = owned.get("detail.white_flower_cluster", np.zeros(shape, dtype=bool))
+    yellow = owned.get("detail.yellow_dandelion_heads", np.zeros(shape, dtype=bool))
+    union = counts > 0
+    return {
+        "ownership_no_overlap": bool((counts <= 1).all()),
+        "residual_fills_unassigned": bool(union.all() and residual.any()),
+        "flower_pixels_absent_from_parent_hedge": bool(
+            not np.logical_and(hedge, white | yellow).any()
+        ),
+    }
+
+
+async def asource_layered_generate(
+    *,
+    source_image: str | Path,
+    mask_dir: str | Path,
+    artifact_dir: str | Path,
+    prompt_contract: str | Path = DEFAULT_PROMPT_CONTRACT,
+    provider: str = "openai",
+    model: str = "gpt-image-2",
+    dry_run: bool = False,
+) -> SourceLayeredGenerationResult:
+    if not dry_run:
+        raise NotImplementedError(
+            "Provider-backed source_layered_generate is not wired in v0.24 yet; "
+            "run with dry_run=True for ownership and artifact validation."
+        )
+
+    source_path = Path(source_image)
+    out_dir = Path(artifact_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    source = Image.open(source_path).convert("RGB")
+    contracts = load_reconstruction_contracts(prompt_contract)
+    source_masks = _load_source_masks(mask_dir)
+    owned = normalize_layer_ownership(
+        size=source.size,
+        layers=contracts.layers,
+        source_masks=source_masks,
+    )
+    layer_policies = build_layer_policy_records(
+        layers=contracts.layers,
+        source_masks=source_masks,
+        owned_masks=owned,
+        size=source.size,
+        dry_run=dry_run,
+    )
+    quality_gates = evaluate_ownership_quality_gates(
+        size=source.size,
+        layers=contracts.layers,
+        owned_masks=owned,
+    )
+
+    layer_results: list[LayerResult] = []
+    for contract in sorted(contracts.layers, key=lambda item: item.z_index):
+        path = out_dir / f"{contract.semantic_path}.png"
+        apply_owned_mask_to_source(source, owned[contract.semantic_path], path)
+        info = LayerInfo(
+            name=contract.semantic_path,
+            description=contract.display_name,
+            z_index=contract.z_index,
+            content_type=contract.visual_role,
+            semantic_path=contract.semantic_path,
+            parent_layer_id=None,
+            locked=contract.mvp_policy == "residual",
+        )
+        layer_results.append(LayerResult(info=info, image_path=str(path)))
+        layer_policies[contract.semantic_path]["file"] = str(path)
+
+    manifest_path = Path(
+        write_manifest(
+            [layer.info for layer in layer_results],
+            output_dir=str(out_dir),
+            width=source.size[0],
+            height=source.size[1],
+            source_image=str(source_path),
+            split_mode="source_layered_generation",
+        )
+    )
+    composite_path = Path(
+        composite_layers(
+            layer_results,
+            width=source.size[0],
+            height=source.size[1],
+            output_path=str(out_dir / "layered_composite.png"),
+        )
+    )
+    summary_path = write_reconstruction_summary(
+        out_dir,
+        source_image=str(source_path),
+        provider=provider,
+        model=model,
+        layer_policies=layer_policies,
+        usage={},
+        cost={"total_cost_usd": 0.0, "known": True},
+        failures=[],
+        quality_gates=quality_gates,
+    )
+    return SourceLayeredGenerationResult(
+        artifact_dir=out_dir,
+        manifest_path=manifest_path,
+        composite_path=composite_path,
+        summary_path=summary_path,
+    )
+
+
+def source_layered_generate(**kwargs) -> SourceLayeredGenerationResult:
+    import asyncio
+
+    return asyncio.run(asource_layered_generate(**kwargs))

--- a/tests/test_layered_reconstruction_contracts.py
+++ b/tests/test_layered_reconstruction_contracts.py
@@ -1,0 +1,67 @@
+from pathlib import Path
+
+import pytest
+
+from vulca.layers.reconstruction import (
+    assert_image_edits_endpoint_allowed,
+    load_reconstruction_contracts,
+)
+
+
+CONTRACT_PATH = Path(
+    "docs/superpowers/contracts/2026-05-05-layered-scene-reconstruction-prompts.json"
+)
+
+
+def test_loads_required_source_layered_generation_contracts():
+    contracts = load_reconstruction_contracts(CONTRACT_PATH)
+
+    assert contracts.schema_version == (
+        "2026-05-05.source_layered_generation.prompt_contracts.v1"
+    )
+    assert contracts.product["workflow_kind"] == "source_conditioned_layered_generation"
+    assert contracts.product["not_a_decompose_workflow"] is True
+    assert contracts.provider["endpoint"] == "/v1/images/edits"
+    assert "/v1/chat/completions" in contracts.provider["forbidden_endpoints"]
+    assert contracts.artifact_policy["default_artifact_root"] == (
+        ".scratch/source-layered-generation"
+    )
+    assert [layer.semantic_path for layer in contracts.layers] == [
+        "background.sky.clean_blue",
+        "background.distant_trees",
+        "subject.vehicle.red_car",
+        "subject.vehicle.yellow_truck",
+        "foreground.guardrail",
+        "foreground.grass_bank",
+        "foreground.hedge_bush",
+        "detail.dry_stems",
+        "detail.white_flower_cluster",
+        "detail.yellow_dandelion_heads",
+        "residual.source_texture",
+    ]
+
+
+def test_rejects_contract_without_residual_layer(tmp_path):
+    contract = CONTRACT_PATH.read_text()
+    edited = contract.replace(
+        '"semantic_path": "residual.source_texture"',
+        '"semantic_path": "residual.missing"',
+    )
+    path = tmp_path / "bad.json"
+    path.write_text(edited)
+
+    with pytest.raises(ValueError, match="residual.source_texture"):
+        load_reconstruction_contracts(path)
+
+
+def test_rejects_chat_completions_endpoint_mode(monkeypatch):
+    monkeypatch.setenv("VULCA_OPENAI_IMAGE_ENDPOINT", "chat_completions")
+
+    with pytest.raises(ValueError, match="/v1/chat/completions"):
+        assert_image_edits_endpoint_allowed()
+
+
+def test_allows_default_images_edits_endpoint(monkeypatch):
+    monkeypatch.delenv("VULCA_OPENAI_IMAGE_ENDPOINT", raising=False)
+
+    assert_image_edits_endpoint_allowed() is None

--- a/tests/test_layered_reconstruction_ownership.py
+++ b/tests/test_layered_reconstruction_ownership.py
@@ -1,0 +1,112 @@
+import numpy as np
+from PIL import Image
+
+from vulca.layers.reconstruction import (
+    LayerPromptContract,
+    evaluate_ownership_quality_gates,
+    normalize_layer_ownership,
+)
+
+
+def _contract(path: str, z: int, policy: str, parent=None):
+    return LayerPromptContract(
+        semantic_path=path,
+        display_name=path,
+        z_index=z,
+        visual_role="detail" if path.startswith("detail.") else "foreground",
+        mvp_policy=policy,
+        allowed_policies=(policy,),
+        edit_risk="low",
+        parent_layer=parent,
+        mask_prompt=path,
+        prompt_lines=(path,),
+        forbidden_content=(),
+    )
+
+
+def _mask(size, box):
+    img = Image.new("L", size, 0)
+    img.paste(Image.new("L", (box[2], box[3]), 255), (box[0], box[1]))
+    return img
+
+
+def test_detail_flower_pixels_are_subtracted_from_parent_hedge():
+    size = (8, 6)
+    layers = (
+        _contract("foreground.hedge_bush", 60, "preserve"),
+        _contract(
+            "detail.white_flower_cluster",
+            80,
+            "local_redraw",
+            "foreground.hedge_bush",
+        ),
+        _contract(
+            "detail.yellow_dandelion_heads",
+            90,
+            "local_redraw",
+            "foreground.hedge_bush",
+        ),
+        _contract("residual.source_texture", 100, "residual"),
+    )
+    source_masks = {
+        "foreground.hedge_bush": _mask(size, (0, 2, 8, 4)),
+        "detail.white_flower_cluster": _mask(size, (2, 3, 2, 2)),
+        "detail.yellow_dandelion_heads": _mask(size, (5, 3, 1, 1)),
+    }
+
+    owned = normalize_layer_ownership(size=size, layers=layers, source_masks=source_masks)
+
+    hedge = np.asarray(owned["foreground.hedge_bush"]) > 0
+    white = np.asarray(owned["detail.white_flower_cluster"]) > 0
+    yellow = np.asarray(owned["detail.yellow_dandelion_heads"]) > 0
+    residual = np.asarray(owned["residual.source_texture"]) > 0
+
+    assert not np.logical_and(hedge, white).any()
+    assert not np.logical_and(hedge, yellow).any()
+    assert white.sum() == 4
+    assert yellow.sum() == 1
+    union = hedge | white | yellow | residual
+    assert union.all()
+
+
+def test_unassigned_pixels_go_to_visible_residual_layer():
+    size = (4, 4)
+    layers = (
+        _contract("background.sky.clean_blue", 0, "reconstruct"),
+        _contract("residual.source_texture", 100, "residual"),
+    )
+    source_masks = {"background.sky.clean_blue": _mask(size, (0, 0, 4, 2))}
+
+    owned = normalize_layer_ownership(size=size, layers=layers, source_masks=source_masks)
+
+    residual = np.asarray(owned["residual.source_texture"]) > 0
+    assert residual[:2, :].sum() == 0
+    assert residual[2:, :].all()
+
+
+def test_quality_gates_detect_flower_overlap_with_parent_hedge():
+    size = (4, 4)
+    layers = (
+        _contract("foreground.hedge_bush", 60, "preserve"),
+        _contract(
+            "detail.white_flower_cluster",
+            80,
+            "local_redraw",
+            "foreground.hedge_bush",
+        ),
+        _contract("residual.source_texture", 100, "residual"),
+    )
+    owned_masks = {
+        "foreground.hedge_bush": _mask(size, (0, 0, 2, 2)),
+        "detail.white_flower_cluster": _mask(size, (1, 1, 2, 2)),
+        "residual.source_texture": _mask(size, (2, 2, 2, 2)),
+    }
+
+    gates = evaluate_ownership_quality_gates(
+        size=size,
+        layers=layers,
+        owned_masks=owned_masks,
+    )
+
+    assert gates["ownership_no_overlap"] is False
+    assert gates["flower_pixels_absent_from_parent_hedge"] is False

--- a/tests/test_layered_reconstruction_summary.py
+++ b/tests/test_layered_reconstruction_summary.py
@@ -1,0 +1,49 @@
+import json
+
+from vulca.layers.reconstruction import write_reconstruction_summary
+
+
+def test_summary_records_policies_usage_cost_failures_and_gates(tmp_path):
+    path = write_reconstruction_summary(
+        tmp_path,
+        source_image="source.png",
+        provider="openai",
+        model="gpt-image-2",
+        layer_policies={
+            "foreground.hedge_bush": {
+                "policy": "preserve",
+                "status": "completed",
+                "mask_area_pct": 40.0,
+                "owned_area_pct": 37.5,
+                "subtracted_by": ["detail.white_flower_cluster"],
+            },
+            "detail.white_flower_cluster": {
+                "policy": "local_redraw",
+                "status": "completed",
+                "mask_area_pct": 2.5,
+                "owned_area_pct": 2.5,
+                "cost_usd": 0.0123,
+            },
+        },
+        usage={"input_tokens": 100, "output_tokens": 200},
+        cost={"total_cost_usd": 0.0123, "known": True},
+        failures=[],
+        quality_gates={
+            "ownership_no_overlap": True,
+            "residual_fills_unassigned": True,
+            "flower_pixels_absent_from_parent_hedge": True,
+        },
+    )
+
+    data = json.loads(path.read_text())
+    assert data["schema_version"] == (
+        "2026-05-05.source_layered_generation.summary.v1"
+    )
+    assert data["source_image"] == "source.png"
+    assert data["provider"] == "openai"
+    assert data["model"] == "gpt-image-2"
+    assert data["layer_policies"]["foreground.hedge_bush"]["policy"] == "preserve"
+    assert data["usage"]["input_tokens"] == 100
+    assert data["cost"]["total_cost_usd"] == 0.0123
+    assert data["failures"] == []
+    assert data["quality_gates"]["flower_pixels_absent_from_parent_hedge"] is True

--- a/tests/test_layered_reconstruction_workflow.py
+++ b/tests/test_layered_reconstruction_workflow.py
@@ -1,0 +1,140 @@
+import json
+import subprocess
+import sys
+
+import numpy as np
+from PIL import Image
+
+from vulca.layers.reconstruction import (
+    apply_owned_mask_to_source,
+    should_use_local_redraw,
+    source_layered_generate,
+)
+
+
+def test_preserve_layer_copies_source_pixels_under_owned_mask(tmp_path):
+    source = Image.new("RGB", (4, 4), (10, 20, 30))
+    mask = Image.new("L", (4, 4), 0)
+    mask.paste(Image.new("L", (2, 2), 255), (1, 1))
+    out_path = tmp_path / "hedge.png"
+
+    result = apply_owned_mask_to_source(source, mask, out_path)
+
+    assert result == out_path
+    rgba = Image.open(out_path).convert("RGBA")
+    arr = np.asarray(rgba)
+    assert tuple(arr[1, 1]) == (10, 20, 30, 255)
+    assert tuple(arr[0, 0]) == (10, 20, 30, 0)
+
+
+def test_only_flower_detail_layers_use_local_redraw():
+    assert should_use_local_redraw("detail.white_flower_cluster", "local_redraw")
+    assert should_use_local_redraw("detail.yellow_dandelion_heads", "local_redraw")
+    assert not should_use_local_redraw("foreground.hedge_bush", "preserve")
+    assert not should_use_local_redraw("foreground.grass_bank", "preserve")
+
+
+def test_prototype_cli_dry_run_writes_summary_without_provider(tmp_path):
+    source = tmp_path / "source.png"
+    Image.new("RGB", (8, 8), (80, 120, 60)).save(source)
+    mask_dir = tmp_path / "masks"
+    mask_dir.mkdir()
+    Image.new("L", (8, 8), 255).save(mask_dir / "foreground.hedge_bush.png")
+    artifact_dir = tmp_path / "artifacts"
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/prototype_source_layered_generation.py",
+            "--source",
+            str(source),
+            "--mask-dir",
+            str(mask_dir),
+            "--artifact-dir",
+            str(artifact_dir),
+            "--dry-run",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert str(artifact_dir / "summary.json") in result.stdout
+    assert (artifact_dir / "manifest.json").exists()
+    assert (artifact_dir / "layered_composite.png").exists()
+    summary = json.loads((artifact_dir / "summary.json").read_text())
+    assert summary["model"] == "gpt-image-2"
+    assert summary["layer_policies"]["foreground.hedge_bush"]["policy"] == "preserve"
+
+
+def test_prototype_cli_requires_dry_run_until_provider_is_wired(tmp_path):
+    source = tmp_path / "source.png"
+    Image.new("RGB", (8, 8), (80, 120, 60)).save(source)
+    mask_dir = tmp_path / "masks"
+    mask_dir.mkdir()
+    artifact_dir = tmp_path / "artifacts"
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/prototype_source_layered_generation.py",
+            "--source",
+            str(source),
+            "--mask-dir",
+            str(mask_dir),
+            "--artifact-dir",
+            str(artifact_dir),
+        ],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode != 0
+    assert "--dry-run" in result.stderr
+
+
+def test_source_layered_generate_dry_run_creates_manifest_composite_and_summary(
+    tmp_path,
+):
+    source = tmp_path / "source.png"
+    Image.new("RGB", (10, 10), (90, 120, 70)).save(source)
+    mask_dir = tmp_path / "masks"
+    mask_dir.mkdir()
+    Image.new("L", (10, 10), 255).save(mask_dir / "foreground.hedge_bush.png")
+
+    result = source_layered_generate(
+        source_image=source,
+        mask_dir=mask_dir,
+        artifact_dir=tmp_path / "run",
+        dry_run=True,
+    )
+
+    assert result.summary_path.exists()
+    assert result.manifest_path.exists()
+    assert result.composite_path.exists()
+    assert result.artifact_dir == tmp_path / "run"
+
+
+def test_source_layered_generate_summary_records_parent_subtraction(tmp_path):
+    source = tmp_path / "source.png"
+    Image.new("RGB", (10, 10), (90, 120, 70)).save(source)
+    mask_dir = tmp_path / "masks"
+    mask_dir.mkdir()
+    Image.new("L", (10, 10), 255).save(mask_dir / "foreground.hedge_bush.png")
+    flower = Image.new("L", (10, 10), 0)
+    flower.paste(Image.new("L", (2, 2), 255), (4, 4))
+    flower.save(mask_dir / "detail.white_flower_cluster.png")
+
+    result = source_layered_generate(
+        source_image=source,
+        mask_dir=mask_dir,
+        artifact_dir=tmp_path / "run",
+        dry_run=True,
+    )
+
+    summary = json.loads(result.summary_path.read_text())
+    hedge = summary["layer_policies"]["foreground.hedge_bush"]
+    assert hedge["mask_area_pct"] == 100.0
+    assert hedge["owned_area_pct"] == 96.0
+    assert hedge["subtracted_by"] == ["detail.white_flower_cluster"]
+    assert hedge["subtracted_pixel_count"] == 4


### PR DESCRIPTION
## Summary
- Adds a production-path dry-run foundation for source-conditioned layered scene reconstruction.
- Adds a clearly named prototype script for source image plus curated control masks.
- Adds focused contract, ownership, summary, and workflow tests for the reconstruction path.

## Scope boundaries
- Provider-backed execution is intentionally blocked unless `dry_run=True`.
- No Learning Loop logging is wired in this PR.
- No MCP/CLI production provider path is added.
- Future `layer_generate_case` integration waits for #46 and is intentionally not implemented here.

## Validation
- `pytest tests/test_layered_reconstruction_contracts.py tests/test_layered_reconstruction_ownership.py tests/test_layered_reconstruction_summary.py tests/test_layered_reconstruction_workflow.py -v`
- `git diff --check codex/redraw-learning-base..HEAD`
- `git diff --name-only codex/redraw-learning-base..HEAD`