### PR TITLE
[codex] Export tiny dataset examples

### DIFF
--- a/scripts/tiny_dataset_eval.py
+++ b/scripts/tiny_dataset_eval.py
@@ -1,0 +1,71 @@
+"""Offline evaluation entrypoint for exported tiny datasets."""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Sequence
+
+
+ROOT = Path(__file__).resolve().parent.parent
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from vulca.learning.tiny_dataset import (  # noqa: E402
+    POLICY_REDRAW_OBSERVABLE_SIGNAL,
+    TINY_DATASET_EVAL_POLICIES,
+    evaluate_tiny_dataset_examples,
+    load_tiny_dataset_examples,
+)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Score provider-free baselines on exported tiny dataset JSONL."
+    )
+    parser.add_argument("dataset", help="Path to tiny dataset JSONL.")
+    parser.add_argument(
+        "--policy",
+        default=POLICY_REDRAW_OBSERVABLE_SIGNAL,
+        choices=sorted(TINY_DATASET_EVAL_POLICIES),
+        help="Offline policy to evaluate.",
+    )
+    parser.add_argument(
+        "--output",
+        "-o",
+        default="",
+        help="Optional JSON report output path.",
+    )
+    parser.add_argument(
+        "--pretty",
+        action="store_true",
+        help="Pretty-print JSON to stdout when --output is omitted.",
+    )
+    args = parser.parse_args(argv)
+
+    report = evaluate_tiny_dataset_examples(
+        load_tiny_dataset_examples(args.dataset),
+        policy_name=args.policy,
+    )
+    if args.output:
+        output_path = Path(args.output)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(
+            json.dumps(report, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        print(f"Tiny dataset eval report: {output_path}")
+    else:
+        indent = 2 if args.pretty else None
+        print(json.dumps(report, indent=indent, sort_keys=True))
+
+    print(f"{args.policy} evaluated_count: {report['evaluated_count']}")
+    print(f"{args.policy} skipped_count: {report['skipped_count']}")
+    print(f"{args.policy} action_accuracy: {report['action_accuracy']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/vulca/cli.py
+++ b/src/vulca/cli.py
@@ -400,6 +400,37 @@ def main(argv: list[str] | None = None) -> None:
         metavar="POLICY=COUNT",
         help="Fail if a policy has more than COUNT mismatched cases",
     )
+    cases_export = cases_sub.add_parser(
+        "export-dataset",
+        help="Export leak-resistant tiny model/agent dataset JSONL",
+    )
+    cases_export.add_argument(
+        "--output",
+        "-o",
+        required=True,
+        help="Output JSONL dataset path",
+    )
+    cases_export.add_argument(
+        "--repo-root",
+        default="",
+        help="Repository root (default: current working directory)",
+    )
+    cases_export.add_argument(
+        "--manifest",
+        default="",
+        help="Seed manifest path (default: docs/benchmarks/learning/local_seed_manifest.json)",
+    )
+    cases_export.add_argument(
+        "--case-log",
+        action="append",
+        default=[],
+        help="Additional reviewed case JSONL path; repeat to include multiple logs",
+    )
+    cases_export.add_argument(
+        "--no-local-seeds",
+        action="store_true",
+        help="Only export records from --case-log inputs",
+    )
 
     # resume command
     resume_p = sub.add_parser("resume", help="Resume pipeline from checkpoint")
@@ -1707,6 +1738,33 @@ def _cmd_layers(args: argparse.Namespace) -> None:
 
 def _cmd_cases(args: argparse.Namespace) -> None:
     import json as _json
+
+    if args.cases_command == "export-dataset":
+        from vulca.learning.seed_cases import DEFAULT_SEED_MANIFEST
+        from vulca.learning.tiny_dataset import write_tiny_dataset
+
+        try:
+            result = write_tiny_dataset(
+                repo_root=args.repo_root or Path.cwd(),
+                output_path=args.output,
+                manifest_path=args.manifest or DEFAULT_SEED_MANIFEST,
+                case_log_paths=args.case_log,
+                include_local_seeds=not args.no_local_seeds,
+            )
+        except (
+            ValueError,
+            FileNotFoundError,
+            subprocess.CalledProcessError,
+            _json.JSONDecodeError,
+        ) as exc:
+            print(f"Error: {exc}", file=sys.stderr)
+            sys.exit(1)
+
+        print(f"  Tiny dataset: {result.output_path}")
+        for case_type in sorted(result.counts_by_case_type):
+            print(f"  {case_type}: {result.counts_by_case_type[case_type]}")
+        print(f"  Tiny dataset index: {result.index_path}")
+        return
 
     if args.cases_command == "baseline-report":
         from vulca.learning.seed_report import (

--- a/src/vulca/learning/tiny_dataset.py
+++ b/src/vulca/learning/tiny_dataset.py
@@ -1,0 +1,406 @@
+"""Tiny model/agent dataset export and offline baseline evaluation."""
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+from collections import Counter
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable, Mapping, Sequence
+
+from vulca.layers.decompose_cases import CASE_TYPE as DECOMPOSE_CASE_TYPE
+from vulca.layers.layer_generate_cases import CASE_TYPE as LAYER_GENERATE_CASE_TYPE
+from vulca.layers.redraw_cases import CASE_TYPE as REDRAW_CASE_TYPE
+from vulca.layers.redraw_router_baseline import (
+    POLICY_OBSERVABLE_SIGNAL,
+    recommend_action,
+)
+from vulca.learning.case_review import load_cases
+from vulca.learning.seed_cases import DEFAULT_SEED_MANIFEST, build_local_seed_cases
+
+
+DATASET_SCHEMA_VERSION = 1
+DATASET_CASE_TYPE = "learning_tiny_dataset_example"
+DATASET_INDEX_CASE_TYPE = "learning_tiny_dataset_index"
+EVAL_REPORT_CASE_TYPE = "learning_tiny_dataset_eval_report"
+
+POLICY_REDRAW_OBSERVABLE_SIGNAL = "redraw_observable_signal"
+TINY_DATASET_EVAL_POLICIES: frozenset[str] = frozenset(
+    {POLICY_REDRAW_OBSERVABLE_SIGNAL}
+)
+SUPPORTED_SOURCE_CASE_TYPES: frozenset[str] = frozenset(
+    {REDRAW_CASE_TYPE, DECOMPOSE_CASE_TYPE, LAYER_GENERATE_CASE_TYPE}
+)
+
+
+@dataclass(frozen=True)
+class TinyDatasetWriteResult:
+    output_path: str
+    index_path: str
+    example_count: int
+    counts_by_case_type: dict[str, int]
+
+
+def build_tiny_dataset_examples(
+    *,
+    repo_root: str | Path,
+    manifest_path: str | Path = DEFAULT_SEED_MANIFEST,
+    case_log_paths: Sequence[str | Path] = (),
+    include_local_seeds: bool = True,
+) -> list[dict[str, Any]]:
+    """Build leak-resistant tiny dataset examples from seeds and case logs."""
+    examples: list[dict[str, Any]] = []
+
+    if include_local_seeds:
+        bundle = build_local_seed_cases(repo_root, manifest_path)
+        for case_type in (
+            REDRAW_CASE_TYPE,
+            DECOMPOSE_CASE_TYPE,
+            LAYER_GENERATE_CASE_TYPE,
+        ):
+            for index, record in enumerate(bundle.get(case_type, [])):
+                examples.append(
+                    _build_example(
+                        record,
+                        source={
+                            "kind": "local_seed",
+                            "split": "seed",
+                            "manifest": str(manifest_path),
+                            "index": index,
+                        },
+                    )
+                )
+
+    for case_log_path in case_log_paths:
+        records = load_cases(case_log_path)
+        for index, record in enumerate(records):
+            examples.append(
+                _build_example(
+                    record,
+                    source={
+                        "kind": "case_log",
+                        "split": "log",
+                        "path": str(case_log_path),
+                        "index": index,
+                    },
+                )
+            )
+
+    return examples
+
+
+def write_tiny_dataset(
+    *,
+    repo_root: str | Path,
+    output_path: str | Path,
+    manifest_path: str | Path = DEFAULT_SEED_MANIFEST,
+    case_log_paths: Sequence[str | Path] = (),
+    include_local_seeds: bool = True,
+    index_path: str | Path | None = None,
+) -> TinyDatasetWriteResult:
+    examples = build_tiny_dataset_examples(
+        repo_root=repo_root,
+        manifest_path=manifest_path,
+        case_log_paths=case_log_paths,
+        include_local_seeds=include_local_seeds,
+    )
+    output = Path(output_path)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    _write_jsonl(output, examples)
+
+    counts = _counts_by_case_type(examples)
+    index = Path(index_path) if index_path is not None else _default_index_path(output)
+    index.parent.mkdir(parents=True, exist_ok=True)
+    index.write_text(
+        json.dumps(
+            {
+                "schema_version": DATASET_SCHEMA_VERSION,
+                "case_type": DATASET_INDEX_CASE_TYPE,
+                "output_path": str(output),
+                "source_manifest": str(manifest_path),
+                "case_log_paths": [str(path) for path in case_log_paths],
+                "include_local_seeds": bool(include_local_seeds),
+                "example_count": len(examples),
+                "counts_by_case_type": counts,
+                "counts_by_source": _counts_by_source(examples),
+                "target_counts": _target_counts(examples),
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return TinyDatasetWriteResult(
+        output_path=str(output),
+        index_path=str(index),
+        example_count=len(examples),
+        counts_by_case_type=counts,
+    )
+
+
+def load_tiny_dataset_examples(path: str | Path) -> list[dict[str, Any]]:
+    return load_cases(path)
+
+
+def evaluate_tiny_dataset_examples(
+    examples: Iterable[Mapping[str, Any]],
+    *,
+    policy_name: str = POLICY_REDRAW_OBSERVABLE_SIGNAL,
+) -> dict[str, Any]:
+    """Evaluate provider-free policies on exported tiny dataset examples."""
+    if policy_name not in TINY_DATASET_EVAL_POLICIES:
+        raise ValueError(
+            f"unsupported tiny dataset eval policy {policy_name!r}; "
+            f"expected one of {sorted(TINY_DATASET_EVAL_POLICIES)}"
+        )
+
+    items = list(examples)
+    action_total = 0
+    action_correct = 0
+    evaluated_count = 0
+    skipped_by_case_type: Counter[str] = Counter()
+    mismatches: list[dict[str, Any]] = []
+    recommendations: list[dict[str, Any]] = []
+
+    for example in items:
+        source_case = _mapping(example.get("source_case"))
+        source_case_type = str(source_case.get("case_type") or "")
+        if (
+            policy_name == POLICY_REDRAW_OBSERVABLE_SIGNAL
+            and source_case_type != REDRAW_CASE_TYPE
+        ):
+            skipped_by_case_type[source_case_type or "unknown"] += 1
+            continue
+
+        case_record = _mapping(_mapping(example.get("input")).get("case_record"))
+        recommendation = recommend_action(
+            case_record,
+            policy_name=POLICY_OBSERVABLE_SIGNAL,
+        )
+        evaluated_count += 1
+        target_action = str(
+            _mapping(example.get("targets")).get("preferred_action") or ""
+        )
+        recommendation_record = {
+            "example_id": str(example.get("example_id") or ""),
+            "case_id": str(source_case.get("case_id") or ""),
+            "source_case_type": source_case_type,
+            "target_action": target_action,
+            "recommended_action": recommendation.recommended_action,
+            "failure_hint": recommendation.failure_hint,
+            "rule_reason": recommendation.rule_reason,
+        }
+        recommendations.append(recommendation_record)
+
+        if target_action:
+            action_total += 1
+            if recommendation.recommended_action == target_action:
+                action_correct += 1
+            else:
+                mismatches.append(recommendation_record)
+
+    skipped_count = sum(skipped_by_case_type.values())
+    return {
+        "schema_version": DATASET_SCHEMA_VERSION,
+        "case_type": EVAL_REPORT_CASE_TYPE,
+        "policy_name": policy_name,
+        "example_count": len(items),
+        "evaluated_count": evaluated_count,
+        "skipped_count": skipped_count,
+        "skipped_by_case_type": dict(sorted(skipped_by_case_type.items())),
+        "action_labeled_count": action_total,
+        "action_accuracy": _ratio(action_correct, action_total),
+        "mismatch_count": len(mismatches),
+        "mismatches": mismatches,
+        "recommendations": recommendations,
+    }
+
+
+def write_tiny_dataset_eval_report(
+    *,
+    dataset_path: str | Path,
+    output_path: str | Path,
+    policy_name: str = POLICY_REDRAW_OBSERVABLE_SIGNAL,
+) -> str:
+    report = evaluate_tiny_dataset_examples(
+        load_tiny_dataset_examples(dataset_path),
+        policy_name=policy_name,
+    )
+    path = Path(output_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(report, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return str(path)
+
+
+def _build_example(
+    record: Mapping[str, Any],
+    *,
+    source: Mapping[str, Any],
+) -> dict[str, Any]:
+    case_type = str(record.get("case_type") or "")
+    if case_type not in SUPPORTED_SOURCE_CASE_TYPES:
+        raise ValueError(
+            f"unsupported source case_type {case_type!r}; "
+            f"expected one of {sorted(SUPPORTED_SOURCE_CASE_TYPES)}"
+        )
+    case_id = str(record.get("case_id") or "")
+    review = _mapping(record.get("review"))
+    human_accept = review.get("human_accept")
+    failure_type = str(review.get("failure_type") or "")
+    preferred_action = str(review.get("preferred_action") or "")
+    source_data = dict(source)
+
+    return {
+        "schema_version": DATASET_SCHEMA_VERSION,
+        "case_type": DATASET_CASE_TYPE,
+        "example_id": _make_example_id(source_data, case_type, case_id),
+        "created_at": str(record.get("created_at") or ""),
+        "source": source_data,
+        "source_case": {
+            "case_type": case_type,
+            "case_id": case_id,
+            "schema_version": int(record.get("schema_version", 0) or 0),
+        },
+        "input": {
+            "case_record": _sanitize_case_for_input(record),
+        },
+        "targets": {
+            "human_accept": human_accept if isinstance(human_accept, bool) else None,
+            "failure_type": failure_type,
+            "preferred_action": preferred_action,
+        },
+        "tasks": {
+            "tiny_model": {
+                "accept_reject": _accept_reject_label(human_accept),
+                "failure_classification": failure_type,
+            },
+            "tiny_agent": {
+                "next_action_policy": preferred_action,
+            },
+        },
+    }
+
+
+def _sanitize_case_for_input(record: Mapping[str, Any]) -> dict[str, Any]:
+    sanitized = copy.deepcopy(dict(record))
+    _drop_label_fields(sanitized)
+    if sanitized.get("case_type") == LAYER_GENERATE_CASE_TYPE:
+        decisions = sanitized.get("decisions")
+        if isinstance(decisions, dict):
+            layer_count = decisions.get("layer_count")
+            if isinstance(layer_count, dict):
+                layer_count.pop("accepted", None)
+        outputs = _mapping(sanitized.get("outputs"))
+        for layer in outputs.get("layers", []) or []:
+            if not isinstance(layer, dict):
+                continue
+            if str(layer.get("status") or "") in {"accepted", "rejected"}:
+                layer["status"] = "generated"
+    return sanitized
+
+
+def _drop_label_fields(value: Any) -> None:
+    if isinstance(value, dict):
+        value.pop("review", None)
+        value.pop("learning_targets", None)
+        for child in value.values():
+            _drop_label_fields(child)
+    elif isinstance(value, list):
+        for child in value:
+            _drop_label_fields(child)
+
+
+def _make_example_id(source: Mapping[str, Any], case_type: str, case_id: str) -> str:
+    seed = json.dumps(
+        {
+            "schema_version": DATASET_SCHEMA_VERSION,
+            "source": dict(source),
+            "case_type": case_type,
+            "case_id": case_id,
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    digest = hashlib.sha256(seed.encode("utf-8")).hexdigest()[:16]
+    return f"tiny_{digest}"
+
+
+def _accept_reject_label(value: Any) -> str:
+    if value is True:
+        return "accept"
+    if value is False:
+        return "reject"
+    return ""
+
+
+def _write_jsonl(path: Path, records: Sequence[Mapping[str, Any]]) -> None:
+    with path.open("w", encoding="utf-8") as fh:
+        for record in records:
+            fh.write(json.dumps(dict(record), sort_keys=True, separators=(",", ":")))
+            fh.write("\n")
+
+
+def _default_index_path(output_path: Path) -> Path:
+    if output_path.suffix == ".jsonl":
+        return output_path.with_suffix(".index.json")
+    return output_path.with_name(f"{output_path.name}.index.json")
+
+
+def _counts_by_case_type(examples: Iterable[Mapping[str, Any]]) -> dict[str, int]:
+    counts: Counter[str] = Counter()
+    for example in examples:
+        key = str(_mapping(example.get("source_case")).get("case_type") or "unknown")
+        counts[key] += 1
+    return dict(sorted(counts.items()))
+
+
+def _counts_by_source(examples: Iterable[Mapping[str, Any]]) -> dict[str, int]:
+    counts: Counter[str] = Counter()
+    for example in examples:
+        counts[str(_mapping(example.get("source")).get("kind") or "unknown")] += 1
+    return dict(sorted(counts.items()))
+
+
+def _target_counts(examples: Iterable[Mapping[str, Any]]) -> dict[str, dict[str, int]]:
+    human_accept_counts: Counter[str] = Counter()
+    failure_counts: Counter[str] = Counter()
+    action_counts: Counter[str] = Counter()
+    for example in examples:
+        targets = _mapping(example.get("targets"))
+        human_accept = targets.get("human_accept")
+        if human_accept is True:
+            human_accept_counts["true"] += 1
+        elif human_accept is False:
+            human_accept_counts["false"] += 1
+        else:
+            human_accept_counts["unlabeled"] += 1
+
+        failure_type = str(targets.get("failure_type") or "")
+        preferred_action = str(targets.get("preferred_action") or "")
+        if failure_type:
+            failure_counts[failure_type] += 1
+        if preferred_action:
+            action_counts[preferred_action] += 1
+
+    return {
+        "human_accept": dict(sorted(human_accept_counts.items())),
+        "failure_type": dict(sorted(failure_counts.items())),
+        "preferred_action": dict(sorted(action_counts.items())),
+    }
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    if isinstance(value, Mapping):
+        return value
+    return {}
+
+
+def _ratio(numerator: int, denominator: int) -> float | None:
+    if denominator <= 0:
+        return None
+    return numerator / denominator

--- a/tests/test_tiny_dataset_export.py
+++ b/tests/test_tiny_dataset_export.py
@@ -1,0 +1,186 @@
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+CLI_ENV = dict(
+    os.environ,
+    PYTHONPATH=str(ROOT / "src") + os.pathsep + os.environ.get("PYTHONPATH", ""),
+)
+
+
+def _read_jsonl(path: Path):
+    return [json.loads(line) for line in path.read_text().splitlines()]
+
+
+def test_build_tiny_dataset_from_local_seeds_strips_label_leakage():
+    from vulca.learning.tiny_dataset import build_tiny_dataset_examples
+
+    examples = build_tiny_dataset_examples(repo_root=ROOT)
+
+    assert len(examples) == 12
+    assert {
+        item["source_case"]["case_type"] for item in examples
+    } == {"redraw_case", "decompose_case", "layer_generate_case"}
+    assert sum(
+        1 for item in examples if item["source_case"]["case_type"] == "redraw_case"
+    ) == 6
+    assert sum(
+        1
+        for item in examples
+        if item["source_case"]["case_type"] == "decompose_case"
+    ) == 1
+    assert sum(
+        1
+        for item in examples
+        if item["source_case"]["case_type"] == "layer_generate_case"
+    ) == 5
+
+    first = examples[0]
+    assert first["case_type"] == "learning_tiny_dataset_example"
+    assert first["schema_version"] == 1
+    assert first["source"]["kind"] == "local_seed"
+    assert first["targets"]["preferred_action"]
+    assert first["tasks"]["tiny_agent"]["next_action_policy"] == first["targets"][
+        "preferred_action"
+    ]
+
+    encoded_inputs = json.dumps([item["input"] for item in examples], sort_keys=True)
+    assert '"review"' not in encoded_inputs
+    assert '"learning_targets"' not in encoded_inputs
+    assert '"accepted"' not in encoded_inputs
+
+
+def test_write_tiny_dataset_writes_jsonl_and_index(tmp_path):
+    from vulca.learning.tiny_dataset import write_tiny_dataset
+
+    output_path = tmp_path / "tiny_dataset.jsonl"
+
+    result = write_tiny_dataset(repo_root=ROOT, output_path=output_path)
+
+    assert result.output_path == str(output_path)
+    assert result.example_count == 12
+    assert result.counts_by_case_type == {
+        "decompose_case": 1,
+        "layer_generate_case": 5,
+        "redraw_case": 6,
+    }
+    assert Path(result.index_path).exists()
+
+    records = _read_jsonl(output_path)
+    index = json.loads(Path(result.index_path).read_text(encoding="utf-8"))
+    assert len(records) == 12
+    assert index["case_type"] == "learning_tiny_dataset_index"
+    assert index["example_count"] == 12
+    assert index["counts_by_case_type"]["layer_generate_case"] == 5
+
+
+def test_tiny_dataset_merges_additional_case_logs(tmp_path):
+    from vulca.learning.seed_cases import build_local_seed_cases
+    from vulca.learning.tiny_dataset import build_tiny_dataset_examples
+
+    seed = build_local_seed_cases(ROOT)["redraw_case"][0]
+    extra = json.loads(json.dumps(seed))
+    extra["case_id"] = "redraw_extra_case"
+    extra["review"]["preferred_action"] = "manual_review"
+    log_path = tmp_path / "extra_redraw_cases.jsonl"
+    log_path.write_text(json.dumps(extra) + "\n", encoding="utf-8")
+
+    examples = build_tiny_dataset_examples(
+        repo_root=ROOT,
+        case_log_paths=[log_path],
+    )
+
+    assert len(examples) == 13
+    extra_examples = [
+        item for item in examples if item["source_case"]["case_id"] == "redraw_extra_case"
+    ]
+    assert len(extra_examples) == 1
+    assert extra_examples[0]["source"]["kind"] == "case_log"
+    assert extra_examples[0]["targets"]["preferred_action"] == "manual_review"
+
+
+def test_cases_export_dataset_cli_writes_dataset(tmp_path):
+    output_path = tmp_path / "tiny_dataset.jsonl"
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "vulca.cli",
+            "cases",
+            "export-dataset",
+            "--repo-root",
+            str(ROOT),
+            "--output",
+            str(output_path),
+        ],
+        capture_output=True,
+        text=True,
+        timeout=20,
+        env=CLI_ENV,
+        cwd=tmp_path,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert output_path.exists()
+    assert "Tiny dataset:" in result.stdout
+    assert "redraw_case: 6" in result.stdout
+    assert "layer_generate_case: 5" in result.stdout
+    assert (tmp_path / "tiny_dataset.index.json").exists()
+
+
+def test_tiny_dataset_eval_scores_redraw_observable_signal(tmp_path):
+    from vulca.learning.tiny_dataset import (
+        evaluate_tiny_dataset_examples,
+        write_tiny_dataset,
+    )
+
+    output_path = tmp_path / "tiny_dataset.jsonl"
+    write_tiny_dataset(repo_root=ROOT, output_path=output_path)
+    examples = _read_jsonl(output_path)
+
+    report = evaluate_tiny_dataset_examples(
+        examples,
+        policy_name="redraw_observable_signal",
+    )
+
+    assert report["case_type"] == "learning_tiny_dataset_eval_report"
+    assert report["policy_name"] == "redraw_observable_signal"
+    assert report["example_count"] == 12
+    assert report["evaluated_count"] == 6
+    assert report["skipped_count"] == 6
+    assert report["action_accuracy"] == 1.0
+    assert report["mismatches"] == []
+
+
+def test_tiny_dataset_eval_script_writes_report(tmp_path):
+    from vulca.learning.tiny_dataset import write_tiny_dataset
+
+    dataset_path = tmp_path / "tiny_dataset.jsonl"
+    report_path = tmp_path / "tiny_dataset_eval.json"
+    write_tiny_dataset(repo_root=ROOT, output_path=dataset_path)
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(ROOT / "scripts" / "tiny_dataset_eval.py"),
+            str(dataset_path),
+            "--output",
+            str(report_path),
+        ],
+        capture_output=True,
+        text=True,
+        timeout=20,
+        env=CLI_ENV,
+        cwd=ROOT,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert report_path.exists()
+    report = json.loads(report_path.read_text(encoding="utf-8"))
+    assert report["evaluated_count"] == 6
+    assert report["action_accuracy"] == 1.0
+    assert "redraw_observable_signal action_accuracy: 1.0" in result.stdout


### PR DESCRIPTION
## Summary
- add leak-resistant tiny model/agent dataset export for local seeds and extra case JSONL logs
- add `vulca cases export-dataset` and JSONL/index output
- add offline `scripts/tiny_dataset_eval.py` harness for redraw observable-signal baseline evaluation

## Validation
- `PYTHONPATH=src /opt/homebrew/bin/python3.11 -m pytest tests/test_tiny_dataset_export.py tests/test_learning_seed_report.py tests/test_learning_seed_cases.py tests/test_case_review.py tests/test_redraw_router_baseline.py tests/test_redraw_cases.py tests/test_redraw_benchmark_manifest.py tests/test_cli_commands.py -q` -> 46 passed
- `PYTHONPATH=src /opt/homebrew/bin/python3.11 -m py_compile src/vulca/learning/tiny_dataset.py scripts/tiny_dataset_eval.py src/vulca/cli.py`
- `git diff --check`
- smoke: `vulca cases export-dataset` produced 12 examples; `tiny_dataset_eval.py` evaluated 6 redraw examples with action_accuracy 1.0