### PR TITLE
[codex] Compare tiny dataset baselines

### DIFF
--- a/scripts/tiny_dataset_eval.py
+++ b/scripts/tiny_dataset_eval.py
@@ -15,7 +15,9 @@ if str(SRC) not in sys.path:
 
 from vulca.learning.tiny_dataset import (  # noqa: E402
     POLICY_REDRAW_OBSERVABLE_SIGNAL,
+    DATASET_SPLITS,
     TINY_DATASET_EVAL_POLICIES,
+    build_tiny_dataset_comparison_report,
     evaluate_tiny_dataset_examples,
     load_tiny_dataset_examples,
 )
@@ -33,6 +35,23 @@ def main(argv: Sequence[str] | None = None) -> int:
         help="Offline policy to evaluate.",
     )
     parser.add_argument(
+        "--split",
+        default="all",
+        choices=("all", *DATASET_SPLITS),
+        help="Dataset split to evaluate.",
+    )
+    parser.add_argument(
+        "--train-split",
+        default="train",
+        choices=DATASET_SPLITS,
+        help="Training split used by train-derived baselines.",
+    )
+    parser.add_argument(
+        "--compare",
+        action="store_true",
+        help="Write a comparison report for default tiny baselines.",
+    )
+    parser.add_argument(
         "--output",
         "-o",
         default="",
@@ -45,10 +64,22 @@ def main(argv: Sequence[str] | None = None) -> int:
     )
     args = parser.parse_args(argv)
 
-    report = evaluate_tiny_dataset_examples(
-        load_tiny_dataset_examples(args.dataset),
-        policy_name=args.policy,
-    )
+    dataset_split = None if args.split == "all" else args.split
+    examples = load_tiny_dataset_examples(args.dataset)
+    if args.compare:
+        eval_split = dataset_split or "test"
+        report = build_tiny_dataset_comparison_report(
+            examples,
+            train_split=args.train_split,
+            eval_split=eval_split,
+        )
+    else:
+        report = evaluate_tiny_dataset_examples(
+            examples,
+            policy_name=args.policy,
+            dataset_split=dataset_split,
+            train_split=args.train_split,
+        )
     if args.output:
         output_path = Path(args.output)
         output_path.parent.mkdir(parents=True, exist_ok=True)
@@ -61,9 +92,16 @@ def main(argv: Sequence[str] | None = None) -> int:
         indent = 2 if args.pretty else None
         print(json.dumps(report, indent=indent, sort_keys=True))
 
-    print(f"{args.policy} evaluated_count: {report['evaluated_count']}")
-    print(f"{args.policy} skipped_count: {report['skipped_count']}")
-    print(f"{args.policy} action_accuracy: {report['action_accuracy']}")
+    if args.compare:
+        for policy_name in sorted(report["policy_reports"]):
+            policy_report = report["policy_reports"][policy_name]
+            print(f"{policy_name} evaluated_count: {policy_report['evaluated_count']}")
+            print(f"{policy_name} skipped_count: {policy_report['skipped_count']}")
+            print(f"{policy_name} action_accuracy: {policy_report['action_accuracy']}")
+    else:
+        print(f"{args.policy} evaluated_count: {report['evaluated_count']}")
+        print(f"{args.policy} skipped_count: {report['skipped_count']}")
+        print(f"{args.policy} action_accuracy: {report['action_accuracy']}")
     return 0
 
 

--- a/src/vulca/cli.py
+++ b/src/vulca/cli.py
@@ -1763,6 +1763,8 @@ def _cmd_cases(args: argparse.Namespace) -> None:
         print(f"  Tiny dataset: {result.output_path}")
         for case_type in sorted(result.counts_by_case_type):
             print(f"  {case_type}: {result.counts_by_case_type[case_type]}")
+        for split in sorted(result.counts_by_split):
+            print(f"  {split}: {result.counts_by_split[split]}")
         print(f"  Tiny dataset index: {result.index_path}")
         return
 

--- a/src/vulca/learning/tiny_dataset.py
+++ b/src/vulca/learning/tiny_dataset.py
@@ -24,11 +24,18 @@ DATASET_SCHEMA_VERSION = 1
 DATASET_CASE_TYPE = "learning_tiny_dataset_example"
 DATASET_INDEX_CASE_TYPE = "learning_tiny_dataset_index"
 EVAL_REPORT_CASE_TYPE = "learning_tiny_dataset_eval_report"
+COMPARISON_REPORT_CASE_TYPE = "learning_tiny_dataset_comparison_report"
 
+POLICY_MAJORITY_ACTION = "majority_action"
 POLICY_REDRAW_OBSERVABLE_SIGNAL = "redraw_observable_signal"
 TINY_DATASET_EVAL_POLICIES: frozenset[str] = frozenset(
-    {POLICY_REDRAW_OBSERVABLE_SIGNAL}
+    {POLICY_MAJORITY_ACTION, POLICY_REDRAW_OBSERVABLE_SIGNAL}
 )
+DEFAULT_COMPARISON_POLICIES: tuple[str, ...] = (
+    POLICY_MAJORITY_ACTION,
+    POLICY_REDRAW_OBSERVABLE_SIGNAL,
+)
+DATASET_SPLITS: tuple[str, ...] = ("train", "dev", "test")
 SUPPORTED_SOURCE_CASE_TYPES: frozenset[str] = frozenset(
     {REDRAW_CASE_TYPE, DECOMPOSE_CASE_TYPE, LAYER_GENERATE_CASE_TYPE}
 )
@@ -40,6 +47,7 @@ class TinyDatasetWriteResult:
     index_path: str
     example_count: int
     counts_by_case_type: dict[str, int]
+    counts_by_split: dict[str, int]
 
 
 def build_tiny_dataset_examples(
@@ -87,6 +95,7 @@ def build_tiny_dataset_examples(
                 )
             )
 
+    _assign_dataset_splits(examples)
     return examples
 
 
@@ -123,6 +132,7 @@ def write_tiny_dataset(
                 "include_local_seeds": bool(include_local_seeds),
                 "example_count": len(examples),
                 "counts_by_case_type": counts,
+                "counts_by_split": _counts_by_split(examples),
                 "counts_by_source": _counts_by_source(examples),
                 "target_counts": _target_counts(examples),
             },
@@ -137,6 +147,7 @@ def write_tiny_dataset(
         index_path=str(index),
         example_count=len(examples),
         counts_by_case_type=counts,
+        counts_by_split=_counts_by_split(examples),
     )
 
 
@@ -148,6 +159,8 @@ def evaluate_tiny_dataset_examples(
     examples: Iterable[Mapping[str, Any]],
     *,
     policy_name: str = POLICY_REDRAW_OBSERVABLE_SIGNAL,
+    dataset_split: str | None = None,
+    train_split: str = "train",
 ) -> dict[str, Any]:
     """Evaluate provider-free policies on exported tiny dataset examples."""
     if policy_name not in TINY_DATASET_EVAL_POLICIES:
@@ -156,7 +169,16 @@ def evaluate_tiny_dataset_examples(
             f"expected one of {sorted(TINY_DATASET_EVAL_POLICIES)}"
         )
 
-    items = list(examples)
+    all_items = list(examples)
+    items = _filter_by_split(all_items, dataset_split)
+    if policy_name == POLICY_MAJORITY_ACTION:
+        return _evaluate_majority_action(
+            all_items,
+            items,
+            dataset_split=dataset_split,
+            train_split=train_split,
+        )
+
     action_total = 0
     action_correct = 0
     evaluated_count = 0
@@ -206,6 +228,7 @@ def evaluate_tiny_dataset_examples(
         "schema_version": DATASET_SCHEMA_VERSION,
         "case_type": EVAL_REPORT_CASE_TYPE,
         "policy_name": policy_name,
+        "split": dataset_split or "all",
         "example_count": len(items),
         "evaluated_count": evaluated_count,
         "skipped_count": skipped_count,
@@ -223,10 +246,14 @@ def write_tiny_dataset_eval_report(
     dataset_path: str | Path,
     output_path: str | Path,
     policy_name: str = POLICY_REDRAW_OBSERVABLE_SIGNAL,
+    dataset_split: str | None = None,
+    train_split: str = "train",
 ) -> str:
     report = evaluate_tiny_dataset_examples(
         load_tiny_dataset_examples(dataset_path),
         policy_name=policy_name,
+        dataset_split=dataset_split,
+        train_split=train_split,
     )
     path = Path(output_path)
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -235,6 +262,35 @@ def write_tiny_dataset_eval_report(
         encoding="utf-8",
     )
     return str(path)
+
+
+def build_tiny_dataset_comparison_report(
+    examples: Iterable[Mapping[str, Any]],
+    *,
+    train_split: str = "train",
+    eval_split: str = "test",
+    policy_names: Sequence[str] = DEFAULT_COMPARISON_POLICIES,
+) -> dict[str, Any]:
+    """Compare offline baselines on a fixed dataset split."""
+    items = list(examples)
+    reports = {
+        policy: evaluate_tiny_dataset_examples(
+            items,
+            policy_name=policy,
+            dataset_split=eval_split,
+            train_split=train_split,
+        )
+        for policy in policy_names
+    }
+    return {
+        "schema_version": DATASET_SCHEMA_VERSION,
+        "case_type": COMPARISON_REPORT_CASE_TYPE,
+        "train_split": train_split,
+        "eval_split": eval_split,
+        "example_count": len(_filter_by_split(items, eval_split)),
+        "policy_reports": reports,
+        "ranked_policies": _rank_policy_reports(reports),
+    }
 
 
 def _build_example(
@@ -284,6 +340,144 @@ def _build_example(
             },
         },
     }
+
+
+def _assign_dataset_splits(examples: list[dict[str, Any]]) -> None:
+    groups: dict[str, list[dict[str, Any]]] = {}
+    for example in examples:
+        case_type = str(_mapping(example.get("source_case")).get("case_type") or "")
+        groups.setdefault(case_type, []).append(example)
+
+    for case_type in sorted(groups):
+        group = groups[case_type]
+        counts = _split_counts(len(group))
+        cursor = 0
+        for split in DATASET_SPLITS:
+            count = counts.get(split, 0)
+            for example in group[cursor : cursor + count]:
+                example["split"] = split
+            cursor += count
+
+
+def _split_counts(total: int) -> dict[str, int]:
+    if total <= 0:
+        return {"train": 0, "dev": 0, "test": 0}
+    if total == 1:
+        return {"train": 1, "dev": 0, "test": 0}
+    if total == 2:
+        return {"train": 1, "dev": 1, "test": 0}
+
+    train = max(1, int(total * 0.7))
+    dev = max(1, int(total * 0.15))
+    test = total - train - dev
+    if test < 1:
+        train = max(1, train - (1 - test))
+        test = 1
+    return {"train": train, "dev": dev, "test": test}
+
+
+def _filter_by_split(
+    examples: Iterable[Mapping[str, Any]],
+    dataset_split: str | None,
+) -> list[Mapping[str, Any]]:
+    if not dataset_split or dataset_split == "all":
+        return list(examples)
+    if dataset_split not in DATASET_SPLITS:
+        raise ValueError(
+            f"unsupported dataset split {dataset_split!r}; "
+            f"expected one of {DATASET_SPLITS}"
+        )
+    return [item for item in examples if item.get("split") == dataset_split]
+
+
+def _evaluate_majority_action(
+    all_items: Sequence[Mapping[str, Any]],
+    eval_items: Sequence[Mapping[str, Any]],
+    *,
+    dataset_split: str | None,
+    train_split: str,
+) -> dict[str, Any]:
+    train_items = _filter_by_split(all_items, train_split)
+    majority_action = _majority_action(train_items) or "manual_review"
+    action_total = 0
+    action_correct = 0
+    mismatches: list[dict[str, Any]] = []
+    recommendations: list[dict[str, Any]] = []
+
+    for example in eval_items:
+        source_case = _mapping(example.get("source_case"))
+        target_action = str(
+            _mapping(example.get("targets")).get("preferred_action") or ""
+        )
+        recommendation_record = {
+            "example_id": str(example.get("example_id") or ""),
+            "case_id": str(source_case.get("case_id") or ""),
+            "source_case_type": str(source_case.get("case_type") or ""),
+            "target_action": target_action,
+            "recommended_action": majority_action,
+            "failure_hint": "",
+            "rule_reason": f"train_split_majority:{train_split}",
+        }
+        recommendations.append(recommendation_record)
+        if target_action:
+            action_total += 1
+            if target_action == majority_action:
+                action_correct += 1
+            else:
+                mismatches.append(recommendation_record)
+
+    return {
+        "schema_version": DATASET_SCHEMA_VERSION,
+        "case_type": EVAL_REPORT_CASE_TYPE,
+        "policy_name": POLICY_MAJORITY_ACTION,
+        "split": dataset_split or "all",
+        "train_split": train_split,
+        "majority_action": majority_action,
+        "example_count": len(eval_items),
+        "evaluated_count": len(eval_items),
+        "skipped_count": 0,
+        "skipped_by_case_type": {},
+        "action_labeled_count": action_total,
+        "action_accuracy": _ratio(action_correct, action_total),
+        "mismatch_count": len(mismatches),
+        "mismatches": mismatches,
+        "recommendations": recommendations,
+    }
+
+
+def _majority_action(examples: Iterable[Mapping[str, Any]]) -> str:
+    counts: Counter[str] = Counter()
+    for example in examples:
+        action = str(_mapping(example.get("targets")).get("preferred_action") or "")
+        if action:
+            counts[action] += 1
+    if not counts:
+        return ""
+    return sorted(counts.items(), key=lambda item: (-item[1], item[0]))[0][0]
+
+
+def _rank_policy_reports(
+    reports: Mapping[str, Mapping[str, Any]],
+) -> list[dict[str, Any]]:
+    rows = []
+    for policy_name, report in reports.items():
+        rows.append(
+            {
+                "policy_name": policy_name,
+                "action_accuracy": report.get("action_accuracy"),
+                "evaluated_count": report.get("evaluated_count", 0),
+                "mismatch_count": report.get("mismatch_count", 0),
+            }
+        )
+    return sorted(
+        rows,
+        key=lambda item: (
+            -(float(item["action_accuracy"]) if item["action_accuracy"] is not None else -1.0),
+            -int(item["evaluated_count"] or 0),
+            int(item["mismatch_count"] or 0),
+            str(item["policy_name"]),
+        ),
+    )
 
 
 def _sanitize_case_for_input(record: Mapping[str, Any]) -> dict[str, Any]:
@@ -356,6 +550,14 @@ def _counts_by_case_type(examples: Iterable[Mapping[str, Any]]) -> dict[str, int
     for example in examples:
         key = str(_mapping(example.get("source_case")).get("case_type") or "unknown")
         counts[key] += 1
+    return dict(sorted(counts.items()))
+
+
+def _counts_by_split(examples: Iterable[Mapping[str, Any]]) -> dict[str, int]:
+    counts: Counter[str] = Counter()
+    for example in examples:
+        split = str(example.get("split") or "unknown")
+        counts[split] += 1
     return dict(sorted(counts.items()))
 
 

--- a/tests/test_tiny_dataset_export.py
+++ b/tests/test_tiny_dataset_export.py
@@ -2,6 +2,7 @@ import json
 import os
 import subprocess
 import sys
+from collections import Counter
 from pathlib import Path
 
 
@@ -76,6 +77,47 @@ def test_write_tiny_dataset_writes_jsonl_and_index(tmp_path):
     assert index["case_type"] == "learning_tiny_dataset_index"
     assert index["example_count"] == 12
     assert index["counts_by_case_type"]["layer_generate_case"] == 5
+    assert index["counts_by_split"] == {
+        "dev": 2,
+        "test": 2,
+        "train": 8,
+    }
+
+
+def test_tiny_dataset_assigns_deterministic_train_dev_test_splits():
+    from vulca.learning.tiny_dataset import build_tiny_dataset_examples
+
+    examples = build_tiny_dataset_examples(repo_root=ROOT)
+    repeated = build_tiny_dataset_examples(repo_root=ROOT)
+
+    assert [item["split"] for item in examples] == [
+        item["split"] for item in repeated
+    ]
+    assert Counter(item["split"] for item in examples) == {
+        "dev": 2,
+        "test": 2,
+        "train": 8,
+    }
+
+    split_by_case_type = {
+        case_type: Counter(
+            item["split"]
+            for item in examples
+            if item["source_case"]["case_type"] == case_type
+        )
+        for case_type in {item["source_case"]["case_type"] for item in examples}
+    }
+    assert split_by_case_type["redraw_case"] == {
+        "dev": 1,
+        "test": 1,
+        "train": 4,
+    }
+    assert split_by_case_type["decompose_case"] == {"train": 1}
+    assert split_by_case_type["layer_generate_case"] == {
+        "dev": 1,
+        "test": 1,
+        "train": 3,
+    }
 
 
 def test_tiny_dataset_merges_additional_case_logs(tmp_path):
@@ -129,6 +171,9 @@ def test_cases_export_dataset_cli_writes_dataset(tmp_path):
     assert "Tiny dataset:" in result.stdout
     assert "redraw_case: 6" in result.stdout
     assert "layer_generate_case: 5" in result.stdout
+    assert "train: 8" in result.stdout
+    assert "dev: 2" in result.stdout
+    assert "test: 2" in result.stdout
     assert (tmp_path / "tiny_dataset.index.json").exists()
 
 
@@ -154,6 +199,58 @@ def test_tiny_dataset_eval_scores_redraw_observable_signal(tmp_path):
     assert report["skipped_count"] == 6
     assert report["action_accuracy"] == 1.0
     assert report["mismatches"] == []
+
+
+def test_tiny_dataset_eval_filters_to_requested_split(tmp_path):
+    from vulca.learning.tiny_dataset import (
+        evaluate_tiny_dataset_examples,
+        write_tiny_dataset,
+    )
+
+    output_path = tmp_path / "tiny_dataset.jsonl"
+    write_tiny_dataset(repo_root=ROOT, output_path=output_path)
+    examples = _read_jsonl(output_path)
+
+    report = evaluate_tiny_dataset_examples(
+        examples,
+        policy_name="redraw_observable_signal",
+        dataset_split="test",
+    )
+
+    assert report["split"] == "test"
+    assert report["example_count"] == 2
+    assert report["evaluated_count"] == 1
+    assert report["skipped_by_case_type"] == {"layer_generate_case": 1}
+    assert report["action_accuracy"] == 1.0
+
+
+def test_tiny_dataset_comparison_report_compares_rule_and_majority_baselines(tmp_path):
+    from vulca.learning.tiny_dataset import (
+        build_tiny_dataset_comparison_report,
+        write_tiny_dataset,
+    )
+
+    output_path = tmp_path / "tiny_dataset.jsonl"
+    write_tiny_dataset(repo_root=ROOT, output_path=output_path)
+    examples = _read_jsonl(output_path)
+
+    report = build_tiny_dataset_comparison_report(
+        examples,
+        train_split="train",
+        eval_split="test",
+    )
+
+    assert report["case_type"] == "learning_tiny_dataset_comparison_report"
+    assert report["train_split"] == "train"
+    assert report["eval_split"] == "test"
+    assert set(report["policy_reports"]) == {
+        "majority_action",
+        "redraw_observable_signal",
+    }
+    assert report["policy_reports"]["majority_action"]["majority_action"] == "accept"
+    assert report["policy_reports"]["majority_action"]["evaluated_count"] == 2
+    assert report["policy_reports"]["redraw_observable_signal"]["evaluated_count"] == 1
+    assert report["ranked_policies"][0]["policy_name"] == "redraw_observable_signal"
 
 
 def test_tiny_dataset_eval_script_writes_report(tmp_path):
@@ -184,3 +281,35 @@ def test_tiny_dataset_eval_script_writes_report(tmp_path):
     assert report["evaluated_count"] == 6
     assert report["action_accuracy"] == 1.0
     assert "redraw_observable_signal action_accuracy: 1.0" in result.stdout
+
+
+def test_tiny_dataset_eval_script_writes_comparison_report(tmp_path):
+    from vulca.learning.tiny_dataset import write_tiny_dataset
+
+    dataset_path = tmp_path / "tiny_dataset.jsonl"
+    report_path = tmp_path / "tiny_dataset_comparison.json"
+    write_tiny_dataset(repo_root=ROOT, output_path=dataset_path)
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(ROOT / "scripts" / "tiny_dataset_eval.py"),
+            str(dataset_path),
+            "--compare",
+            "--split",
+            "test",
+            "--output",
+            str(report_path),
+        ],
+        capture_output=True,
+        text=True,
+        timeout=20,
+        env=CLI_ENV,
+        cwd=ROOT,
+    )
+
+    assert result.returncode == 0, result.stderr
+    report = json.loads(report_path.read_text(encoding="utf-8"))
+    assert report["case_type"] == "learning_tiny_dataset_comparison_report"
+    assert "majority_action action_accuracy:" in result.stdout
+    assert "redraw_observable_signal action_accuracy:" in result.stdout


### PR DESCRIPTION
## Summary
- add deterministic train/dev/test splits to exported tiny dataset examples
- include split counts in the dataset index and CLI output
- add majority-action baseline and comparison report against redraw observable-signal baseline
- extend `scripts/tiny_dataset_eval.py` with `--split`, `--train-split`, and `--compare`

## Validation
- `PYTHONPATH=src /opt/homebrew/bin/python3.11 -m pytest tests/test_tiny_dataset_export.py tests/test_learning_seed_report.py tests/test_learning_seed_cases.py tests/test_case_review.py tests/test_redraw_router_baseline.py tests/test_redraw_cases.py tests/test_redraw_benchmark_manifest.py tests/test_cli_commands.py -q` -> 50 passed
- `PYTHONPATH=src /opt/homebrew/bin/python3.11 -m py_compile src/vulca/learning/tiny_dataset.py scripts/tiny_dataset_eval.py src/vulca/cli.py`
- `ruff check src/ tests/` -> passed
- `git diff --check` -> passed
- `scripts/local_seed_baseline_gate.py` -> passed
- smoke: export produced 12 examples with train/dev/test = 8/2/2; comparison test split ranked redraw_observable_signal above majority_action