### PR TITLE
[codex] Add tiny case source manifests

### DIFF
--- a/src/vulca/cli.py
+++ b/src/vulca/cli.py
@@ -427,6 +427,11 @@ def main(argv: list[str] | None = None) -> None:
         help="Additional reviewed case JSONL path; repeat to include multiple logs",
     )
     cases_export.add_argument(
+        "--case-source-manifest",
+        default="",
+        help="JSON manifest describing user/manual/synthetic reviewed case logs",
+    )
+    cases_export.add_argument(
         "--no-local-seeds",
         action="store_true",
         help="Only export records from --case-log inputs",
@@ -1749,6 +1754,7 @@ def _cmd_cases(args: argparse.Namespace) -> None:
                 output_path=args.output,
                 manifest_path=args.manifest or DEFAULT_SEED_MANIFEST,
                 case_log_paths=args.case_log,
+                case_source_manifest_path=args.case_source_manifest or None,
                 include_local_seeds=not args.no_local_seeds,
             )
         except (

--- a/src/vulca/learning/tiny_dataset.py
+++ b/src/vulca/learning/tiny_dataset.py
@@ -34,6 +34,7 @@ DATASET_CASE_TYPE = "learning_tiny_dataset_example"
 DATASET_INDEX_CASE_TYPE = "learning_tiny_dataset_index"
 EVAL_REPORT_CASE_TYPE = "learning_tiny_dataset_eval_report"
 COMPARISON_REPORT_CASE_TYPE = "learning_tiny_dataset_comparison_report"
+CASE_SOURCE_MANIFEST_CASE_TYPE = "learning_tiny_case_source_manifest"
 
 POLICY_MAJORITY_ACTION = "majority_action"
 POLICY_REDRAW_OBSERVABLE_SIGNAL = "redraw_observable_signal"
@@ -45,6 +46,15 @@ DEFAULT_COMPARISON_POLICIES: tuple[str, ...] = (
     POLICY_REDRAW_OBSERVABLE_SIGNAL,
 )
 DATASET_SPLITS: tuple[str, ...] = ("train", "dev", "test")
+CASE_SOURCE_KINDS: frozenset[str] = frozenset(
+    {"case_log", "manual_case_log", "synthetic_case_log", "user_case_log"}
+)
+CASE_SOURCE_PRIVACY_SCOPES: frozenset[str] = frozenset(
+    {"private", "project", "public"}
+)
+CASE_SOURCE_CURATION_STATUSES: frozenset[str] = frozenset(
+    {"curated", "reviewed", "synthetic_reviewed"}
+)
 SUPPORTED_SOURCE_CASE_TYPES: frozenset[str] = frozenset(
     {REDRAW_CASE_TYPE, DECOMPOSE_CASE_TYPE, LAYER_GENERATE_CASE_TYPE}
 )
@@ -64,11 +74,31 @@ class TinyDatasetWriteResult:
     counts_by_split: dict[str, int]
 
 
+@dataclass(frozen=True)
+class TinyCaseSourceSpec:
+    source_id: str
+    kind: str
+    path: str
+    privacy_scope: str
+    curation_status: str
+
+    def source_for_record(self, index: int) -> dict[str, Any]:
+        return {
+            "kind": self.kind,
+            "source_id": self.source_id,
+            "path": self.path,
+            "privacy_scope": self.privacy_scope,
+            "curation_status": self.curation_status,
+            "index": index,
+        }
+
+
 def build_tiny_dataset_examples(
     *,
     repo_root: str | Path,
     manifest_path: str | Path = DEFAULT_SEED_MANIFEST,
     case_log_paths: Sequence[str | Path] = (),
+    case_source_manifest_path: str | Path | None = None,
     include_local_seeds: bool = True,
 ) -> list[dict[str, Any]]:
     """Build leak-resistant tiny dataset examples from seeds and case logs."""
@@ -109,6 +139,17 @@ def build_tiny_dataset_examples(
                 )
             )
 
+    case_sources = _load_case_source_specs(case_source_manifest_path)
+    for spec in case_sources:
+        records = load_cases(spec.path)
+        for index, record in enumerate(records):
+            examples.append(
+                _build_example(
+                    record,
+                    source=spec.source_for_record(index),
+                )
+            )
+
     _assign_dataset_splits(examples)
     return examples
 
@@ -119,13 +160,16 @@ def write_tiny_dataset(
     output_path: str | Path,
     manifest_path: str | Path = DEFAULT_SEED_MANIFEST,
     case_log_paths: Sequence[str | Path] = (),
+    case_source_manifest_path: str | Path | None = None,
     include_local_seeds: bool = True,
     index_path: str | Path | None = None,
 ) -> TinyDatasetWriteResult:
+    case_sources = _load_case_source_specs(case_source_manifest_path)
     examples = build_tiny_dataset_examples(
         repo_root=repo_root,
         manifest_path=manifest_path,
         case_log_paths=case_log_paths,
+        case_source_manifest_path=case_source_manifest_path,
         include_local_seeds=include_local_seeds,
     )
     output = Path(output_path)
@@ -143,6 +187,8 @@ def write_tiny_dataset(
                 "output_path": str(output),
                 "source_manifest": str(manifest_path),
                 "case_log_paths": [str(path) for path in case_log_paths],
+                "case_source_manifest_path": str(case_source_manifest_path or ""),
+                "case_sources": _case_source_summaries(case_sources, examples),
                 "include_local_seeds": bool(include_local_seeds),
                 "example_count": len(examples),
                 "counts_by_case_type": counts,
@@ -496,6 +542,107 @@ def _build_example(
             },
         },
     }
+
+
+def _load_case_source_specs(
+    manifest_path: str | Path | None,
+) -> tuple[TinyCaseSourceSpec, ...]:
+    if not manifest_path:
+        return ()
+
+    path = Path(manifest_path)
+    manifest = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(manifest, Mapping):
+        raise ValueError("case source manifest must be a JSON object")
+    if manifest.get("case_type") != CASE_SOURCE_MANIFEST_CASE_TYPE:
+        raise ValueError(
+            f"case source manifest case_type must be {CASE_SOURCE_MANIFEST_CASE_TYPE!r}"
+        )
+    sources = manifest.get("sources")
+    if not isinstance(sources, list):
+        raise ValueError("case source manifest sources must be a list")
+
+    specs: list[TinyCaseSourceSpec] = []
+    errors: list[str] = []
+    seen_source_ids: set[str] = set()
+    for index, item in enumerate(sources):
+        if not isinstance(item, Mapping):
+            errors.append(f"sources[{index}] must be an object")
+            continue
+
+        source_id = str(item.get("source_id") or "")
+        kind = str(item.get("kind") or "")
+        raw_path = str(item.get("path") or "")
+        privacy_scope = str(item.get("privacy_scope") or "")
+        curation_status = str(item.get("curation_status") or "")
+
+        if not source_id:
+            errors.append(f"sources[{index}]: source_id is required")
+        elif source_id in seen_source_ids:
+            errors.append(f"sources[{index}]: duplicate source_id {source_id!r}")
+        else:
+            seen_source_ids.add(source_id)
+
+        if kind not in CASE_SOURCE_KINDS:
+            errors.append(
+                f"sources[{index}]: unsupported case source kind {kind!r}; "
+                f"expected one of {sorted(CASE_SOURCE_KINDS)}"
+            )
+        if not raw_path:
+            errors.append(f"sources[{index}]: path is required")
+        if privacy_scope not in CASE_SOURCE_PRIVACY_SCOPES:
+            errors.append(
+                f"sources[{index}]: unsupported privacy_scope {privacy_scope!r}; "
+                f"expected one of {sorted(CASE_SOURCE_PRIVACY_SCOPES)}"
+            )
+        if curation_status not in CASE_SOURCE_CURATION_STATUSES:
+            errors.append(
+                f"sources[{index}]: unsupported curation_status "
+                f"{curation_status!r}; expected one of "
+                f"{sorted(CASE_SOURCE_CURATION_STATUSES)}"
+            )
+
+        if source_id and kind in CASE_SOURCE_KINDS and raw_path:
+            source_path = Path(raw_path)
+            if not source_path.is_absolute():
+                source_path = path.parent / source_path
+            specs.append(
+                TinyCaseSourceSpec(
+                    source_id=source_id,
+                    kind=kind,
+                    path=str(source_path),
+                    privacy_scope=privacy_scope,
+                    curation_status=curation_status,
+                )
+            )
+
+    if errors:
+        raise ValueError("; ".join(errors))
+    return tuple(specs)
+
+
+def _case_source_summaries(
+    specs: Sequence[TinyCaseSourceSpec],
+    examples: Iterable[Mapping[str, Any]],
+) -> list[dict[str, Any]]:
+    counts: Counter[str] = Counter()
+    for example in examples:
+        source = _mapping(example.get("source"))
+        source_id = str(source.get("source_id") or "")
+        if source_id:
+            counts[source_id] += 1
+
+    return [
+        {
+            "source_id": spec.source_id,
+            "kind": spec.kind,
+            "path": spec.path,
+            "privacy_scope": spec.privacy_scope,
+            "curation_status": spec.curation_status,
+            "record_count": counts.get(spec.source_id, 0),
+        }
+        for spec in specs
+    ]
 
 
 def _assign_dataset_splits(examples: list[dict[str, Any]]) -> None:

--- a/tests/test_tiny_dataset_export.py
+++ b/tests/test_tiny_dataset_export.py
@@ -145,6 +145,144 @@ def test_tiny_dataset_merges_additional_case_logs(tmp_path):
     assert extra_examples[0]["targets"]["preferred_action"] == "manual_review"
 
 
+def test_tiny_dataset_case_source_manifest_preserves_source_metadata(tmp_path):
+    from vulca.learning.seed_cases import build_local_seed_cases
+    from vulca.learning.tiny_dataset import write_tiny_dataset
+
+    seed = build_local_seed_cases(ROOT)["redraw_case"][0]
+    user_case = json.loads(json.dumps(seed))
+    user_case["case_id"] = "redraw_user_private_case"
+    user_case["review"]["preferred_action"] = "manual_review"
+    manual_case = json.loads(json.dumps(seed))
+    manual_case["case_id"] = "redraw_manual_boundary_case"
+    manual_case["review"]["preferred_action"] = "adjust_mask"
+
+    user_log = tmp_path / "user_cases.jsonl"
+    manual_log = tmp_path / "manual_cases.jsonl"
+    user_log.write_text(json.dumps(user_case) + "\n", encoding="utf-8")
+    manual_log.write_text(json.dumps(manual_case) + "\n", encoding="utf-8")
+    manifest_path = tmp_path / "case_sources.json"
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "case_type": "learning_tiny_case_source_manifest",
+                "sources": [
+                    {
+                        "source_id": "user_session_redraw_001",
+                        "kind": "user_case_log",
+                        "path": "user_cases.jsonl",
+                        "privacy_scope": "private",
+                        "curation_status": "reviewed",
+                    },
+                    {
+                        "source_id": "manual_redraw_boundaries_v1",
+                        "kind": "manual_case_log",
+                        "path": "manual_cases.jsonl",
+                        "privacy_scope": "project",
+                        "curation_status": "curated",
+                    },
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    output_path = tmp_path / "tiny_dataset.jsonl"
+
+    result = write_tiny_dataset(
+        repo_root=ROOT,
+        output_path=output_path,
+        include_local_seeds=False,
+        case_source_manifest_path=manifest_path,
+    )
+
+    assert result.example_count == 2
+    records = _read_jsonl(output_path)
+    source_by_case_id = {
+        item["source_case"]["case_id"]: item["source"] for item in records
+    }
+    assert source_by_case_id["redraw_user_private_case"] == {
+        "kind": "user_case_log",
+        "source_id": "user_session_redraw_001",
+        "path": str(user_log),
+        "privacy_scope": "private",
+        "curation_status": "reviewed",
+        "index": 0,
+    }
+    assert source_by_case_id["redraw_manual_boundary_case"] == {
+        "kind": "manual_case_log",
+        "source_id": "manual_redraw_boundaries_v1",
+        "path": str(manual_log),
+        "privacy_scope": "project",
+        "curation_status": "curated",
+        "index": 0,
+    }
+
+    index = json.loads(Path(result.index_path).read_text(encoding="utf-8"))
+    assert index["case_source_manifest_path"] == str(manifest_path)
+    assert index["counts_by_source"] == {
+        "manual_case_log": 1,
+        "user_case_log": 1,
+    }
+    assert index["case_sources"] == [
+        {
+            "source_id": "user_session_redraw_001",
+            "kind": "user_case_log",
+            "path": str(user_log),
+            "privacy_scope": "private",
+            "curation_status": "reviewed",
+            "record_count": 1,
+        },
+        {
+            "source_id": "manual_redraw_boundaries_v1",
+            "kind": "manual_case_log",
+            "path": str(manual_log),
+            "privacy_scope": "project",
+            "curation_status": "curated",
+            "record_count": 1,
+        },
+    ]
+
+
+def test_tiny_dataset_rejects_invalid_case_source_manifest(tmp_path):
+    from vulca.learning.tiny_dataset import write_tiny_dataset
+
+    manifest_path = tmp_path / "case_sources.json"
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "case_type": "learning_tiny_case_source_manifest",
+                "sources": [
+                    {
+                        "source_id": "",
+                        "kind": "spreadsheet_dump",
+                        "path": "missing.jsonl",
+                        "privacy_scope": "unknown",
+                        "curation_status": "raw",
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    try:
+        write_tiny_dataset(
+            repo_root=ROOT,
+            output_path=tmp_path / "tiny_dataset.jsonl",
+            include_local_seeds=False,
+            case_source_manifest_path=manifest_path,
+        )
+    except ValueError as exc:
+        message = str(exc)
+        assert "source_id is required" in message
+        assert "unsupported case source kind" in message
+        assert "unsupported privacy_scope" in message
+    else:
+        raise AssertionError("expected invalid case source manifest to fail")
+
+
 def test_cases_export_dataset_cli_writes_dataset(tmp_path):
     output_path = tmp_path / "tiny_dataset.jsonl"
     result = subprocess.run(
@@ -175,6 +313,65 @@ def test_cases_export_dataset_cli_writes_dataset(tmp_path):
     assert "dev: 2" in result.stdout
     assert "test: 2" in result.stdout
     assert (tmp_path / "tiny_dataset.index.json").exists()
+
+
+def test_cases_export_dataset_cli_accepts_case_source_manifest(tmp_path):
+    from vulca.learning.seed_cases import build_local_seed_cases
+
+    seed = build_local_seed_cases(ROOT)["redraw_case"][0]
+    manual_case = json.loads(json.dumps(seed))
+    manual_case["case_id"] = "redraw_cli_manual_case"
+    manual_case["review"]["preferred_action"] = "manual_review"
+    manual_log = tmp_path / "manual_cases.jsonl"
+    manual_log.write_text(json.dumps(manual_case) + "\n", encoding="utf-8")
+    manifest_path = tmp_path / "case_sources.json"
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "case_type": "learning_tiny_case_source_manifest",
+                "sources": [
+                    {
+                        "source_id": "manual_cli_pack",
+                        "kind": "manual_case_log",
+                        "path": "manual_cases.jsonl",
+                        "privacy_scope": "project",
+                        "curation_status": "curated",
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    output_path = tmp_path / "tiny_dataset.jsonl"
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "vulca.cli",
+            "cases",
+            "export-dataset",
+            "--repo-root",
+            str(ROOT),
+            "--output",
+            str(output_path),
+            "--no-local-seeds",
+            "--case-source-manifest",
+            str(manifest_path),
+        ],
+        capture_output=True,
+        text=True,
+        timeout=20,
+        env=CLI_ENV,
+        cwd=tmp_path,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "redraw_case: 1" in result.stdout
+    records = _read_jsonl(output_path)
+    assert records[0]["source"]["kind"] == "manual_case_log"
+    assert records[0]["source"]["source_id"] == "manual_cli_pack"
 
 
 def test_tiny_dataset_eval_scores_redraw_observable_signal(tmp_path):


### PR DESCRIPTION
## Summary
- Add a tiny case source manifest contract for reviewed user, manual, and synthetic case logs.
- Preserve source metadata (`source_id`, source kind, privacy scope, curation status, path, index) in exported tiny dataset examples.
- Add dataset index summaries for manifest-backed sources and expose the manifest through `cases export-dataset --case-source-manifest`.

## Why
This gives parallel sessions a clean handoff format for adding real user cases and manually curated boundary cases without flattening everything into anonymous `case_log` input. It also keeps privacy/curation metadata visible before we train or evaluate a tiny action model.

## Validation
- `PYTHONPATH=src /opt/homebrew/bin/python3.11 -m pytest tests/test_tiny_dataset_export.py::test_tiny_dataset_case_source_manifest_preserves_source_metadata tests/test_tiny_dataset_export.py::test_tiny_dataset_rejects_invalid_case_source_manifest tests/test_tiny_dataset_export.py::test_cases_export_dataset_cli_accepts_case_source_manifest -q` -> `3 passed`
- `PYTHONPATH=src /opt/homebrew/bin/python3.11 -m pytest tests/test_tiny_dataset_export.py tests/test_tiny_baseline_predict.py tests/test_learning_seed_cases.py tests/test_cli_commands.py -q` -> `32 passed`
- `PYTHONPATH=src /opt/homebrew/bin/python3.11 -m py_compile src/vulca/learning/tiny_dataset.py src/vulca/cli.py`
- `ruff check src/vulca/learning/tiny_dataset.py src/vulca/cli.py tests/test_tiny_dataset_export.py`
- `git diff --check`
