### PR TITLE
[codex] Report local seed baselines

### DIFF
--- a/src/vulca/cli.py
+++ b/src/vulca/cli.py
@@ -359,6 +359,33 @@ def main(argv: list[str] | None = None) -> None:
         default="",
         help="Seed manifest path (default: docs/benchmarks/learning/local_seed_manifest.json)",
     )
+    cases_baseline = cases_sub.add_parser(
+        "baseline-report",
+        help="Build local seed baseline metrics report",
+    )
+    cases_baseline.add_argument(
+        "--output",
+        "-o",
+        required=True,
+        help="Output JSON report path",
+    )
+    cases_baseline.add_argument(
+        "--repo-root",
+        default="",
+        help="Repository root (default: current working directory)",
+    )
+    cases_baseline.add_argument(
+        "--manifest",
+        default="",
+        help="Seed manifest path (default: docs/benchmarks/learning/local_seed_manifest.json)",
+    )
+    cases_baseline.add_argument(
+        "--policy",
+        action="append",
+        default=[],
+        choices=("label_oracle", "observable_signal"),
+        help="Redraw router policy to evaluate; repeat to include multiple policies",
+    )
 
     # resume command
     resume_p = sub.add_parser("resume", help="Resume pipeline from checkpoint")
@@ -1666,6 +1693,34 @@ def _cmd_layers(args: argparse.Namespace) -> None:
 
 def _cmd_cases(args: argparse.Namespace) -> None:
     import json as _json
+
+    if args.cases_command == "baseline-report":
+        from vulca.learning.seed_report import (
+            DEFAULT_BASELINE_POLICIES,
+            write_local_seed_baseline_report,
+        )
+        from vulca.learning.seed_cases import DEFAULT_SEED_MANIFEST
+
+        policies = tuple(args.policy) if args.policy else DEFAULT_BASELINE_POLICIES
+        try:
+            output_path = write_local_seed_baseline_report(
+                repo_root=args.repo_root or Path.cwd(),
+                output_path=args.output,
+                manifest_path=args.manifest or DEFAULT_SEED_MANIFEST,
+                policies=policies,
+            )
+            report = _json.loads(Path(output_path).read_text(encoding="utf-8"))
+        except (ValueError, FileNotFoundError, subprocess.CalledProcessError, _json.JSONDecodeError) as exc:
+            print(f"Error: {exc}", file=sys.stderr)
+            sys.exit(1)
+
+        print(f"  Baseline report: {output_path}")
+        for case_type in sorted(report["seed_counts"]):
+            print(f"  {case_type}: {report['seed_counts'][case_type]}")
+        for policy in policies:
+            metrics = report["redraw_router_baselines"][policy]
+            print(f"  {policy} action_accuracy: {metrics['action_accuracy']}")
+        return
 
     if args.cases_command == "seed":
         from vulca.learning.seed_cases import (

--- a/src/vulca/learning/seed_report.py
+++ b/src/vulca/learning/seed_report.py
@@ -1,0 +1,152 @@
+"""Build baseline reports from local seed case records."""
+from __future__ import annotations
+
+import json
+from collections import Counter
+from pathlib import Path
+from typing import Any, Iterable, Mapping, Sequence
+
+from vulca.layers.redraw_router_baseline import (
+    POLICIES as REDRAW_ROUTER_POLICIES,
+    POLICY_LABEL_ORACLE,
+    POLICY_OBSERVABLE_SIGNAL,
+    evaluate_records,
+    recommend_action,
+)
+from vulca.learning.seed_cases import DEFAULT_SEED_MANIFEST, build_local_seed_cases
+
+
+CASE_TYPE = "learning_local_seed_baseline_report"
+SCHEMA_VERSION = 1
+DEFAULT_BASELINE_POLICIES: tuple[str, ...] = (
+    POLICY_LABEL_ORACLE,
+    POLICY_OBSERVABLE_SIGNAL,
+)
+
+
+def build_local_seed_baseline_report(
+    repo_root: str | Path,
+    manifest_path: str | Path = DEFAULT_SEED_MANIFEST,
+    policies: Sequence[str] = DEFAULT_BASELINE_POLICIES,
+) -> dict[str, Any]:
+    """Build a reproducible baseline report from tracked local seed cases."""
+    checked_policies = _validate_policies(policies)
+    bundle = build_local_seed_cases(repo_root, manifest_path)
+    redraw_records = bundle.get("redraw_case", [])
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "case_type": CASE_TYPE,
+        "source_manifest": str(manifest_path),
+        "seed_counts": {
+            case_type: len(records) for case_type, records in sorted(bundle.items())
+        },
+        "review_summary": {
+            case_type: _review_summary(records)
+            for case_type, records in sorted(bundle.items())
+        },
+        "redraw_router_baselines": {
+            policy: evaluate_records(redraw_records, policy_name=policy)
+            for policy in checked_policies
+        },
+        "redraw_router_mismatches": {
+            policy: _redraw_router_mismatches(redraw_records, policy)
+            for policy in checked_policies
+        },
+    }
+
+
+def write_local_seed_baseline_report(
+    *,
+    repo_root: str | Path,
+    output_path: str | Path,
+    manifest_path: str | Path = DEFAULT_SEED_MANIFEST,
+    policies: Sequence[str] = DEFAULT_BASELINE_POLICIES,
+) -> str:
+    report = build_local_seed_baseline_report(
+        repo_root=repo_root,
+        manifest_path=manifest_path,
+        policies=policies,
+    )
+    path = Path(output_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(report, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return str(path)
+
+
+def _validate_policies(policies: Sequence[str]) -> tuple[str, ...]:
+    checked = tuple(str(item) for item in policies)
+    if not checked:
+        raise ValueError("at least one baseline policy is required")
+    unsupported = sorted(set(checked) - REDRAW_ROUTER_POLICIES)
+    if unsupported:
+        raise ValueError(
+            f"unsupported baseline policy {unsupported}; "
+            f"expected one of {sorted(REDRAW_ROUTER_POLICIES)}"
+        )
+    return checked
+
+
+def _review_summary(records: Iterable[Mapping[str, Any]]) -> dict[str, Any]:
+    items = list(records)
+    accept_counts = {"true": 0, "false": 0, "unlabeled": 0}
+    failure_counts: Counter[str] = Counter()
+    action_counts: Counter[str] = Counter()
+
+    for record in items:
+        review = _mapping(record.get("review"))
+        human_accept = review.get("human_accept")
+        if human_accept is True:
+            accept_counts["true"] += 1
+        elif human_accept is False:
+            accept_counts["false"] += 1
+        else:
+            accept_counts["unlabeled"] += 1
+
+        failure_type = str(review.get("failure_type") or "")
+        preferred_action = str(review.get("preferred_action") or "")
+        if failure_type:
+            failure_counts[failure_type] += 1
+        if preferred_action:
+            action_counts[preferred_action] += 1
+
+    return {
+        "case_count": len(items),
+        "human_accept_counts": accept_counts,
+        "failure_type_counts": dict(sorted(failure_counts.items())),
+        "preferred_action_counts": dict(sorted(action_counts.items())),
+    }
+
+
+def _redraw_router_mismatches(
+    records: Iterable[Mapping[str, Any]],
+    policy_name: str,
+) -> list[dict[str, Any]]:
+    mismatches = []
+    for record in records:
+        review = _mapping(record.get("review"))
+        target_action = str(review.get("preferred_action") or "")
+        if not target_action:
+            continue
+        recommendation = recommend_action(record, policy_name=policy_name)
+        if recommendation.recommended_action == target_action:
+            continue
+        mismatches.append(
+            {
+                "case_id": str(record.get("case_id", "")),
+                "failure_type": str(review.get("failure_type") or ""),
+                "target_action": target_action,
+                "recommended_action": recommendation.recommended_action,
+                "failure_hint": recommendation.failure_hint,
+                "rule_reason": recommendation.rule_reason,
+            }
+        )
+    return mismatches
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    if isinstance(value, Mapping):
+        return value
+    return {}

--- a/tests/test_learning_seed_report.py
+++ b/tests/test_learning_seed_report.py
@@ -1,0 +1,85 @@
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+CLI_ENV = dict(
+    os.environ,
+    PYTHONPATH=str(ROOT / "src") + os.pathsep + os.environ.get("PYTHONPATH", ""),
+)
+
+
+def test_build_local_seed_baseline_report_summarizes_cases_and_router_metrics():
+    from vulca.learning.seed_report import build_local_seed_baseline_report
+
+    report = build_local_seed_baseline_report(ROOT)
+
+    assert report["case_type"] == "learning_local_seed_baseline_report"
+    assert report["seed_counts"] == {
+        "redraw_case": 6,
+        "decompose_case": 1,
+        "layer_generate_case": 1,
+    }
+    assert report["review_summary"]["redraw_case"]["preferred_action_counts"][
+        "adjust_mask"
+    ] == 2
+    assert report["review_summary"]["decompose_case"]["human_accept_counts"][
+        "true"
+    ] == 1
+
+    label_oracle = report["redraw_router_baselines"]["label_oracle"]
+    assert label_oracle["case_count"] == 6
+    assert label_oracle["action_accuracy"] == 1.0
+    assert report["redraw_router_mismatches"]["label_oracle"] == []
+
+    observable = report["redraw_router_baselines"]["observable_signal"]
+    assert observable["case_count"] == 6
+    assert observable["action_accuracy"] == 0.5
+    assert len(report["redraw_router_mismatches"]["observable_signal"]) == 3
+
+
+def test_write_local_seed_baseline_report_creates_json(tmp_path):
+    from vulca.learning.seed_report import write_local_seed_baseline_report
+
+    output_path = tmp_path / "local_seed_baseline_report.json"
+
+    result_path = write_local_seed_baseline_report(
+        repo_root=ROOT,
+        output_path=output_path,
+    )
+
+    assert result_path == str(output_path)
+    report = json.loads(output_path.read_text(encoding="utf-8"))
+    assert report["redraw_router_baselines"]["observable_signal"][
+        "failure_macro_f1"
+    ] == 0.42857142857142855
+
+
+def test_cases_baseline_report_cli_writes_report(tmp_path):
+    output_path = tmp_path / "baseline.json"
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "vulca.cli",
+            "cases",
+            "baseline-report",
+            "--repo-root",
+            str(ROOT),
+            "--output",
+            str(output_path),
+        ],
+        capture_output=True,
+        text=True,
+        timeout=20,
+        env=CLI_ENV,
+        cwd=tmp_path,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert output_path.exists()
+    assert "Baseline report:" in result.stdout
+    assert "observable_signal action_accuracy: 0.5" in result.stdout


### PR DESCRIPTION
## Summary
- Add `vulca.learning.seed_report` to build a reproducible local seed baseline report.
- Add `vulca cases baseline-report --output PATH` for seed counts, review label summaries, redraw router baseline metrics, and mismatch records.
- Cover the report builder, writer, and CLI with focused tests.

## Why
#49 gives us reproducible local seed cases. This PR turns those seeds into a stable calibration report for the tiny router path, showing where the observable-signal baseline diverges from reviewed local labels.

## Current local seed signal
- Seed counts: 6 redraw, 1 decompose, 1 layer_generate
- `label_oracle` redraw action accuracy: 1.0
- `observable_signal` redraw action accuracy: 0.5
- `observable_signal` mismatch count: 3

## Test Plan
- `PYTHONPATH=src /opt/homebrew/bin/python3.11 -m pytest tests/test_learning_seed_report.py tests/test_learning_seed_cases.py tests/test_case_review.py tests/test_redraw_router_baseline.py tests/test_redraw_cases.py tests/test_decompose_cases.py tests/test_layer_generate_cases.py tests/test_cli_commands.py::TestCLICommands::test_layers_redraw_help_mentions_case_log tests/test_cli_commands.py::TestCLICommands::test_layers_split_help_mentions_case_log -v`
- `PYTHONPATH=src /opt/homebrew/bin/python3.11 -m py_compile src/vulca/learning/seed_report.py src/vulca/learning/seed_cases.py src/vulca/learning/case_review.py src/vulca/cli.py`
- `git diff --check`
- `PYTHONPATH=src /opt/homebrew/bin/python3.11 -m vulca.cli cases baseline-report --repo-root /Users/yhryzy/dev/vulca/.worktrees/local-seed-baseline-report --output /tmp/vulca-baseline-report.HDlSVC/report.json`
