### PR TITLE
[codex] Expand local layer seed set

### DIFF
--- a/docs/benchmarks/learning/local_seed_manifest.json
+++ b/docs/benchmarks/learning/local_seed_manifest.json
@@ -20,6 +20,34 @@
   ],
   "layer_generate_seeds": [
     {
+      "id": "demo_layers_extract_layer_generate",
+      "user_intent": "Generate a layered Chinese ink landscape with paper background, distant mountains, midground landscape, pavilion pines, mist, and calligraphy/seals.",
+      "tradition": "chinese_xieyi",
+      "provider": "local_seed",
+      "model": "tracked_artifact",
+      "artifact_dir": "assets/demo/v2/layers-extract",
+      "layer_manifest_path": "assets/demo/v2/layers-extract/manifest.json",
+      "composite_path": "assets/demo/v2/layers-extract/composite.png",
+      "preview_path": "assets/demo/v2/layers-extract/composite.png",
+      "human_accept": true,
+      "failure_type": "",
+      "preferred_action": "accept"
+    },
+    {
+      "id": "scenario1_layer_generate",
+      "user_intent": "Generate a layered Chinese ink mountain landscape with canvas, distant mountains, mist, midground landscape, and calligraphy/seals.",
+      "tradition": "chinese_xieyi",
+      "provider": "local_seed",
+      "model": "tracked_artifact",
+      "artifact_dir": "assets/demo/v2/scenario1",
+      "layer_manifest_path": "assets/demo/v2/scenario1/manifest.json",
+      "composite_path": "assets/demo/v2/scenario1/final-with-sunset.png",
+      "preview_path": "assets/demo/v2/scenario1/preview-no-mist.png",
+      "human_accept": true,
+      "failure_type": "",
+      "preferred_action": "accept"
+    },
+    {
       "id": "scenario1_redo_layer_generate",
       "user_intent": "Generate a layered Chinese ink landscape with sky, mountains, midground landscape, pavilion pines, and calligraphy/seals.",
       "tradition": "chinese_xieyi",
@@ -29,6 +57,30 @@
       "layer_manifest_path": "assets/demo/v2/scenario1-redo/manifest.json",
       "composite_path": "assets/demo/v2/scenario1-redo/after.png",
       "preview_path": "assets/demo/v2/scenario1-redo/after.png",
+      "human_accept": true,
+      "failure_type": "",
+      "preferred_action": "accept"
+    },
+    {
+      "id": "great_wave_layer_generate",
+      "user_intent": "Generate a layered ukiyo-e wave composition with background, subject wave, and foreground water forms.",
+      "tradition": "ukiyoe",
+      "provider": "local_seed",
+      "model": "tracked_artifact",
+      "artifact_dir": "assets/showcase/layers/great-wave",
+      "layer_manifest_path": "assets/showcase/layers/great-wave/manifest.json",
+      "human_accept": true,
+      "failure_type": "",
+      "preferred_action": "accept"
+    },
+    {
+      "id": "nighthawks_v2_layer_generate",
+      "user_intent": "Generate a layered Nighthawks-style diner scene with separated people, diner interior, glass, street buildings, and residual layer.",
+      "tradition": "american_modernism",
+      "provider": "local_seed",
+      "model": "tracked_artifact",
+      "artifact_dir": "assets/showcase/layers_v2/nighthawks",
+      "layer_manifest_path": "assets/showcase/layers_v2/nighthawks/manifest.json",
       "human_accept": true,
       "failure_type": "",
       "preferred_action": "accept"

--- a/tests/test_learning_seed_cases.py
+++ b/tests/test_learning_seed_cases.py
@@ -23,7 +23,7 @@ def test_build_local_seed_cases_uses_tracked_repo_artifacts():
 
     assert len(bundle["redraw_case"]) == 6
     assert len(bundle["decompose_case"]) == 1
-    assert len(bundle["layer_generate_case"]) == 1
+    assert len(bundle["layer_generate_case"]) == 5
 
     redraw = bundle["redraw_case"][0]
     assert redraw["case_type"] == "redraw_case"
@@ -43,6 +43,16 @@ def test_build_local_seed_cases_uses_tracked_repo_artifacts():
     assert layer_generate["review"]["preferred_action"] == "accept"
     assert layer_generate["outputs"]["layers"]
     assert {item["status"] for item in layer_generate["outputs"]["layers"]} == {"accepted"}
+    assert {
+        item["outputs"]["artifact_dir"]
+        for item in bundle["layer_generate_case"]
+    } == {
+        "assets/demo/v2/layers-extract",
+        "assets/demo/v2/scenario1",
+        "assets/demo/v2/scenario1-redo",
+        "assets/showcase/layers/great-wave",
+        "assets/showcase/layers_v2/nighthawks",
+    }
 
 
 def test_write_local_seed_case_logs_creates_reviewable_jsonl(tmp_path):
@@ -58,7 +68,7 @@ def test_write_local_seed_case_logs_creates_reviewable_jsonl(tmp_path):
     assert result.counts == {
         "redraw_case": 6,
         "decompose_case": 1,
-        "layer_generate_case": 1,
+        "layer_generate_case": 5,
     }
     assert set(result.paths) == {
         "redraw_case",
@@ -105,7 +115,7 @@ def test_cases_seed_cli_writes_seed_logs(tmp_path):
     assert result.returncode == 0, result.stderr
     assert "redraw_case: 6" in result.stdout
     assert "decompose_case: 1" in result.stdout
-    assert "layer_generate_case: 1" in result.stdout
+    assert "layer_generate_case: 5" in result.stdout
     assert (output_dir / "redraw_cases.seed.jsonl").exists()
     assert (output_dir / "decompose_cases.seed.jsonl").exists()
     assert (output_dir / "layer_generate_cases.seed.jsonl").exists()

--- a/tests/test_learning_seed_report.py
+++ b/tests/test_learning_seed_report.py
@@ -21,7 +21,7 @@ def test_build_local_seed_baseline_report_summarizes_cases_and_router_metrics():
     assert report["seed_counts"] == {
         "redraw_case": 6,
         "decompose_case": 1,
-        "layer_generate_case": 1,
+        "layer_generate_case": 5,
     }
     assert report["review_summary"]["redraw_case"]["preferred_action_counts"][
         "adjust_mask"


### PR DESCRIPTION
## Summary
- Expand the tracked local seed manifest with four additional layer_generate seeds.
- Add demo extraction, demo scenario1, Great Wave, and Nighthawks v2 layered artifacts.
- Update seed/report tests for 12 total local seed cases: 6 redraw, 1 decompose, 5 layer_generate.

## Why
The local seed pipeline now has generation/report/gate support. This PR starts widening the seed set using only repo-tracked layered artifacts, without committing generated JSONL outputs.

## Added layer seeds
- `assets/demo/v2/layers-extract`
- `assets/demo/v2/scenario1`
- `assets/showcase/layers/great-wave`
- `assets/showcase/layers_v2/nighthawks`

## Test Plan
- `PYTHONPATH=src /opt/homebrew/bin/python3.11 -m pytest tests/test_learning_seed_cases.py tests/test_learning_seed_report.py tests/test_case_review.py tests/test_layer_generate_cases.py tests/test_redraw_router_baseline.py tests/test_redraw_cases.py tests/test_redraw_benchmark_manifest.py -v`
- `PYTHONPATH=src /opt/homebrew/bin/python3.11 -m py_compile src/vulca/learning/seed_cases.py src/vulca/learning/seed_report.py src/vulca/cli.py`
- `git diff --check`
- `PYTHONPATH=src /opt/homebrew/bin/python3.11 -m vulca.cli cases seed --repo-root /Users/yhryzy/dev/vulca/.worktrees/local-seed-manifest-expansion --output /tmp/vulca-expanded-seeds.u33EBz/seeds`
- `PYTHONPATH=src /opt/homebrew/bin/python3.11 -m vulca.cli cases baseline-report --repo-root /Users/yhryzy/dev/vulca/.worktrees/local-seed-manifest-expansion --output /tmp/vulca-expanded-seeds.u33EBz/report.json --min-action-accuracy observable_signal=1.0 --max-mismatches observable_signal=0`
