### PR TITLE
[codex] Gate local seed baselines

### DIFF
--- a/src/vulca/cli.py
+++ b/src/vulca/cli.py
@@ -386,6 +386,20 @@ def main(argv: list[str] | None = None) -> None:
         choices=("label_oracle", "observable_signal"),
         help="Redraw router policy to evaluate; repeat to include multiple policies",
     )
+    cases_baseline.add_argument(
+        "--min-action-accuracy",
+        action="append",
+        default=[],
+        metavar="POLICY=VALUE",
+        help="Fail if a policy action_accuracy is below VALUE",
+    )
+    cases_baseline.add_argument(
+        "--max-mismatches",
+        action="append",
+        default=[],
+        metavar="POLICY=COUNT",
+        help="Fail if a policy has more than COUNT mismatched cases",
+    )
 
     # resume command
     resume_p = sub.add_parser("resume", help="Resume pipeline from checkpoint")
@@ -1697,6 +1711,9 @@ def _cmd_cases(args: argparse.Namespace) -> None:
     if args.cases_command == "baseline-report":
         from vulca.learning.seed_report import (
             DEFAULT_BASELINE_POLICIES,
+            check_baseline_report,
+            parse_policy_int_thresholds,
+            parse_policy_thresholds,
             write_local_seed_baseline_report,
         )
         from vulca.learning.seed_cases import DEFAULT_SEED_MANIFEST
@@ -1710,6 +1727,13 @@ def _cmd_cases(args: argparse.Namespace) -> None:
                 policies=policies,
             )
             report = _json.loads(Path(output_path).read_text(encoding="utf-8"))
+            violations = check_baseline_report(
+                report,
+                min_action_accuracy=parse_policy_thresholds(
+                    args.min_action_accuracy
+                ),
+                max_mismatches=parse_policy_int_thresholds(args.max_mismatches),
+            )
         except (ValueError, FileNotFoundError, subprocess.CalledProcessError, _json.JSONDecodeError) as exc:
             print(f"Error: {exc}", file=sys.stderr)
             sys.exit(1)
@@ -1720,6 +1744,24 @@ def _cmd_cases(args: argparse.Namespace) -> None:
         for policy in policies:
             metrics = report["redraw_router_baselines"][policy]
             print(f"  {policy} action_accuracy: {metrics['action_accuracy']}")
+        if violations:
+            print("Baseline gate failed:", file=sys.stderr)
+            for item in violations:
+                if item["metric"] == "action_accuracy":
+                    expected = str(item["expected"]).replace(">= ", "")
+                    print(
+                        f"  {item['policy']} action_accuracy "
+                        f"{item['actual']} < {expected}",
+                        file=sys.stderr,
+                    )
+                elif item["metric"] == "mismatch_count":
+                    expected = str(item["expected"]).replace("<= ", "")
+                    print(
+                        f"  {item['policy']} mismatch_count "
+                        f"{item['actual']} > {expected}",
+                        file=sys.stderr,
+                    )
+            sys.exit(1)
         return
 
     if args.cases_command == "seed":

--- a/src/vulca/learning/seed_report.py
+++ b/src/vulca/learning/seed_report.py
@@ -76,6 +76,82 @@ def write_local_seed_baseline_report(
     return str(path)
 
 
+def parse_policy_thresholds(values: Sequence[str]) -> dict[str, float]:
+    """Parse CLI ``policy=value`` threshold pairs."""
+    thresholds: dict[str, float] = {}
+    for raw in values:
+        if "=" not in raw:
+            raise ValueError(
+                f"invalid baseline threshold {raw!r}; expected POLICY=VALUE"
+            )
+        policy, value = raw.split("=", 1)
+        policy = policy.strip()
+        if policy not in REDRAW_ROUTER_POLICIES:
+            raise ValueError(
+                f"unsupported baseline policy {policy!r}; "
+                f"expected one of {sorted(REDRAW_ROUTER_POLICIES)}"
+            )
+        try:
+            thresholds[policy] = float(value.strip())
+        except ValueError as exc:
+            raise ValueError(
+                f"invalid threshold value {value!r} for policy {policy!r}"
+            ) from exc
+    return thresholds
+
+
+def parse_policy_int_thresholds(values: Sequence[str]) -> dict[str, int]:
+    """Parse CLI ``policy=count`` threshold pairs."""
+    thresholds: dict[str, int] = {}
+    for policy, value in parse_policy_thresholds(values).items():
+        count = int(value)
+        if count != value:
+            raise ValueError(
+                f"integer threshold required for policy {policy!r}: {value!r}"
+            )
+        thresholds[policy] = count
+    return thresholds
+
+
+def check_baseline_report(
+    report: Mapping[str, Any],
+    *,
+    min_action_accuracy: Mapping[str, float] | None = None,
+    max_mismatches: Mapping[str, int] | None = None,
+) -> list[dict[str, Any]]:
+    """Return threshold violations for a local seed baseline report."""
+    violations: list[dict[str, Any]] = []
+    baselines = _mapping(report.get("redraw_router_baselines"))
+    mismatches = _mapping(report.get("redraw_router_mismatches"))
+
+    for policy, threshold in sorted((min_action_accuracy or {}).items()):
+        metrics = _mapping(baselines.get(policy))
+        actual = metrics.get("action_accuracy")
+        if actual is None or float(actual) < float(threshold):
+            violations.append(
+                {
+                    "policy": str(policy),
+                    "metric": "action_accuracy",
+                    "actual": actual,
+                    "expected": f">= {float(threshold)}",
+                }
+            )
+
+    for policy, threshold in sorted((max_mismatches or {}).items()):
+        actual = len(list(mismatches.get(policy) or []))
+        if actual > int(threshold):
+            violations.append(
+                {
+                    "policy": str(policy),
+                    "metric": "mismatch_count",
+                    "actual": actual,
+                    "expected": f"<= {int(threshold)}",
+                }
+            )
+
+    return violations
+
+
 def _validate_policies(policies: Sequence[str]) -> tuple[str, ...]:
     checked = tuple(str(item) for item in policies)
     if not checked:

--- a/tests/test_learning_seed_report.py
+++ b/tests/test_learning_seed_report.py
@@ -58,6 +58,62 @@ def test_write_local_seed_baseline_report_creates_json(tmp_path):
     ] == 1.0
 
 
+def test_baseline_gate_returns_violations_for_threshold_regressions():
+    from vulca.learning.seed_report import (
+        build_local_seed_baseline_report,
+        check_baseline_report,
+    )
+
+    report = build_local_seed_baseline_report(ROOT)
+    assert check_baseline_report(
+        report,
+        min_action_accuracy={"observable_signal": 1.0},
+        max_mismatches={"observable_signal": 0},
+    ) == []
+
+    regressed = json.loads(json.dumps(report))
+    regressed["redraw_router_baselines"]["observable_signal"]["action_accuracy"] = 0.5
+    regressed["redraw_router_mismatches"]["observable_signal"] = [
+        {"case_id": "seed_regression"}
+    ]
+
+    violations = check_baseline_report(
+        regressed,
+        min_action_accuracy={"observable_signal": 1.0},
+        max_mismatches={"observable_signal": 0},
+    )
+
+    assert violations == [
+        {
+            "policy": "observable_signal",
+            "metric": "action_accuracy",
+            "actual": 0.5,
+            "expected": ">= 1.0",
+        },
+        {
+            "policy": "observable_signal",
+            "metric": "mismatch_count",
+            "actual": 1,
+            "expected": "<= 0",
+        },
+    ]
+
+
+def test_parse_baseline_gate_thresholds_validates_policy_values():
+    from vulca.learning.seed_report import parse_policy_thresholds
+
+    assert parse_policy_thresholds(["observable_signal=1.0"]) == {
+        "observable_signal": 1.0
+    }
+
+    try:
+        parse_policy_thresholds(["unknown=1.0"])
+    except ValueError as exc:
+        assert "unsupported baseline policy" in str(exc)
+    else:
+        raise AssertionError("expected unsupported policy to be rejected")
+
+
 def test_cases_baseline_report_cli_writes_report(tmp_path):
     output_path = tmp_path / "baseline.json"
     result = subprocess.run(
@@ -83,3 +139,34 @@ def test_cases_baseline_report_cli_writes_report(tmp_path):
     assert output_path.exists()
     assert "Baseline report:" in result.stdout
     assert "observable_signal action_accuracy: 1.0" in result.stdout
+
+
+def test_cases_baseline_report_cli_fails_when_gate_violates(tmp_path):
+    output_path = tmp_path / "baseline.json"
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "vulca.cli",
+            "cases",
+            "baseline-report",
+            "--repo-root",
+            str(ROOT),
+            "--output",
+            str(output_path),
+            "--min-action-accuracy",
+            "observable_signal=1.01",
+            "--max-mismatches",
+            "observable_signal=0",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=20,
+        env=CLI_ENV,
+        cwd=tmp_path,
+    )
+
+    assert result.returncode == 1
+    assert output_path.exists()
+    assert "Baseline gate failed:" in result.stderr
+    assert "observable_signal action_accuracy 1.0 < 1.01" in result.stderr


### PR DESCRIPTION
## Summary
- Add baseline gate helpers for local seed reports.
- Add `--min-action-accuracy POLICY=VALUE` and `--max-mismatches POLICY=COUNT` to `vulca cases baseline-report`.
- Keep report generation non-destructive: reports are written even when a gate fails, while the CLI exits non-zero for automation.

## Why
#51 calibrated the current observable-signal router to zero local seed mismatches. This PR adds the guardrail so future router changes can use the same baseline report command as a regression gate.

## Example
Passing gate:
```bash
vulca cases baseline-report --output report.json \
  --min-action-accuracy observable_signal=1.0 \
  --max-mismatches observable_signal=0
```

Failing gate exits `1` and prints the violated metric.

## Test Plan
- `PYTHONPATH=src /opt/homebrew/bin/python3.11 -m pytest tests/test_learning_seed_report.py tests/test_learning_seed_cases.py tests/test_case_review.py tests/test_redraw_router_baseline.py tests/test_redraw_cases.py tests/test_redraw_benchmark_manifest.py -v`
- `PYTHONPATH=src /opt/homebrew/bin/python3.11 -m py_compile src/vulca/learning/seed_report.py src/vulca/cli.py`
- `git diff --check`
- `PYTHONPATH=src /opt/homebrew/bin/python3.11 -m vulca.cli cases baseline-report --repo-root /Users/yhryzy/dev/vulca/.worktrees/local-seed-baseline-gate --output /tmp/vulca-baseline-gate.0XOxgU/pass.json --min-action-accuracy observable_signal=1.0 --max-mismatches observable_signal=0`
- `PYTHONPATH=src /opt/homebrew/bin/python3.11 -m vulca.cli cases baseline-report --repo-root /Users/yhryzy/dev/vulca/.worktrees/local-seed-baseline-gate --output /tmp/vulca-baseline-gate.0XOxgU/fail.json --min-action-accuracy observable_signal=1.01 --max-mismatches observable_signal=0`
