### PR TITLE
[codex] Evaluate tiny prediction JSONL

### DIFF
--- a/scripts/tiny_dataset_eval.py
+++ b/scripts/tiny_dataset_eval.py
@@ -52,6 +52,12 @@ def main(argv: Sequence[str] | None = None) -> int:
         help="Write a comparison report for default tiny baselines.",
     )
     parser.add_argument(
+        "--prediction",
+        action="append",
+        default=[],
+        help="External prediction JSONL path; repeat to compare multiple models.",
+    )
+    parser.add_argument(
         "--output",
         "-o",
         default="",
@@ -72,6 +78,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             examples,
             train_split=args.train_split,
             eval_split=eval_split,
+            prediction_paths=args.prediction,
         )
     else:
         report = evaluate_tiny_dataset_examples(

--- a/src/vulca/learning/tiny_dataset.py
+++ b/src/vulca/learning/tiny_dataset.py
@@ -9,9 +9,18 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Iterable, Mapping, Sequence
 
-from vulca.layers.decompose_cases import CASE_TYPE as DECOMPOSE_CASE_TYPE
-from vulca.layers.layer_generate_cases import CASE_TYPE as LAYER_GENERATE_CASE_TYPE
-from vulca.layers.redraw_cases import CASE_TYPE as REDRAW_CASE_TYPE
+from vulca.layers.decompose_cases import (
+    CASE_TYPE as DECOMPOSE_CASE_TYPE,
+    PREFERRED_ACTIONS as DECOMPOSE_PREFERRED_ACTIONS,
+)
+from vulca.layers.layer_generate_cases import (
+    CASE_TYPE as LAYER_GENERATE_CASE_TYPE,
+    PREFERRED_ACTIONS as LAYER_GENERATE_PREFERRED_ACTIONS,
+)
+from vulca.layers.redraw_cases import (
+    CASE_TYPE as REDRAW_CASE_TYPE,
+    PREFERRED_ACTIONS as REDRAW_PREFERRED_ACTIONS,
+)
 from vulca.layers.redraw_router_baseline import (
     POLICY_OBSERVABLE_SIGNAL,
     recommend_action,
@@ -38,6 +47,11 @@ DEFAULT_COMPARISON_POLICIES: tuple[str, ...] = (
 DATASET_SPLITS: tuple[str, ...] = ("train", "dev", "test")
 SUPPORTED_SOURCE_CASE_TYPES: frozenset[str] = frozenset(
     {REDRAW_CASE_TYPE, DECOMPOSE_CASE_TYPE, LAYER_GENERATE_CASE_TYPE}
+)
+SUPPORTED_PREDICTION_ACTIONS: frozenset[str] = frozenset(
+    set(REDRAW_PREFERRED_ACTIONS)
+    | set(DECOMPOSE_PREFERRED_ACTIONS)
+    | set(LAYER_GENERATE_PREFERRED_ACTIONS)
 )
 
 
@@ -155,6 +169,51 @@ def load_tiny_dataset_examples(path: str | Path) -> list[dict[str, Any]]:
     return load_cases(path)
 
 
+def load_tiny_prediction_records(
+    path: str | Path,
+    *,
+    policy_name: str | None = None,
+) -> list[dict[str, Any]]:
+    """Load external tiny model/agent predictions keyed by dataset example_id."""
+    prediction_path = Path(path)
+    records = load_cases(prediction_path)
+    predictions: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    default_policy = policy_name or prediction_path.stem
+
+    for index, record in enumerate(records):
+        example_id = str(record.get("example_id") or "")
+        if not example_id:
+            raise ValueError(f"{prediction_path}:{index + 1}: example_id is required")
+        if example_id in seen:
+            raise ValueError(f"duplicate prediction example_id {example_id!r}")
+        seen.add(example_id)
+
+        action = str(record.get("recommended_action") or "")
+        if not action:
+            raise ValueError(
+                f"{prediction_path}:{index + 1}: recommended_action is required"
+            )
+        if action not in SUPPORTED_PREDICTION_ACTIONS:
+            raise ValueError(
+                f"{prediction_path}:{index + 1}: unsupported recommended_action "
+                f"{action!r}"
+            )
+
+        predictions.append(
+            {
+                "policy_name": str(record.get("policy_name") or default_policy),
+                "example_id": example_id,
+                "recommended_action": action,
+                "failure_hint": str(record.get("failure_hint") or ""),
+                "confidence": record.get("confidence"),
+                "source_path": str(prediction_path),
+            }
+        )
+
+    return predictions
+
+
 def evaluate_tiny_dataset_examples(
     examples: Iterable[Mapping[str, Any]],
     *,
@@ -241,6 +300,93 @@ def evaluate_tiny_dataset_examples(
     }
 
 
+def evaluate_tiny_prediction_records(
+    examples: Iterable[Mapping[str, Any]],
+    predictions: Iterable[Mapping[str, Any]],
+    *,
+    dataset_split: str | None = None,
+    policy_name: str | None = None,
+    prediction_path: str | Path | None = None,
+) -> dict[str, Any]:
+    """Evaluate external predictions against exported tiny dataset examples."""
+    items = _filter_by_split(list(examples), dataset_split)
+    prediction_items = list(predictions)
+    resolved_policy = policy_name or _prediction_policy_name(prediction_items)
+    prediction_by_id = {
+        str(item.get("example_id") or ""): item for item in prediction_items
+    }
+    expected_ids = {str(item.get("example_id") or "") for item in items}
+    extra_ids = sorted(set(prediction_by_id) - expected_ids)
+
+    action_total = 0
+    action_correct = 0
+    matched_count = 0
+    missing_predictions: list[dict[str, str]] = []
+    mismatches: list[dict[str, Any]] = []
+    recommendations: list[dict[str, Any]] = []
+
+    for example in items:
+        example_id = str(example.get("example_id") or "")
+        source_case = _mapping(example.get("source_case"))
+        target_action = str(
+            _mapping(example.get("targets")).get("preferred_action") or ""
+        )
+        prediction = prediction_by_id.get(example_id)
+        if prediction is None:
+            missing_predictions.append(
+                {
+                    "example_id": example_id,
+                    "case_id": str(source_case.get("case_id") or ""),
+                    "source_case_type": str(source_case.get("case_type") or ""),
+                    "target_action": target_action,
+                }
+            )
+            continue
+
+        matched_count += 1
+        recommended_action = str(prediction.get("recommended_action") or "")
+        recommendation_record = {
+            "example_id": example_id,
+            "case_id": str(source_case.get("case_id") or ""),
+            "source_case_type": str(source_case.get("case_type") or ""),
+            "target_action": target_action,
+            "recommended_action": recommended_action,
+            "failure_hint": str(prediction.get("failure_hint") or ""),
+            "confidence": prediction.get("confidence"),
+            "rule_reason": "prediction_jsonl",
+        }
+        recommendations.append(recommendation_record)
+        if target_action:
+            action_total += 1
+            if recommended_action == target_action:
+                action_correct += 1
+            else:
+                mismatches.append(recommendation_record)
+
+    return {
+        "schema_version": DATASET_SCHEMA_VERSION,
+        "case_type": EVAL_REPORT_CASE_TYPE,
+        "policy_name": resolved_policy,
+        "split": dataset_split or "all",
+        "prediction_path": str(prediction_path or _prediction_path(prediction_items)),
+        "example_count": len(items),
+        "prediction_count": len(prediction_items),
+        "matched_count": matched_count,
+        "missing_count": len(missing_predictions),
+        "extra_count": len(extra_ids),
+        "extra_predictions": extra_ids,
+        "missing_predictions": missing_predictions,
+        "evaluated_count": matched_count,
+        "skipped_count": len(missing_predictions),
+        "skipped_by_case_type": _missing_counts_by_case_type(missing_predictions),
+        "action_labeled_count": action_total,
+        "action_accuracy": _ratio(action_correct, action_total),
+        "mismatch_count": len(mismatches),
+        "mismatches": mismatches,
+        "recommendations": recommendations,
+    }
+
+
 def write_tiny_dataset_eval_report(
     *,
     dataset_path: str | Path,
@@ -270,6 +416,7 @@ def build_tiny_dataset_comparison_report(
     train_split: str = "train",
     eval_split: str = "test",
     policy_names: Sequence[str] = DEFAULT_COMPARISON_POLICIES,
+    prediction_paths: Sequence[str | Path] = (),
 ) -> dict[str, Any]:
     """Compare offline baselines on a fixed dataset split."""
     items = list(examples)
@@ -282,6 +429,15 @@ def build_tiny_dataset_comparison_report(
         )
         for policy in policy_names
     }
+    for prediction_path in prediction_paths:
+        predictions = load_tiny_prediction_records(prediction_path)
+        report = evaluate_tiny_prediction_records(
+            items,
+            predictions,
+            dataset_split=eval_split,
+            prediction_path=prediction_path,
+        )
+        reports[str(report["policy_name"])] = report
     return {
         "schema_version": DATASET_SCHEMA_VERSION,
         "case_type": COMPARISON_REPORT_CASE_TYPE,
@@ -472,12 +628,52 @@ def _rank_policy_reports(
     return sorted(
         rows,
         key=lambda item: (
-            -(float(item["action_accuracy"]) if item["action_accuracy"] is not None else -1.0),
+            -(
+                float(item["action_accuracy"])
+                if item["action_accuracy"] is not None
+                else -1.0
+            ),
             -int(item["evaluated_count"] or 0),
             int(item["mismatch_count"] or 0),
             str(item["policy_name"]),
         ),
     )
+
+
+def _prediction_policy_name(predictions: Sequence[Mapping[str, Any]]) -> str:
+    names = {
+        str(item.get("policy_name") or "")
+        for item in predictions
+        if str(item.get("policy_name") or "")
+    }
+    if len(names) > 1:
+        raise ValueError(
+            "prediction file contains multiple policy_name values: "
+            f"{sorted(names)}"
+        )
+    if names:
+        return next(iter(names))
+    return "prediction_file"
+
+
+def _prediction_path(predictions: Sequence[Mapping[str, Any]]) -> str:
+    paths = {
+        str(item.get("source_path") or "")
+        for item in predictions
+        if str(item.get("source_path") or "")
+    }
+    if len(paths) == 1:
+        return next(iter(paths))
+    return ""
+
+
+def _missing_counts_by_case_type(
+    missing_predictions: Iterable[Mapping[str, Any]],
+) -> dict[str, int]:
+    counts: Counter[str] = Counter()
+    for item in missing_predictions:
+        counts[str(item.get("source_case_type") or "unknown")] += 1
+    return dict(sorted(counts.items()))
 
 
 def _sanitize_case_for_input(record: Mapping[str, Any]) -> dict[str, Any]:

--- a/tests/test_tiny_dataset_export.py
+++ b/tests/test_tiny_dataset_export.py
@@ -253,6 +253,179 @@ def test_tiny_dataset_comparison_report_compares_rule_and_majority_baselines(tmp
     assert report["ranked_policies"][0]["policy_name"] == "redraw_observable_signal"
 
 
+def test_tiny_prediction_jsonl_scores_against_dataset_split(tmp_path):
+    from vulca.learning.tiny_dataset import (
+        evaluate_tiny_prediction_records,
+        load_tiny_prediction_records,
+        write_tiny_dataset,
+    )
+
+    dataset_path = tmp_path / "tiny_dataset.jsonl"
+    write_tiny_dataset(repo_root=ROOT, output_path=dataset_path)
+    examples = _read_jsonl(dataset_path)
+    test_examples = [item for item in examples if item["split"] == "test"]
+    prediction_path = tmp_path / "mock_tiny_model_predictions.jsonl"
+    prediction_path.write_text(
+        "\n".join(
+            json.dumps(
+                {
+                    "policy_name": "mock_tiny_model",
+                    "example_id": item["example_id"],
+                    "recommended_action": item["targets"]["preferred_action"],
+                    "failure_hint": item["targets"]["failure_type"],
+                    "confidence": 0.91,
+                }
+            )
+            for item in test_examples
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    predictions = load_tiny_prediction_records(prediction_path)
+    report = evaluate_tiny_prediction_records(
+        examples,
+        predictions,
+        dataset_split="test",
+    )
+
+    assert report["case_type"] == "learning_tiny_dataset_eval_report"
+    assert report["policy_name"] == "mock_tiny_model"
+    assert report["split"] == "test"
+    assert report["example_count"] == 2
+    assert report["prediction_count"] == 2
+    assert report["matched_count"] == 2
+    assert report["missing_count"] == 0
+    assert report["extra_count"] == 0
+    assert report["action_accuracy"] == 1.0
+    assert report["recommendations"][0]["confidence"] == 0.91
+
+
+def test_tiny_prediction_jsonl_reports_missing_and_extra_predictions(tmp_path):
+    from vulca.learning.tiny_dataset import (
+        evaluate_tiny_prediction_records,
+        load_tiny_prediction_records,
+        write_tiny_dataset,
+    )
+
+    dataset_path = tmp_path / "tiny_dataset.jsonl"
+    write_tiny_dataset(repo_root=ROOT, output_path=dataset_path)
+    examples = _read_jsonl(dataset_path)
+    test_examples = [item for item in examples if item["split"] == "test"]
+    prediction_path = tmp_path / "partial_predictions.jsonl"
+    prediction_path.write_text(
+        "\n".join(
+            [
+                json.dumps(
+                    {
+                        "policy_name": "partial_tiny_model",
+                        "example_id": test_examples[0]["example_id"],
+                        "recommended_action": "manual_review",
+                    }
+                ),
+                json.dumps(
+                    {
+                        "policy_name": "partial_tiny_model",
+                        "example_id": "tiny_unknown_extra",
+                        "recommended_action": "manual_review",
+                    }
+                ),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    report = evaluate_tiny_prediction_records(
+        examples,
+        load_tiny_prediction_records(prediction_path),
+        dataset_split="test",
+    )
+
+    assert report["policy_name"] == "partial_tiny_model"
+    assert report["matched_count"] == 1
+    assert report["missing_count"] == 1
+    assert report["extra_count"] == 1
+    assert len(report["missing_predictions"]) == 1
+    assert report["extra_predictions"] == ["tiny_unknown_extra"]
+
+
+def test_tiny_prediction_jsonl_rejects_duplicate_example_ids(tmp_path):
+    from vulca.learning.tiny_dataset import load_tiny_prediction_records
+
+    prediction_path = tmp_path / "duplicate_predictions.jsonl"
+    prediction_path.write_text(
+        "\n".join(
+            [
+                json.dumps(
+                    {
+                        "example_id": "tiny_duplicate",
+                        "recommended_action": "accept",
+                    }
+                ),
+                json.dumps(
+                    {
+                        "example_id": "tiny_duplicate",
+                        "recommended_action": "manual_review",
+                    }
+                ),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    try:
+        load_tiny_prediction_records(prediction_path)
+    except ValueError as exc:
+        assert "duplicate prediction example_id" in str(exc)
+    else:
+        raise AssertionError("expected duplicate prediction example_id to fail")
+
+
+def test_tiny_dataset_comparison_report_includes_prediction_file(tmp_path):
+    from vulca.learning.tiny_dataset import (
+        build_tiny_dataset_comparison_report,
+        write_tiny_dataset,
+    )
+
+    dataset_path = tmp_path / "tiny_dataset.jsonl"
+    write_tiny_dataset(repo_root=ROOT, output_path=dataset_path)
+    examples = _read_jsonl(dataset_path)
+    test_examples = [item for item in examples if item["split"] == "test"]
+    prediction_path = tmp_path / "mock_tiny_model_predictions.jsonl"
+    prediction_path.write_text(
+        "\n".join(
+            json.dumps(
+                {
+                    "policy_name": "mock_tiny_model",
+                    "example_id": item["example_id"],
+                    "recommended_action": item["targets"]["preferred_action"],
+                }
+            )
+            for item in test_examples
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    report = build_tiny_dataset_comparison_report(
+        examples,
+        train_split="train",
+        eval_split="test",
+        prediction_paths=[prediction_path],
+    )
+
+    assert "mock_tiny_model" in report["policy_reports"]
+    assert report["policy_reports"]["mock_tiny_model"]["prediction_path"] == str(
+        prediction_path
+    )
+    assert report["policy_reports"]["mock_tiny_model"]["action_accuracy"] == 1.0
+    assert {
+        row["policy_name"] for row in report["ranked_policies"]
+    } >= {"mock_tiny_model", "majority_action", "redraw_observable_signal"}
+
+
 def test_tiny_dataset_eval_script_writes_report(tmp_path):
     from vulca.learning.tiny_dataset import write_tiny_dataset
 
@@ -313,3 +486,53 @@ def test_tiny_dataset_eval_script_writes_comparison_report(tmp_path):
     assert report["case_type"] == "learning_tiny_dataset_comparison_report"
     assert "majority_action action_accuracy:" in result.stdout
     assert "redraw_observable_signal action_accuracy:" in result.stdout
+
+
+def test_tiny_dataset_eval_script_accepts_prediction_jsonl(tmp_path):
+    from vulca.learning.tiny_dataset import write_tiny_dataset
+
+    dataset_path = tmp_path / "tiny_dataset.jsonl"
+    report_path = tmp_path / "tiny_dataset_prediction_comparison.json"
+    prediction_path = tmp_path / "mock_tiny_model_predictions.jsonl"
+    write_tiny_dataset(repo_root=ROOT, output_path=dataset_path)
+    examples = _read_jsonl(dataset_path)
+    test_examples = [item for item in examples if item["split"] == "test"]
+    prediction_path.write_text(
+        "\n".join(
+            json.dumps(
+                {
+                    "policy_name": "mock_tiny_model",
+                    "example_id": item["example_id"],
+                    "recommended_action": item["targets"]["preferred_action"],
+                }
+            )
+            for item in test_examples
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(ROOT / "scripts" / "tiny_dataset_eval.py"),
+            str(dataset_path),
+            "--compare",
+            "--split",
+            "test",
+            "--prediction",
+            str(prediction_path),
+            "--output",
+            str(report_path),
+        ],
+        capture_output=True,
+        text=True,
+        timeout=20,
+        env=CLI_ENV,
+        cwd=ROOT,
+    )
+
+    assert result.returncode == 0, result.stderr
+    report = json.loads(report_path.read_text(encoding="utf-8"))
+    assert "mock_tiny_model" in report["policy_reports"]
+    assert "mock_tiny_model action_accuracy: 1.0" in result.stdout


### PR DESCRIPTION
## Summary
- add external prediction JSONL loading for tiny model/agent outputs keyed by `example_id`
- add prediction evaluation with matched/missing/extra counts and per-example recommendations
- include prediction files in tiny dataset comparison reports
- add `scripts/tiny_dataset_eval.py --prediction` for comparison against built-in baselines

## Prediction JSONL contract
Each line is a JSON object with:
- `example_id`
- `recommended_action`
- optional `policy_name`, `failure_hint`, `confidence`

## Validation
- `PYTHONPATH=src /opt/homebrew/bin/python3.11 -m pytest tests/test_tiny_dataset_export.py tests/test_learning_seed_report.py tests/test_learning_seed_cases.py tests/test_case_review.py tests/test_redraw_router_baseline.py tests/test_redraw_cases.py tests/test_redraw_benchmark_manifest.py tests/test_cli_commands.py -q` -> 55 passed
- `PYTHONPATH=src /opt/homebrew/bin/python3.11 -m py_compile src/vulca/learning/tiny_dataset.py scripts/tiny_dataset_eval.py src/vulca/cli.py`
- `ruff check src/ tests/` -> passed
- `git diff --check` -> passed
- `scripts/local_seed_baseline_gate.py` -> passed
- smoke: comparison report included `mock_tiny_model` with matched=2, missing=0, extra=0, action_accuracy=1.0