### PR TITLE
[codex] Generate local seed case logs

### DIFF
--- a/docs/benchmarks/learning/local_seed_manifest.json
+++ b/docs/benchmarks/learning/local_seed_manifest.json
@@ -1,0 +1,37 @@
+{
+  "schema_version": 1,
+  "case_type": "learning_local_seed_manifest",
+  "redraw_seed_manifest": "docs/benchmarks/redraw/seed_manifest.json",
+  "decompose_seeds": [
+    {
+      "id": "scottish_chinese_native_decompose",
+      "source_image": "docs/visual-specs/2026-04-23-scottish-chinese-fusion/decompose/v0_17_14_native/iter0.png",
+      "output_dir": "docs/visual-specs/2026-04-23-scottish-chinese-fusion/decompose/v0_17_14_native",
+      "manifest_path": "docs/visual-specs/2026-04-23-scottish-chinese-fusion/decompose/v0_17_14_native/manifest.json",
+      "mode": "orchestrated",
+      "provider": "",
+      "model": "",
+      "tradition": "scottish_chinese_fusion",
+      "human_accept": true,
+      "failure_type": "",
+      "preferred_action": "accept",
+      "notes": "Tracked multi-layer split artifact used as a positive decompose seed."
+    }
+  ],
+  "layer_generate_seeds": [
+    {
+      "id": "scenario1_redo_layer_generate",
+      "user_intent": "Generate a layered Chinese ink landscape with sky, mountains, midground landscape, pavilion pines, and calligraphy/seals.",
+      "tradition": "chinese_xieyi",
+      "provider": "local_seed",
+      "model": "tracked_artifact",
+      "artifact_dir": "assets/demo/v2/scenario1-redo",
+      "layer_manifest_path": "assets/demo/v2/scenario1-redo/manifest.json",
+      "composite_path": "assets/demo/v2/scenario1-redo/after.png",
+      "preview_path": "assets/demo/v2/scenario1-redo/after.png",
+      "human_accept": true,
+      "failure_type": "",
+      "preferred_action": "accept"
+    }
+  ]
+}

--- a/src/vulca/cli.py
+++ b/src/vulca/cli.py
@@ -14,7 +14,9 @@ from __future__ import annotations
 
 import argparse
 import logging
+import subprocess
 import sys
+from pathlib import Path
 
 from vulca._version import __version__
 
@@ -339,6 +341,23 @@ def main(argv: list[str] | None = None) -> None:
         "--sidecar-output",
         default="",
         help="Optional review-only JSONL sidecar path, appended if provided",
+    )
+    cases_seed = cases_sub.add_parser("seed", help="Build local seed case JSONL logs")
+    cases_seed.add_argument(
+        "--output",
+        "-o",
+        required=True,
+        help="Output directory for seed JSONL logs",
+    )
+    cases_seed.add_argument(
+        "--repo-root",
+        default="",
+        help="Repository root (default: current working directory)",
+    )
+    cases_seed.add_argument(
+        "--manifest",
+        default="",
+        help="Seed manifest path (default: docs/benchmarks/learning/local_seed_manifest.json)",
     )
 
     # resume command
@@ -1647,6 +1666,28 @@ def _cmd_layers(args: argparse.Namespace) -> None:
 
 def _cmd_cases(args: argparse.Namespace) -> None:
     import json as _json
+
+    if args.cases_command == "seed":
+        from vulca.learning.seed_cases import (
+            DEFAULT_SEED_MANIFEST,
+            write_local_seed_case_logs,
+        )
+
+        try:
+            result = write_local_seed_case_logs(
+                repo_root=args.repo_root or Path.cwd(),
+                output_dir=args.output,
+                manifest_path=args.manifest or DEFAULT_SEED_MANIFEST,
+            )
+        except (ValueError, FileNotFoundError, subprocess.CalledProcessError, _json.JSONDecodeError) as exc:
+            print(f"Error: {exc}", file=sys.stderr)
+            sys.exit(1)
+
+        print(f"  Seed cases: {result.output_dir}")
+        for case_type in sorted(result.counts):
+            print(f"  {case_type}: {result.counts[case_type]} -> {result.paths[case_type]}")
+        print(f"  Seed index: {result.index_path}")
+        return
 
     if args.cases_command != "review":
         print(f"Unknown cases command: {args.cases_command}", file=sys.stderr)

--- a/src/vulca/learning/case_review.py
+++ b/src/vulca/learning/case_review.py
@@ -12,6 +12,16 @@ from vulca.layers.redraw_cases import (
     validate_failure_type as validate_redraw_failure_type,
     validate_preferred_action as validate_redraw_preferred_action,
 )
+from vulca.layers.decompose_cases import (
+    CASE_TYPE as DECOMPOSE_CASE_TYPE,
+    validate_failure_type as validate_decompose_failure_type,
+    validate_preferred_action as validate_decompose_preferred_action,
+)
+from vulca.layers.layer_generate_cases import (
+    CASE_TYPE as LAYER_GENERATE_CASE_TYPE,
+    validate_failure_type as validate_layer_generate_failure_type,
+    validate_preferred_action as validate_layer_generate_preferred_action,
+)
 
 
 _UNSET = object()
@@ -41,7 +51,17 @@ CASE_REVIEW_SPECS: dict[str, CaseReviewSpec] = {
         case_type=REDRAW_CASE_TYPE,
         validate_failure_type=validate_redraw_failure_type,
         validate_preferred_action=validate_redraw_preferred_action,
-    )
+    ),
+    DECOMPOSE_CASE_TYPE: CaseReviewSpec(
+        case_type=DECOMPOSE_CASE_TYPE,
+        validate_failure_type=validate_decompose_failure_type,
+        validate_preferred_action=validate_decompose_preferred_action,
+    ),
+    LAYER_GENERATE_CASE_TYPE: CaseReviewSpec(
+        case_type=LAYER_GENERATE_CASE_TYPE,
+        validate_failure_type=validate_layer_generate_failure_type,
+        validate_preferred_action=validate_layer_generate_preferred_action,
+    ),
 }
 
 

--- a/src/vulca/learning/seed_cases.py
+++ b/src/vulca/learning/seed_cases.py
@@ -1,0 +1,343 @@
+"""Build local seed case logs from tracked Vulca artifacts."""
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping
+
+from vulca.layers.decompose_cases import build_decompose_case
+from vulca.layers.layer_generate_cases import build_layer_generate_case
+from vulca.layers.redraw_cases import build_redraw_case
+from vulca.layers.types import LayerInfo
+
+
+DEFAULT_SEED_MANIFEST = Path("docs/benchmarks/learning/local_seed_manifest.json")
+CREATED_AT = "2026-05-05T14:45:00Z"
+
+
+@dataclass(frozen=True)
+class SeedWriteResult:
+    output_dir: str
+    paths: dict[str, str]
+    counts: dict[str, int]
+    index_path: str
+
+
+def build_local_seed_cases(
+    repo_root: str | Path,
+    manifest_path: str | Path = DEFAULT_SEED_MANIFEST,
+) -> dict[str, list[dict[str, Any]]]:
+    root = Path(repo_root).resolve()
+    manifest = _load_manifest(root, manifest_path)
+    return {
+        "redraw_case": _build_redraw_seeds(root, manifest),
+        "decompose_case": _build_decompose_seeds(root, manifest),
+        "layer_generate_case": _build_layer_generate_seeds(root, manifest),
+    }
+
+
+def write_local_seed_case_logs(
+    *,
+    repo_root: str | Path,
+    output_dir: str | Path,
+    manifest_path: str | Path = DEFAULT_SEED_MANIFEST,
+) -> SeedWriteResult:
+    bundle = build_local_seed_cases(repo_root, manifest_path)
+    out_dir = Path(output_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    names = {
+        "redraw_case": "redraw_cases.seed.jsonl",
+        "decompose_case": "decompose_cases.seed.jsonl",
+        "layer_generate_case": "layer_generate_cases.seed.jsonl",
+    }
+    paths: dict[str, str] = {}
+    counts: dict[str, int] = {}
+    for case_type, records in bundle.items():
+        path = out_dir / names[case_type]
+        _write_jsonl(path, records)
+        paths[case_type] = str(path)
+        counts[case_type] = len(records)
+
+    index_path = out_dir / "seed_index.json"
+    index_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "case_type": "learning_seed_index",
+                "source_manifest": str(manifest_path),
+                "paths": paths,
+                "counts": counts,
+            },
+            indent=2,
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+    return SeedWriteResult(
+        output_dir=str(out_dir),
+        paths=paths,
+        counts=counts,
+        index_path=str(index_path),
+    )
+
+
+def _load_manifest(root: Path, manifest_path: str | Path) -> dict[str, Any]:
+    path = _repo_file(root, manifest_path)
+    data = json.loads(path.read_text())
+    if data.get("case_type") != "learning_local_seed_manifest":
+        raise ValueError("local seed manifest has unexpected case_type")
+    if int(data.get("schema_version", 0) or 0) != 1:
+        raise ValueError("local seed manifest has unsupported schema_version")
+    return data
+
+
+def _build_redraw_seeds(
+    root: Path,
+    manifest: Mapping[str, Any],
+) -> list[dict[str, Any]]:
+    redraw_manifest_path = manifest.get("redraw_seed_manifest", "")
+    redraw_manifest = json.loads(_repo_file(root, redraw_manifest_path).read_text())
+    records = []
+    for item in redraw_manifest.get("items", []) or []:
+        source_artifact = str(item["source_artifact"])
+        _repo_file(root, source_artifact)
+        layer = LayerInfo(
+            id=str(item["id"]),
+            name=str(item["id"]),
+            description=str(item.get("notes", "")),
+            z_index=0,
+            content_type="seed",
+            semantic_path=str(item["id"]).replace("_", "."),
+            quality_status="seed",
+            area_pct=0.0,
+        )
+        records.append(
+            build_redraw_case(
+                artwork_dir=str(Path(source_artifact).parent),
+                source_image=source_artifact,
+                layer_info=layer,
+                instruction=str(item.get("notes", "")),
+                provider="local_seed",
+                model="tracked_artifact",
+                route_requested="seed",
+                source_layer_path=source_artifact,
+                redrawn_layer_path="",
+                redraw_advisory={
+                    "route_chosen": "",
+                    "quality_gate_passed": False,
+                    "quality_failures": [str(item["failure_type"])],
+                },
+                created_at=CREATED_AT,
+                human_accept=False,
+                failure_type=str(item["failure_type"]),
+                preferred_action=str(item["preferred_action"]),
+                reviewer="seed_manifest",
+                reviewed_at=CREATED_AT,
+            )
+        )
+    return records
+
+
+def _build_decompose_seeds(
+    root: Path,
+    manifest: Mapping[str, Any],
+) -> list[dict[str, Any]]:
+    records = []
+    for item in manifest.get("decompose_seeds", []) or []:
+        source_image = str(item["source_image"])
+        output_dir = str(item["output_dir"])
+        manifest_path = str(item["manifest_path"])
+        _repo_file(root, source_image)
+        manifest_file = _repo_file(root, manifest_path)
+        manifest_data = json.loads(manifest_file.read_text(encoding="utf-8"))
+        records.append(
+            build_decompose_case(
+                source_image=source_image,
+                mode=str(item.get("mode", "")),
+                provider=str(item.get("provider", "")),
+                model=str(item.get("model", "")),
+                tradition=str(item.get("tradition", "")),
+                output_dir=output_dir,
+                manifest_path=manifest_path,
+                manifest_data=manifest_data,
+                target_layer_hints=[],
+                created_at=CREATED_AT,
+                human_accept=bool(item.get("human_accept", False)),
+                failure_type=str(item.get("failure_type", "")),
+                preferred_action=str(item.get("preferred_action", "")),
+                reviewer="seed_manifest",
+                reviewed_at=CREATED_AT,
+                notes=str(item.get("notes", "")),
+            )
+        )
+    return records
+
+
+def _build_layer_generate_seeds(
+    root: Path,
+    manifest: Mapping[str, Any],
+) -> list[dict[str, Any]]:
+    records = []
+    for item in manifest.get("layer_generate_seeds", []) or []:
+        artifact_dir = str(item["artifact_dir"])
+        layer_manifest_path = str(item["layer_manifest_path"])
+        composite_path = str(item.get("composite_path", ""))
+        preview_path = str(item.get("preview_path", ""))
+        manifest_file = _repo_file(root, layer_manifest_path)
+        if composite_path:
+            _repo_file(root, composite_path)
+        if preview_path:
+            _repo_file(root, preview_path)
+        manifest_data = json.loads(manifest_file.read_text(encoding="utf-8"))
+        layers = manifest_data.get("layers", []) or []
+        for layer in layers:
+            layer_file = str(layer.get("file", ""))
+            if layer_file:
+                _repo_file(root, Path(artifact_dir) / layer_file)
+        layer_status = _accepted_layer_status(item)
+        records.append(
+            build_layer_generate_case(
+                user_intent=str(item["user_intent"]),
+                tradition=str(item.get("tradition", "")),
+                style_constraints=_style_constraints(manifest_data),
+                layer_plan=_layer_plan(layers),
+                prompt_stack=_prompt_stack(layers),
+                provider=str(item.get("provider", "")),
+                model=str(item.get("model", "")),
+                artifact_dir=artifact_dir,
+                layer_manifest_path=layer_manifest_path,
+                layers=_layer_outputs(artifact_dir, layers, status=layer_status),
+                composite_path=composite_path,
+                preview_path=preview_path,
+                created_at=CREATED_AT,
+                human_accept=bool(item.get("human_accept", False)),
+                failure_type=str(item.get("failure_type", "")),
+                preferred_action=str(item.get("preferred_action", "")),
+                reviewer="seed_manifest",
+                reviewed_at=CREATED_AT,
+            )
+        )
+    return records
+
+
+def _accepted_layer_status(item: Mapping[str, Any]) -> str:
+    if item.get("human_accept") is True and item.get("preferred_action") == "accept":
+        return "accepted"
+    return "generated"
+
+
+def _style_constraints(manifest_data: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        "positive": ["tracked layered artifact", "manifest-backed layer assets"],
+        "negative": [],
+        "palette": [],
+        "composition": [],
+        "required_motifs": [
+            str(layer.get("name", ""))
+            for layer in manifest_data.get("layers", []) or []
+            if layer.get("name")
+        ],
+        "prohibited_motifs": [],
+    }
+
+
+def _layer_plan(layers: list[Mapping[str, Any]]) -> dict[str, Any]:
+    planned = []
+    for layer in layers:
+        semantic_path = _semantic_path(layer)
+        planned.append(
+            {
+                "semantic_path": semantic_path,
+                "display_name": str(layer.get("name", semantic_path)),
+                "role": str(layer.get("content_type", "")),
+                "z_index": int(layer.get("z_index", 0) or 0),
+                "generation_prompt_ref": "",
+                "alpha_strategy": "manifest_layer_asset",
+                "required": True,
+            }
+        )
+    return {
+        "source": "tracked_manifest",
+        "desired_layer_count": len(planned),
+        "layers": planned,
+    }
+
+
+def _prompt_stack(layers: list[Mapping[str, Any]]) -> dict[str, Any]:
+    refs = []
+    for layer in layers:
+        prompt = str(layer.get("regeneration_prompt", ""))
+        refs.append(
+            {
+                "semantic_path": _semantic_path(layer),
+                "prompt_path": "",
+                "prompt_text_hash": _hash_text(prompt),
+            }
+        )
+    return {
+        "system_prompt_path": "",
+        "plan_prompt_path": "",
+        "layer_prompt_refs": refs,
+        "negative_prompt_path": "",
+        "provider_request": {"source": "tracked_manifest"},
+    }
+
+
+def _layer_outputs(
+    artifact_dir: str,
+    layers: list[Mapping[str, Any]],
+    *,
+    status: str,
+) -> list[dict[str, Any]]:
+    outputs = []
+    for layer in layers:
+        semantic_path = _semantic_path(layer)
+        outputs.append(
+            {
+                "semantic_path": semantic_path,
+                "asset_path": str(Path(artifact_dir) / str(layer.get("file", ""))),
+                "mask_path": "",
+                "alpha_path": "",
+                "visible": bool(layer.get("visible", True)),
+                "locked": bool(layer.get("locked", False)),
+                "status": status,
+            }
+        )
+    return outputs
+
+
+def _semantic_path(layer: Mapping[str, Any]) -> str:
+    return str(layer.get("semantic_path", "") or layer.get("name", "layer"))
+
+
+def _hash_text(value: str) -> str:
+    digest = hashlib.sha256(value.encode("utf-8")).hexdigest()
+    return f"sha256:{digest}"
+
+
+def _repo_file(root: Path, relative_path: str | Path) -> Path:
+    path = Path(relative_path)
+    if path.is_absolute():
+        raise ValueError(f"seed artifact must be repo-relative: {relative_path}")
+    resolved = (root / path).resolve()
+    if not resolved.is_relative_to(root):
+        raise ValueError(f"seed artifact escapes repo: {relative_path}")
+    if not resolved.is_file():
+        raise FileNotFoundError(str(relative_path))
+    subprocess.run(
+        ["git", "-C", str(root), "ls-files", "--error-unmatch", str(path)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return resolved
+
+
+def _write_jsonl(path: Path, records: list[Mapping[str, Any]]) -> None:
+    with path.open("w", encoding="utf-8") as fh:
+        for record in records:
+            fh.write(json.dumps(dict(record), sort_keys=True, separators=(",", ":")))
+            fh.write("\n")

--- a/tests/test_case_review.py
+++ b/tests/test_case_review.py
@@ -105,6 +105,53 @@ def test_review_case_log_rejects_invalid_labels(tmp_path):
         )
 
 
+def test_review_case_log_supports_decompose_and_layer_generate_cases(tmp_path):
+    from vulca.learning.case_review import load_cases, review_case_log
+
+    input_path = tmp_path / "cases.jsonl"
+    output_path = tmp_path / "reviewed.jsonl"
+    _write_jsonl(
+        input_path,
+        [
+            {
+                "schema_version": 1,
+                "case_type": "decompose_case",
+                "case_id": "decompose_a",
+                "review": {},
+            },
+            {
+                "schema_version": 1,
+                "case_type": "layer_generate_case",
+                "case_id": "layer_generate_a",
+                "review": {},
+            },
+        ],
+    )
+
+    review_case_log(
+        input_path,
+        case_id="decompose_a",
+        output_path=output_path,
+        failure_type="under_split",
+        preferred_action="adjust_hints",
+        reviewed_at="2026-05-05T14:00:00Z",
+    )
+    review_case_log(
+        output_path,
+        case_id="layer_generate_a",
+        output_path=output_path,
+        failure_type="missing_layer",
+        preferred_action="rerun_layer",
+        reviewed_at="2026-05-05T14:01:00Z",
+    )
+
+    reread = load_cases(output_path)
+    assert reread[0]["review"]["failure_type"] == "under_split"
+    assert reread[0]["review"]["preferred_action"] == "adjust_hints"
+    assert reread[1]["review"]["failure_type"] == "missing_layer"
+    assert reread[1]["review"]["preferred_action"] == "rerun_layer"
+
+
 def test_review_case_log_can_append_review_sidecar(tmp_path):
     from vulca.learning.case_review import review_case_log
 

--- a/tests/test_learning_seed_cases.py
+++ b/tests/test_learning_seed_cases.py
@@ -1,0 +1,114 @@
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+CLI_ENV = dict(
+    os.environ,
+    PYTHONPATH=str(ROOT / "src") + os.pathsep + os.environ.get("PYTHONPATH", ""),
+)
+
+
+def _read_jsonl(path: Path):
+    return [json.loads(line) for line in path.read_text().splitlines()]
+
+
+def test_build_local_seed_cases_uses_tracked_repo_artifacts():
+    from vulca.learning.seed_cases import DEFAULT_SEED_MANIFEST, build_local_seed_cases
+
+    bundle = build_local_seed_cases(ROOT, DEFAULT_SEED_MANIFEST)
+
+    assert len(bundle["redraw_case"]) == 6
+    assert len(bundle["decompose_case"]) == 1
+    assert len(bundle["layer_generate_case"]) == 1
+
+    redraw = bundle["redraw_case"][0]
+    assert redraw["case_type"] == "redraw_case"
+    assert redraw["review"]["failure_type"] == "color_drift"
+    assert redraw["review"]["preferred_action"] == "adjust_mask"
+    assert redraw["artifacts"]["source_layer_path"].startswith("docs/")
+
+    decompose = bundle["decompose_case"][0]
+    assert decompose["case_type"] == "decompose_case"
+    assert decompose["review"]["human_accept"] is True
+    assert decompose["review"]["preferred_action"] == "accept"
+    assert decompose["output"]["layers"]
+
+    layer_generate = bundle["layer_generate_case"][0]
+    assert layer_generate["case_type"] == "layer_generate_case"
+    assert layer_generate["review"]["human_accept"] is True
+    assert layer_generate["review"]["preferred_action"] == "accept"
+    assert layer_generate["outputs"]["layers"]
+    assert {item["status"] for item in layer_generate["outputs"]["layers"]} == {"accepted"}
+
+
+def test_write_local_seed_case_logs_creates_reviewable_jsonl(tmp_path):
+    from vulca.learning.case_review import review_case_log
+    from vulca.learning.seed_cases import DEFAULT_SEED_MANIFEST, write_local_seed_case_logs
+
+    result = write_local_seed_case_logs(
+        repo_root=ROOT,
+        output_dir=tmp_path,
+        manifest_path=DEFAULT_SEED_MANIFEST,
+    )
+
+    assert result.counts == {
+        "redraw_case": 6,
+        "decompose_case": 1,
+        "layer_generate_case": 1,
+    }
+    assert set(result.paths) == {
+        "redraw_case",
+        "decompose_case",
+        "layer_generate_case",
+    }
+    assert (tmp_path / "seed_index.json").exists()
+
+    decompose_cases = _read_jsonl(Path(result.paths["decompose_case"]))
+    review_case_log(
+        result.paths["decompose_case"],
+        case_id=decompose_cases[0]["case_id"],
+        output_path=tmp_path / "decompose.reviewed.jsonl",
+        failure_type="under_split",
+        preferred_action="adjust_hints",
+        reviewed_at="2026-05-05T14:30:00Z",
+    )
+    reviewed = _read_jsonl(tmp_path / "decompose.reviewed.jsonl")
+    assert reviewed[0]["review"]["failure_type"] == "under_split"
+    assert reviewed[0]["review"]["preferred_action"] == "adjust_hints"
+
+
+def test_cases_seed_cli_writes_seed_logs(tmp_path):
+    output_dir = tmp_path / "seed-output"
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "vulca.cli",
+            "cases",
+            "seed",
+            "--repo-root",
+            str(ROOT),
+            "--output",
+            str(output_dir),
+        ],
+        capture_output=True,
+        text=True,
+        timeout=20,
+        env=CLI_ENV,
+        cwd=tmp_path,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "redraw_case: 6" in result.stdout
+    assert "decompose_case: 1" in result.stdout
+    assert "layer_generate_case: 1" in result.stdout
+    assert (output_dir / "redraw_cases.seed.jsonl").exists()
+    assert (output_dir / "decompose_cases.seed.jsonl").exists()
+    assert (output_dir / "layer_generate_cases.seed.jsonl").exists()
+
+    decompose_cases = _read_jsonl(output_dir / "decompose_cases.seed.jsonl")
+    assert decompose_cases[0]["output"]["layers"]


### PR DESCRIPTION
## Summary
- Add a tracked local seed manifest plus generator for redraw, decompose, and layer_generate learning case logs.
- Add `vulca cases seed --output DIR` with optional `--repo-root` and `--manifest` inputs.
- Extend case review labeling to validate decompose and layer_generate case labels in addition to redraw.

## Why
This gives the tiny router / tiny agent learning loop a reproducible local seed dataset without committing generated JSONL outputs. The generator only consumes repo-tracked artifacts, so local seed runs are stable and reviewable.

## Test Plan
- `PYTHONPATH=src /opt/homebrew/bin/python3.11 -m pytest tests/test_case_review.py tests/test_learning_seed_cases.py tests/test_redraw_cases.py tests/test_decompose_cases.py tests/test_layer_generate_cases.py tests/test_redraw_router_baseline.py tests/test_redraw_benchmark_manifest.py -v`
- `PYTHONPATH=src /opt/homebrew/bin/python3.11 -m py_compile src/vulca/learning/seed_cases.py src/vulca/learning/case_review.py src/vulca/cli.py`
- `git diff --cached --check`
- `PYTHONPATH=src /opt/homebrew/bin/python3.11 -m vulca.cli cases seed --repo-root /Users/yhryzy/dev/vulca/.worktrees/local-case-seed-conversion --output /tmp/vulca-local-seeds.NGJaHC`
- `PYTHONPATH=src /opt/homebrew/bin/python3.11 scripts/redraw_router_baseline_eval.py /tmp/vulca-local-seeds.NGJaHC/redraw_cases.seed.jsonl --policy label_oracle`
