### PR TITLE
[codex] user case intake v1

### DIFF
--- a/src/vulca/cli.py
+++ b/src/vulca/cli.py
@@ -342,6 +342,27 @@ def main(argv: list[str] | None = None) -> None:
         default="",
         help="Optional review-only JSONL sidecar path, appended if provided",
     )
+    cases_intake_user = cases_sub.add_parser(
+        "intake-user",
+        help="Normalize reviewed private user case JSONL into a case source manifest",
+    )
+    cases_intake_user.add_argument("input", help="Reviewed user case JSONL")
+    cases_intake_user.add_argument("--source-id", required=True, help="Stable user case source id")
+    cases_intake_user.add_argument(
+        "--output-dir",
+        default="",
+        help="Output directory for private user case log and source manifest",
+    )
+    cases_intake_user.add_argument(
+        "--output-log",
+        default="",
+        help="Output private user case JSONL path (default: OUTPUT_DIR/SOURCE.private.user_cases.jsonl)",
+    )
+    cases_intake_user.add_argument(
+        "--manifest-output",
+        default="",
+        help="Output case source manifest path (default: OUTPUT_DIR/SOURCE.case_source_manifest.json)",
+    )
     cases_seed = cases_sub.add_parser("seed", help="Build local seed case JSONL logs")
     cases_seed.add_argument(
         "--output",
@@ -1743,6 +1764,27 @@ def _cmd_layers(args: argparse.Namespace) -> None:
 
 def _cmd_cases(args: argparse.Namespace) -> None:
     import json as _json
+
+    if args.cases_command == "intake-user":
+        from vulca.learning.user_case_intake import write_user_case_intake
+
+        try:
+            result = write_user_case_intake(
+                input_path=args.input,
+                source_id=args.source_id,
+                output_dir=args.output_dir or None,
+                output_path=args.output_log or None,
+                manifest_path=args.manifest_output or None,
+            )
+        except (ValueError, FileNotFoundError, _json.JSONDecodeError) as exc:
+            print(f"Error: {exc}", file=sys.stderr)
+            sys.exit(1)
+
+        print(f"  User case log: {result.output_path}")
+        print(f"  Records: {result.record_count}")
+        print(f"  Source id: {result.source_id}")
+        print(f"  Case source manifest: {result.manifest_path}")
+        return
 
     if args.cases_command == "export-dataset":
         from vulca.learning.seed_cases import DEFAULT_SEED_MANIFEST

--- a/src/vulca/learning/user_case_intake.py
+++ b/src/vulca/learning/user_case_intake.py
@@ -1,0 +1,222 @@
+"""Provider-free intake for reviewed private user case logs."""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+from dataclasses import dataclass
+from pathlib import Path, PureWindowsPath
+from typing import Any, Mapping
+
+from vulca.learning.case_review import load_cases, write_cases
+
+
+USER_CASE_INTAKE_SCHEMA_VERSION = 1
+CASE_SOURCE_MANIFEST_CASE_TYPE = "learning_tiny_case_source_manifest"
+USER_CASE_LOG_KIND = "user_case_log"
+PRIVATE_PRIVACY_SCOPE = "private"
+REVIEWED_CURATION_STATUS = "reviewed"
+SUPPORTED_USER_CASE_TYPES: frozenset[str] = frozenset(
+    {"redraw_case", "decompose_case", "layer_generate_case"}
+)
+
+_EMAIL_RE = re.compile(r"\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b", re.IGNORECASE)
+_PHONE_RE = re.compile(r"(?<!\w)(?:\+?\d[\d\s().-]{7,}\d)(?!\w)")
+_SECRET_RE = re.compile(r"\b(?:sk|api|key|token)[-_][A-Za-z0-9]{12,}\b")
+_POSIX_LOCAL_PATH_RE = re.compile(
+    r"(?<![\w:])/(?:Users|home|private|var|tmp|Volumes)/[^\s,;\"')\]]+"
+)
+_WINDOWS_LOCAL_PATH_RE = re.compile(
+    r"\b[A-Za-z]:\\(?:Users|Documents and Settings)\\[^\s,;\"')\]]+"
+)
+_SENSITIVE_KEY_RE = re.compile(
+    r"(?:api[_-]?key|auth(?:orization)?|credential|password|secret|token)",
+    re.IGNORECASE,
+)
+_SAFE_FILENAME_RE = re.compile(r"[^A-Za-z0-9._-]+")
+
+
+@dataclass(frozen=True)
+class UserCaseIntakeResult:
+    source_id: str
+    output_path: str
+    manifest_path: str
+    record_count: int
+
+
+def write_user_case_intake(
+    *,
+    input_path: str | Path,
+    source_id: str,
+    output_dir: str | Path | None = None,
+    output_path: str | Path | None = None,
+    manifest_path: str | Path | None = None,
+) -> UserCaseIntakeResult:
+    """Normalize reviewed user case JSONL into a private user_case_log source."""
+    resolved_source_id = str(source_id).strip()
+    if not resolved_source_id:
+        raise ValueError("source_id is required")
+
+    input_records = load_cases(input_path)
+    base_dir = Path(output_dir) if output_dir is not None else Path(input_path).parent
+    path_token = _path_token(resolved_source_id)
+    output = (
+        Path(output_path)
+        if output_path is not None
+        else base_dir / f"{path_token}.private.user_cases.jsonl"
+    )
+    manifest = (
+        Path(manifest_path)
+        if manifest_path is not None
+        else base_dir / f"{path_token}.case_source_manifest.json"
+    )
+
+    normalized_records = [
+        normalize_user_case_record(
+            record,
+            source_id=resolved_source_id,
+            record_index=index,
+        )
+        for index, record in enumerate(input_records)
+    ]
+
+    write_cases(output, normalized_records)
+    _write_case_source_manifest(
+        manifest_path=manifest,
+        output_path=output,
+        source_id=resolved_source_id,
+    )
+    return UserCaseIntakeResult(
+        source_id=resolved_source_id,
+        output_path=str(output),
+        manifest_path=str(manifest),
+        record_count=len(normalized_records),
+    )
+
+
+def normalize_user_case_record(
+    record: Mapping[str, Any],
+    *,
+    source_id: str,
+    record_index: int,
+) -> dict[str, Any]:
+    """Return a sanitized reviewed case record with private intake metadata."""
+    _validate_reviewed_case(record, record_index=record_index)
+    normalized = _sanitize_value(dict(record), key="")
+    if not isinstance(normalized, dict):
+        raise ValueError(f"record {record_index}: expected JSON object")
+    normalized["user_case_intake"] = {
+        "schema_version": USER_CASE_INTAKE_SCHEMA_VERSION,
+        "source_id": source_id,
+        "privacy_scope": PRIVATE_PRIVACY_SCOPE,
+        "curation_status": REVIEWED_CURATION_STATUS,
+        "record_index": record_index,
+    }
+    return normalized
+
+
+def _validate_reviewed_case(record: Mapping[str, Any], *, record_index: int) -> None:
+    case_type = str(record.get("case_type") or "")
+    if case_type not in SUPPORTED_USER_CASE_TYPES:
+        raise ValueError(
+            f"record {record_index}: unsupported case_type {case_type!r}; "
+            f"expected one of {sorted(SUPPORTED_USER_CASE_TYPES)}"
+        )
+    if not str(record.get("case_id") or ""):
+        raise ValueError(f"record {record_index}: case_id is required")
+
+    review = record.get("review")
+    if not isinstance(review, Mapping):
+        raise ValueError(f"record {record_index}: review object is required")
+    if not str(review.get("reviewed_at") or ""):
+        raise ValueError(f"record {record_index}: review.reviewed_at is required")
+    human_accept = review.get("human_accept")
+    failure_type = str(review.get("failure_type") or "")
+    preferred_action = str(review.get("preferred_action") or "")
+    if not isinstance(human_accept, bool) and not failure_type and not preferred_action:
+        raise ValueError(f"record {record_index}: at least one review label is required")
+
+
+def _write_case_source_manifest(
+    *,
+    manifest_path: Path,
+    output_path: Path,
+    source_id: str,
+) -> None:
+    manifest_path.parent.mkdir(parents=True, exist_ok=True)
+    manifest = {
+        "schema_version": USER_CASE_INTAKE_SCHEMA_VERSION,
+        "case_type": CASE_SOURCE_MANIFEST_CASE_TYPE,
+        "sources": [
+            {
+                "source_id": source_id,
+                "kind": USER_CASE_LOG_KIND,
+                "path": _manifest_relative_path(output_path, manifest_path.parent),
+                "privacy_scope": PRIVATE_PRIVACY_SCOPE,
+                "curation_status": REVIEWED_CURATION_STATUS,
+            }
+        ],
+    }
+    manifest_path.write_text(
+        json.dumps(manifest, indent=2, sort_keys=False) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _sanitize_value(value: Any, *, key: str) -> Any:
+    if _SENSITIVE_KEY_RE.search(key):
+        return "<redacted>"
+    if isinstance(value, dict):
+        return {
+            str(child_key): _sanitize_value(child_value, key=str(child_key))
+            for child_key, child_value in value.items()
+        }
+    if isinstance(value, list):
+        return [_sanitize_value(child, key=key) for child in value]
+    if isinstance(value, str):
+        return _sanitize_text(value)
+    return value
+
+
+def _sanitize_text(value: str) -> str:
+    sanitized = _POSIX_LOCAL_PATH_RE.sub(_canonical_posix_path, value)
+    sanitized = _WINDOWS_LOCAL_PATH_RE.sub(_canonical_windows_path, sanitized)
+    sanitized = _EMAIL_RE.sub("<email:redacted>", sanitized)
+    sanitized = _PHONE_RE.sub("<phone:redacted>", sanitized)
+    sanitized = _SECRET_RE.sub("<secret:redacted>", sanitized)
+    return sanitized
+
+
+def _canonical_posix_path(match: re.Match[str]) -> str:
+    raw, trailing = _strip_trailing_punctuation(match.group(0))
+    return f"{_canonical_path_token(raw, Path(raw).name)}{trailing}"
+
+
+def _canonical_windows_path(match: re.Match[str]) -> str:
+    raw, trailing = _strip_trailing_punctuation(match.group(0))
+    return f"{_canonical_path_token(raw, PureWindowsPath(raw).name)}{trailing}"
+
+
+def _canonical_path_token(raw_path: str, name: str) -> str:
+    digest = hashlib.sha256(raw_path.encode("utf-8")).hexdigest()[:12]
+    safe_name = _SAFE_FILENAME_RE.sub("_", name or "path").strip("._") or "path"
+    return f"private://local_path/{digest}/{safe_name[:80]}"
+
+
+def _strip_trailing_punctuation(value: str) -> tuple[str, str]:
+    stripped = value.rstrip(".:")
+    return stripped, value[len(stripped):]
+
+
+def _manifest_relative_path(output_path: Path, manifest_dir: Path) -> str:
+    rel = os.path.relpath(output_path, manifest_dir)
+    return Path(rel).as_posix()
+
+
+def _path_token(source_id: str) -> str:
+    token = _SAFE_FILENAME_RE.sub("_", source_id).strip("._")
+    if token:
+        return token
+    digest = hashlib.sha256(source_id.encode("utf-8")).hexdigest()[:12]
+    return f"user_case_source_{digest}"

--- a/tests/test_user_case_intake.py
+++ b/tests/test_user_case_intake.py
@@ -1,0 +1,179 @@
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parent.parent
+CLI_ENV = dict(
+    os.environ,
+    PYTHONPATH=str(ROOT / "src") + os.pathsep + os.environ.get("PYTHONPATH", ""),
+)
+
+
+def _write_jsonl(path: Path, records: list[dict]) -> None:
+    path.write_text(
+        "\n".join(json.dumps(record, sort_keys=True) for record in records) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _read_jsonl(path: Path) -> list[dict]:
+    return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines()]
+
+
+def _reviewed_redraw_case() -> dict:
+    return {
+        "schema_version": 1,
+        "case_type": "redraw_case",
+        "case_id": "redraw_user_001",
+        "created_at": "2026-05-05T15:00:00Z",
+        "source_image": "/Users/alice/private-client/source.png",
+        "instruction": (
+            "Redraw the sign edge using alice@example.com reference "
+            "from /Users/alice/private-client/ref.png; call +1 415 555 0134."
+        ),
+        "observables": {
+            "alpha_edge_delta": 0.42,
+            "texture_mismatch_score": 0.78,
+        },
+        "artifacts": {
+            "source_layer_path": "/Users/alice/private-client/layers/sign.png",
+            "redrawn_layer_path": "/Users/alice/private-client/out/sign_redraw.png",
+        },
+        "review": {
+            "human_accept": False,
+            "failure_type": "texture_leak",
+            "preferred_action": "adjust_instruction",
+            "reviewer": "alice@example.com",
+            "reviewed_at": "2026-05-05T16:00:00Z",
+            "notes": "Observable texture leak; private notes at /Users/alice/private-client/notes.txt.",
+        },
+    }
+
+
+def test_user_case_intake_writes_private_manifest_and_sanitized_log(tmp_path):
+    from vulca.learning.tiny_dataset import write_tiny_dataset
+    from vulca.learning.user_case_intake import write_user_case_intake
+
+    input_path = tmp_path / "reviewed_user_cases.jsonl"
+    _write_jsonl(input_path, [_reviewed_redraw_case()])
+
+    result = write_user_case_intake(
+        input_path=input_path,
+        output_dir=tmp_path / "intake",
+        source_id="user_session_2026_05",
+    )
+
+    assert result.source_id == "user_session_2026_05"
+    assert result.record_count == 1
+    manifest = json.loads(Path(result.manifest_path).read_text(encoding="utf-8"))
+    assert manifest == {
+        "schema_version": 1,
+        "case_type": "learning_tiny_case_source_manifest",
+        "sources": [
+            {
+                "source_id": "user_session_2026_05",
+                "kind": "user_case_log",
+                "path": "user_session_2026_05.private.user_cases.jsonl",
+                "privacy_scope": "private",
+                "curation_status": "reviewed",
+            }
+        ],
+    }
+
+    records = _read_jsonl(Path(result.output_path))
+    assert records[0]["case_id"] == "redraw_user_001"
+    assert records[0]["review"]["human_accept"] is False
+    assert records[0]["review"]["failure_type"] == "texture_leak"
+    assert records[0]["review"]["preferred_action"] == "adjust_instruction"
+    assert records[0]["observables"] == {
+        "alpha_edge_delta": 0.42,
+        "texture_mismatch_score": 0.78,
+    }
+    assert records[0]["user_case_intake"] == {
+        "schema_version": 1,
+        "source_id": "user_session_2026_05",
+        "privacy_scope": "private",
+        "curation_status": "reviewed",
+        "record_index": 0,
+    }
+
+    serialized = json.dumps(records[0], sort_keys=True)
+    assert "/Users/alice" not in serialized
+    assert "alice@example.com" not in serialized
+    assert "415 555 0134" not in serialized
+    assert "private://local_path/" in serialized
+    assert "<email:redacted>" in serialized
+    assert "<phone:redacted>" in serialized
+
+    dataset_path = tmp_path / "tiny_dataset.jsonl"
+    dataset_result = write_tiny_dataset(
+        repo_root=ROOT,
+        output_path=dataset_path,
+        include_local_seeds=False,
+        case_source_manifest_path=result.manifest_path,
+    )
+    assert dataset_result.example_count == 1
+    example = _read_jsonl(dataset_path)[0]
+    assert example["source"]["source_id"] == "user_session_2026_05"
+    assert example["source"]["privacy_scope"] == "private"
+    assert example["source"]["curation_status"] == "reviewed"
+    assert example["source_case"]["case_id"] == "redraw_user_001"
+
+
+def test_user_case_intake_rejects_unreviewed_cases(tmp_path):
+    from vulca.learning.user_case_intake import write_user_case_intake
+
+    unreviewed = _reviewed_redraw_case()
+    unreviewed["review"] = {"human_accept": False}
+    input_path = tmp_path / "unreviewed.jsonl"
+    _write_jsonl(input_path, [unreviewed])
+
+    with pytest.raises(ValueError, match="reviewed_at is required"):
+        write_user_case_intake(
+            input_path=input_path,
+            output_dir=tmp_path / "intake",
+            source_id="user_session_2026_05",
+        )
+
+
+def test_cases_intake_user_cli_writes_manifest_and_private_log(tmp_path):
+    input_path = tmp_path / "reviewed_user_cases.jsonl"
+    output_dir = tmp_path / "intake"
+    _write_jsonl(input_path, [_reviewed_redraw_case()])
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "vulca.cli",
+            "cases",
+            "intake-user",
+            str(input_path),
+            "--source-id",
+            "cli_user_session",
+            "--output-dir",
+            str(output_dir),
+        ],
+        capture_output=True,
+        text=True,
+        timeout=10,
+        env=CLI_ENV,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "User case log:" in result.stdout
+    assert "Case source manifest:" in result.stdout
+    manifest_path = output_dir / "cli_user_session.case_source_manifest.json"
+    log_path = output_dir / "cli_user_session.private.user_cases.jsonl"
+    assert manifest_path.exists()
+    assert log_path.exists()
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert manifest["sources"][0]["source_id"] == "cli_user_session"
+    assert manifest["sources"][0]["kind"] == "user_case_log"
+    assert manifest["sources"][0]["privacy_scope"] == "private"
+    assert manifest["sources"][0]["curation_status"] == "reviewed"


### PR DESCRIPTION
## Summary
- Add provider-free `vulca cases intake-user` CLI for reviewed private user case JSONL intake.
- Normalize user cases into a manifest-referenceable `user_case_log` with `privacy_scope=private` and `curation_status=reviewed`.
- Add basic anonymization/canonicalization for local paths, emails, phones, obvious secrets, while preserving observable signals and review labels.

## Scope
- No model training.
- No changes to redraw, decompose, or layer_generate runtime paths.

## Validation
- `PYTHONPATH=src python3 -m pytest tests/test_user_case_intake.py tests/test_tiny_dataset_export.py::test_tiny_dataset_case_source_manifest_preserves_source_metadata tests/test_tiny_dataset_export.py::test_cases_export_dataset_cli_accepts_case_source_manifest`
- `python3 -m py_compile src/vulca/learning/user_case_intake.py src/vulca/cli.py tests/test_user_case_intake.py`
- `/opt/homebrew/bin/ruff check src/vulca/learning/user_case_intake.py src/vulca/cli.py tests/test_user_case_intake.py`
- `git diff --check`
