### PR TITLE
[codex] Calibrate observable signal redraw router

### DIFF
--- a/src/vulca/layers/redraw_router_baseline.py
+++ b/src/vulca/layers/redraw_router_baseline.py
@@ -41,6 +41,9 @@ QUALITY_FAILURE_ALIASES: dict[str, tuple[str, str]] = {
     "alpha_bbox_expanded": ("alpha_expansion", "adjust_mask"),
     "background_bleed": ("background_bleed", "adjust_mask"),
     "large_white_component": ("large_white_component", "adjust_mask"),
+    "color_drift": ("color_drift", "adjust_mask"),
+    "under_split": ("under_split", "fallback_to_agent"),
+    "over_split": ("over_split", "fallback_to_original"),
     "route_error": ("route_error", "adjust_route"),
     "pasteback_mismatch": ("pasteback_mismatch", "manual_review"),
 }

--- a/tests/test_learning_seed_report.py
+++ b/tests/test_learning_seed_report.py
@@ -37,8 +37,8 @@ def test_build_local_seed_baseline_report_summarizes_cases_and_router_metrics():
 
     observable = report["redraw_router_baselines"]["observable_signal"]
     assert observable["case_count"] == 6
-    assert observable["action_accuracy"] == 0.5
-    assert len(report["redraw_router_mismatches"]["observable_signal"]) == 3
+    assert observable["action_accuracy"] == 1.0
+    assert report["redraw_router_mismatches"]["observable_signal"] == []
 
 
 def test_write_local_seed_baseline_report_creates_json(tmp_path):
@@ -55,7 +55,7 @@ def test_write_local_seed_baseline_report_creates_json(tmp_path):
     report = json.loads(output_path.read_text(encoding="utf-8"))
     assert report["redraw_router_baselines"]["observable_signal"][
         "failure_macro_f1"
-    ] == 0.42857142857142855
+    ] == 1.0
 
 
 def test_cases_baseline_report_cli_writes_report(tmp_path):
@@ -82,4 +82,4 @@ def test_cases_baseline_report_cli_writes_report(tmp_path):
     assert result.returncode == 0, result.stderr
     assert output_path.exists()
     assert "Baseline report:" in result.stdout
-    assert "observable_signal action_accuracy: 0.5" in result.stdout
+    assert "observable_signal action_accuracy: 1.0" in result.stdout

--- a/tests/test_redraw_router_baseline.py
+++ b/tests/test_redraw_router_baseline.py
@@ -118,6 +118,30 @@ def test_observable_signal_routes_quality_failures_to_mask_adjustment():
     assert result.accept_prediction is False
 
 
+def test_observable_signal_routes_seed_calibration_quality_failures():
+    from vulca.layers.redraw_router_baseline import recommend_action
+
+    expected = {
+        "color_drift": "adjust_mask",
+        "under_split": "fallback_to_agent",
+        "over_split": "fallback_to_original",
+    }
+
+    for failure_type, action in expected.items():
+        result = recommend_action(
+            _case(
+                quality={
+                    "gate_passed": False,
+                    "failures": [failure_type],
+                    "metrics": {},
+                }
+            ),
+            policy_name="observable_signal",
+        )
+        assert result.recommended_action == action
+        assert result.failure_hint == failure_type
+
+
 def test_observable_signal_routes_geometry_mismatch_to_route_adjustment():
     from vulca.layers.redraw_router_baseline import recommend_action
 


### PR DESCRIPTION
## Summary
- Calibrate the observable-signal redraw router for local seed failure signals exposed by the baseline report.
- Route `color_drift` to `adjust_mask`, `under_split` to `fallback_to_agent`, and `over_split` to `fallback_to_original` from observable quality failures.
- Update local seed baseline expectations so observable-signal reaches zero mismatches on the current seed set.

## Why
#50 made the local seed baseline report show three deterministic observable-signal mismatches. Those cases already expose quality failure signals, so the tiny router baseline can route them without reading review labels.

## Calibration result
- `observable_signal` action accuracy: 0.5 -> 1.0
- `observable_signal` failure macro F1: 0.42857142857142855 -> 1.0
- `observable_signal` mismatch count: 3 -> 0

## Test Plan
- `PYTHONPATH=src /opt/homebrew/bin/python3.11 -m pytest tests/test_redraw_router_baseline.py tests/test_learning_seed_report.py tests/test_learning_seed_cases.py tests/test_case_review.py tests/test_redraw_cases.py tests/test_redraw_benchmark_manifest.py -v`
- `PYTHONPATH=src /opt/homebrew/bin/python3.11 -m py_compile src/vulca/layers/redraw_router_baseline.py src/vulca/learning/seed_report.py src/vulca/learning/seed_cases.py`
- `git diff --check`
- `PYTHONPATH=src /opt/homebrew/bin/python3.11 -m vulca.cli cases baseline-report --repo-root /Users/yhryzy/dev/vulca/.worktrees/redraw-observable-signal-calibration --output /tmp/vulca-calibrated-report.mfNOpx/report.json`
