### PR TITLE
[codex] Add tiny baseline predictors

### DIFF
--- a/scripts/tiny_baseline_predict.py
+++ b/scripts/tiny_baseline_predict.py
@@ -1,0 +1,69 @@
+"""Generate tiny baseline prediction JSONL for exported tiny datasets."""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import Sequence
+
+
+ROOT = Path(__file__).resolve().parent.parent
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from vulca.learning.tiny_baseline_model import (  # noqa: E402
+    POLICY_TINY_AGENT,
+    TINY_BASELINE_POLICIES,
+    write_tiny_baseline_predictions,
+)
+from vulca.learning.tiny_dataset import DATASET_SPLITS  # noqa: E402
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Generate tiny baseline prediction JSONL from an exported tiny dataset."
+    )
+    parser.add_argument("dataset", help="Path to tiny dataset JSONL.")
+    parser.add_argument(
+        "--policy",
+        default=POLICY_TINY_AGENT,
+        choices=sorted(TINY_BASELINE_POLICIES),
+        help="Tiny baseline policy to run.",
+    )
+    parser.add_argument(
+        "--split",
+        default="test",
+        choices=DATASET_SPLITS,
+        help="Dataset split to predict.",
+    )
+    parser.add_argument(
+        "--train-split",
+        default="train",
+        choices=DATASET_SPLITS,
+        help="Dataset split used to fit train-derived priors.",
+    )
+    parser.add_argument(
+        "--output",
+        "-o",
+        required=True,
+        help="Output prediction JSONL path.",
+    )
+    args = parser.parse_args(argv)
+
+    result = write_tiny_baseline_predictions(
+        dataset_path=args.dataset,
+        output_path=args.output,
+        policy_name=args.policy,
+        split=args.split,
+        train_split=args.train_split,
+    )
+    print(f"{result.policy_name} predictions: {result.prediction_count}")
+    print(f"split: {result.split}")
+    print(f"train_split: {result.train_split}")
+    print(f"output: {result.output_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/vulca/learning/tiny_baseline_model.py
+++ b/src/vulca/learning/tiny_baseline_model.py
@@ -1,0 +1,173 @@
+"""Tiny provider-free predictors that emit prediction JSONL."""
+from __future__ import annotations
+
+import json
+from collections import Counter
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable, Mapping, Sequence
+
+from vulca.layers.redraw_cases import CASE_TYPE as REDRAW_CASE_TYPE
+from vulca.layers.redraw_router_baseline import (
+    POLICY_OBSERVABLE_SIGNAL,
+    recommend_action,
+)
+from vulca.learning.tiny_dataset import (
+    DATASET_SPLITS,
+    load_tiny_dataset_examples,
+)
+
+
+POLICY_TINY_CASE_TYPE_PRIOR = "tiny_case_type_prior_v0"
+POLICY_TINY_AGENT = "tiny_agent_v0"
+TINY_BASELINE_POLICIES: frozenset[str] = frozenset(
+    {POLICY_TINY_AGENT, POLICY_TINY_CASE_TYPE_PRIOR}
+)
+
+
+@dataclass(frozen=True)
+class TinyBaselinePredictionResult:
+    output_path: str
+    policy_name: str
+    split: str
+    train_split: str
+    prediction_count: int
+
+
+def build_tiny_baseline_predictions(
+    examples: Iterable[Mapping[str, Any]],
+    *,
+    policy_name: str = POLICY_TINY_AGENT,
+    split: str = "test",
+    train_split: str = "train",
+) -> list[dict[str, Any]]:
+    """Build prediction records from a tiny train-derived baseline."""
+    if policy_name not in TINY_BASELINE_POLICIES:
+        raise ValueError(
+            f"unsupported tiny baseline policy {policy_name!r}; "
+            f"expected one of {sorted(TINY_BASELINE_POLICIES)}"
+        )
+    _validate_split(split)
+    _validate_split(train_split)
+
+    items = list(examples)
+    prior = _ActionPrior.from_examples(
+        item for item in items if item.get("split") == train_split
+    )
+    eval_items = [item for item in items if item.get("split") == split]
+    return [
+        _predict_one(item, prior=prior, policy_name=policy_name)
+        for item in eval_items
+    ]
+
+
+def write_tiny_baseline_predictions(
+    *,
+    dataset_path: str | Path,
+    output_path: str | Path,
+    policy_name: str = POLICY_TINY_AGENT,
+    split: str = "test",
+    train_split: str = "train",
+) -> TinyBaselinePredictionResult:
+    predictions = build_tiny_baseline_predictions(
+        load_tiny_dataset_examples(dataset_path),
+        policy_name=policy_name,
+        split=split,
+        train_split=train_split,
+    )
+    path = Path(output_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as fh:
+        for record in predictions:
+            fh.write(json.dumps(record, sort_keys=True, separators=(",", ":")))
+            fh.write("\n")
+    return TinyBaselinePredictionResult(
+        output_path=str(path),
+        policy_name=policy_name,
+        split=split,
+        train_split=train_split,
+        prediction_count=len(predictions),
+    )
+
+
+@dataclass(frozen=True)
+class _ActionPrior:
+    by_case_type: dict[str, str]
+    global_action: str
+
+    @classmethod
+    def from_examples(cls, examples: Iterable[Mapping[str, Any]]) -> "_ActionPrior":
+        by_case_type_counts: dict[str, Counter[str]] = {}
+        global_counts: Counter[str] = Counter()
+        for example in examples:
+            action = str(_mapping(example.get("targets")).get("preferred_action") or "")
+            if not action:
+                continue
+            case_type = str(_mapping(example.get("source_case")).get("case_type") or "")
+            by_case_type_counts.setdefault(case_type, Counter())[action] += 1
+            global_counts[action] += 1
+
+        return cls(
+            by_case_type={
+                case_type: _majority_action(counts)
+                for case_type, counts in by_case_type_counts.items()
+            },
+            global_action=_majority_action(global_counts) or "manual_review",
+        )
+
+    def action_for(self, case_type: str) -> str:
+        return self.by_case_type.get(case_type, self.global_action)
+
+
+def _predict_one(
+    example: Mapping[str, Any],
+    *,
+    prior: _ActionPrior,
+    policy_name: str,
+) -> dict[str, Any]:
+    source_case = _mapping(example.get("source_case"))
+    case_type = str(source_case.get("case_type") or "")
+
+    if policy_name == POLICY_TINY_AGENT and case_type == REDRAW_CASE_TYPE:
+        case_record = _mapping(_mapping(example.get("input")).get("case_record"))
+        recommendation = recommend_action(
+            case_record,
+            policy_name=POLICY_OBSERVABLE_SIGNAL,
+        )
+        action = recommendation.recommended_action
+        failure_hint = recommendation.failure_hint
+        source_policy = "redraw_observable_signal"
+        confidence = 0.8 if action == "manual_review" else 0.85
+    else:
+        action = prior.action_for(case_type)
+        failure_hint = ""
+        source_policy = "case_type_prior"
+        confidence = 0.55
+
+    return {
+        "policy_name": policy_name,
+        "example_id": str(example.get("example_id") or ""),
+        "recommended_action": action,
+        "failure_hint": failure_hint,
+        "confidence": confidence,
+        "source_policy": source_policy,
+    }
+
+
+def _majority_action(counts: Counter[str]) -> str:
+    if not counts:
+        return ""
+    return sorted(counts.items(), key=lambda item: (-item[1], item[0]))[0][0]
+
+
+def _validate_split(value: str) -> None:
+    if value not in DATASET_SPLITS:
+        raise ValueError(
+            f"unsupported tiny baseline split {value!r}; expected one of {DATASET_SPLITS}"
+        )
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    if isinstance(value, Mapping):
+        return value
+    return {}

--- a/tests/test_tiny_baseline_predict.py
+++ b/tests/test_tiny_baseline_predict.py
@@ -1,0 +1,145 @@
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+CLI_ENV = dict(
+    os.environ,
+    PYTHONPATH=str(ROOT / "src") + os.pathsep + os.environ.get("PYTHONPATH", ""),
+)
+
+
+def _read_jsonl(path: Path):
+    return [json.loads(line) for line in path.read_text().splitlines()]
+
+
+def test_tiny_case_type_prior_writes_prediction_jsonl(tmp_path):
+    from vulca.learning.tiny_baseline_model import write_tiny_baseline_predictions
+    from vulca.learning.tiny_dataset import (
+        build_tiny_dataset_comparison_report,
+        write_tiny_dataset,
+    )
+
+    dataset_path = tmp_path / "tiny_dataset.jsonl"
+    prediction_path = tmp_path / "case_type_prior.jsonl"
+    write_tiny_dataset(repo_root=ROOT, output_path=dataset_path)
+
+    result = write_tiny_baseline_predictions(
+        dataset_path=dataset_path,
+        output_path=prediction_path,
+        policy_name="tiny_case_type_prior_v0",
+        split="test",
+    )
+
+    assert result.output_path == str(prediction_path)
+    assert result.prediction_count == 2
+    predictions = _read_jsonl(prediction_path)
+    assert {item["policy_name"] for item in predictions} == {
+        "tiny_case_type_prior_v0"
+    }
+    assert all(item["example_id"] for item in predictions)
+    assert all(item["recommended_action"] for item in predictions)
+
+    report = build_tiny_dataset_comparison_report(
+        _read_jsonl(dataset_path),
+        eval_split="test",
+        prediction_paths=[prediction_path],
+    )
+    assert report["policy_reports"]["tiny_case_type_prior_v0"][
+        "action_accuracy"
+    ] == 0.5
+
+
+def test_tiny_agent_v0_combines_redraw_router_and_learned_prior(tmp_path):
+    from vulca.learning.tiny_baseline_model import write_tiny_baseline_predictions
+    from vulca.learning.tiny_dataset import (
+        build_tiny_dataset_comparison_report,
+        write_tiny_dataset,
+    )
+
+    dataset_path = tmp_path / "tiny_dataset.jsonl"
+    prediction_path = tmp_path / "tiny_agent_v0.jsonl"
+    write_tiny_dataset(repo_root=ROOT, output_path=dataset_path)
+
+    result = write_tiny_baseline_predictions(
+        dataset_path=dataset_path,
+        output_path=prediction_path,
+        policy_name="tiny_agent_v0",
+        split="test",
+    )
+
+    assert result.policy_name == "tiny_agent_v0"
+    assert result.prediction_count == 2
+    predictions = _read_jsonl(prediction_path)
+    assert {item["policy_name"] for item in predictions} == {"tiny_agent_v0"}
+    assert {item["source_policy"] for item in predictions} == {
+        "case_type_prior",
+        "redraw_observable_signal",
+    }
+
+    report = build_tiny_dataset_comparison_report(
+        _read_jsonl(dataset_path),
+        eval_split="test",
+        prediction_paths=[prediction_path],
+    )
+    assert report["policy_reports"]["tiny_agent_v0"]["matched_count"] == 2
+    assert report["policy_reports"]["tiny_agent_v0"]["action_accuracy"] == 1.0
+    assert report["ranked_policies"][0]["policy_name"] == "tiny_agent_v0"
+
+
+def test_tiny_baseline_predict_script_outputs_comparable_predictions(tmp_path):
+    from vulca.learning.tiny_dataset import write_tiny_dataset
+
+    dataset_path = tmp_path / "tiny_dataset.jsonl"
+    prediction_path = tmp_path / "tiny_agent_v0.jsonl"
+    report_path = tmp_path / "comparison.json"
+    write_tiny_dataset(repo_root=ROOT, output_path=dataset_path)
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(ROOT / "scripts" / "tiny_baseline_predict.py"),
+            str(dataset_path),
+            "--policy",
+            "tiny_agent_v0",
+            "--split",
+            "test",
+            "--output",
+            str(prediction_path),
+        ],
+        capture_output=True,
+        text=True,
+        timeout=20,
+        env=CLI_ENV,
+        cwd=ROOT,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert prediction_path.exists()
+    assert "tiny_agent_v0 predictions: 2" in result.stdout
+
+    eval_result = subprocess.run(
+        [
+            sys.executable,
+            str(ROOT / "scripts" / "tiny_dataset_eval.py"),
+            str(dataset_path),
+            "--compare",
+            "--split",
+            "test",
+            "--prediction",
+            str(prediction_path),
+            "--output",
+            str(report_path),
+        ],
+        capture_output=True,
+        text=True,
+        timeout=20,
+        env=CLI_ENV,
+        cwd=ROOT,
+    )
+
+    assert eval_result.returncode == 0, eval_result.stderr
+    assert "tiny_agent_v0 action_accuracy: 1.0" in eval_result.stdout


### PR DESCRIPTION
## Summary
- Add provider-free tiny baseline predictors that emit prediction JSONL for exported tiny datasets.
- Add `tiny_case_type_prior_v0` and `tiny_agent_v0`; the tiny agent combines redraw observable-signal routing with train-split case-type priors for non-redraw cases.
- Add a CLI for offline prediction generation plus focused tests that verify prediction ingest and comparison reporting.

## Validation
- `PYTHONPATH=src /opt/homebrew/bin/python3.11 -m pytest tests/test_tiny_baseline_predict.py -q` -> `3 passed`
- `PYTHONPATH=src /opt/homebrew/bin/python3.11 -m pytest tests/test_tiny_baseline_predict.py tests/test_tiny_dataset_export.py tests/test_learning_seed_report.py tests/test_learning_seed_cases.py tests/test_case_review.py tests/test_redraw_router_baseline.py tests/test_redraw_cases.py tests/test_redraw_benchmark_manifest.py tests/test_cli_commands.py -q` -> `58 passed`
- `PYTHONPATH=src /opt/homebrew/bin/python3.11 -m py_compile src/vulca/learning/tiny_baseline_model.py scripts/tiny_baseline_predict.py src/vulca/learning/tiny_dataset.py scripts/tiny_dataset_eval.py`
- `ruff check src/ tests/`
- `git diff --check`

## Local seed smoke
- Exported 12 local seed examples: train 8, dev 2, test 2.
- `tiny_agent_v0` test action accuracy: `1.0` over 2 evaluated examples.
- `tiny_case_type_prior_v0` test action accuracy: `0.5` over 2 evaluated examples.
- Existing local seed baseline gate passed.
