### PR TITLE
[codex] add tiny training eval gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,3 +71,8 @@ jobs:
             -q
       - name: Local seed baseline gate
         run: python scripts/local_seed_baseline_gate.py
+      - name: Tiny training eval gate
+        run: |
+          python scripts/tiny_training_eval_gate.py \
+            --output-dir "$RUNNER_TEMP/tiny-training-eval" \
+            --report "$RUNNER_TEMP/tiny-training-eval/report.json"

--- a/scripts/tiny_training_eval_gate.py
+++ b/scripts/tiny_training_eval_gate.py
@@ -1,0 +1,176 @@
+"""Run the canonical provider-free tiny training/eval gate."""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Sequence
+
+
+ROOT = Path(__file__).resolve().parent.parent
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from vulca.learning.tiny_dataset import DATASET_SPLITS  # noqa: E402
+from vulca.learning.tiny_training_eval import (  # noqa: E402
+    DEFAULT_MANUAL_CURATED_CASE_SOURCE_MANIFEST,
+    DEFAULT_MAX_MISMATCHES,
+    DEFAULT_MIN_ACTION_ACCURACY,
+    DEFAULT_OUTPUT_DIR,
+    format_gate_violation,
+    parse_policy_float_thresholds,
+    parse_policy_int_thresholds,
+    run_tiny_training_eval_gate,
+)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Export the tiny dataset, run provider-free tiny_agent_v0 and "
+            "tiny_action_model_v1 predictions, compare policies, and enforce "
+            "the tiny training/eval quality gate."
+        )
+    )
+    parser.add_argument(
+        "--repo-root",
+        default=str(ROOT),
+        help="Repository root (default: this script's repository).",
+    )
+    parser.add_argument(
+        "--output-dir",
+        default=str(DEFAULT_OUTPUT_DIR),
+        help="Directory for generated dataset, predictions, and comparison JSON.",
+    )
+    parser.add_argument(
+        "--report",
+        default="",
+        help="Stable JSON gate report path (default: OUTPUT_DIR/tiny_training_eval_report.json).",
+    )
+    parser.add_argument(
+        "--manifest",
+        default="",
+        help="Seed manifest path (default: docs/benchmarks/learning/local_seed_manifest.json).",
+    )
+    parser.add_argument(
+        "--case-log",
+        action="append",
+        default=[],
+        help="Additional reviewed case JSONL path; repeat to include multiple logs.",
+    )
+    parser.add_argument(
+        "--case-source-manifest",
+        default=str(DEFAULT_MANUAL_CURATED_CASE_SOURCE_MANIFEST),
+        help=(
+            "Reviewed case source manifest to include. Defaults to the manual "
+            "curated v1 manifest."
+        ),
+    )
+    parser.add_argument(
+        "--no-case-source-manifest",
+        action="store_true",
+        help="Do not include the default manual curated case source manifest.",
+    )
+    parser.add_argument(
+        "--no-local-seeds",
+        action="store_true",
+        help="Only export records from --case-log/--case-source-manifest inputs.",
+    )
+    parser.add_argument(
+        "--split",
+        default="test",
+        choices=DATASET_SPLITS,
+        help="Dataset split to predict and compare.",
+    )
+    parser.add_argument(
+        "--train-split",
+        default="train",
+        choices=DATASET_SPLITS,
+        help="Dataset split used to fit train-derived policies.",
+    )
+    parser.add_argument(
+        "--min-action-accuracy",
+        action="append",
+        default=[],
+        metavar="POLICY=VALUE",
+        help=(
+            "Fail if a policy action_accuracy is below VALUE. "
+            f"Default: {dict(DEFAULT_MIN_ACTION_ACCURACY)}."
+        ),
+    )
+    parser.add_argument(
+        "--max-mismatches",
+        action="append",
+        default=[],
+        metavar="POLICY=COUNT",
+        help=(
+            "Fail if a policy has more than COUNT mismatches. "
+            f"Default: {dict(DEFAULT_MAX_MISMATCHES)}."
+        ),
+    )
+    parser.add_argument(
+        "--allow-missing-predictions",
+        action="store_true",
+        help="Do not fail when prediction JSONL files omit examples from the eval split.",
+    )
+    parser.add_argument(
+        "--pretty",
+        action="store_true",
+        help="Print the full JSON report to stdout after writing it.",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        min_thresholds = parse_policy_float_thresholds(args.min_action_accuracy)
+        max_thresholds = parse_policy_int_thresholds(args.max_mismatches)
+        report = run_tiny_training_eval_gate(
+            repo_root=args.repo_root,
+            output_dir=args.output_dir,
+            report_path=args.report or None,
+            manifest_path=args.manifest or None,
+            case_log_paths=args.case_log,
+            case_source_manifest_path=(
+                None if args.no_case_source_manifest else args.case_source_manifest
+            ),
+            include_local_seeds=not args.no_local_seeds,
+            eval_split=args.split,
+            train_split=args.train_split,
+            min_action_accuracy=min_thresholds,
+            max_mismatches=max_thresholds,
+            require_no_missing_predictions=not args.allow_missing_predictions,
+        )
+    except (ValueError, FileNotFoundError, json.JSONDecodeError) as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 2
+
+    if args.pretty:
+        print(json.dumps(report, indent=2, sort_keys=True))
+
+    print(f"Tiny training/eval report: {report['artifacts']['report_path']}")
+    print(f"Tiny dataset: {report['artifacts']['dataset_path']}")
+    print(
+        "tiny_agent_v0 predictions: "
+        f"{report['predictions']['tiny_agent_v0']['prediction_count']}"
+    )
+    print(
+        "tiny_action_model_v1 predictions: "
+        f"{report['predictions']['tiny_action_model_v1']['prediction_count']}"
+    )
+    for policy in sorted(report["comparison"]["policy_reports"]):
+        policy_report = report["comparison"]["policy_reports"][policy]
+        print(f"{policy} action_accuracy: {policy_report['action_accuracy']}")
+
+    if not report["gate"]["passed"]:
+        print("Tiny training/eval gate failed:", file=sys.stderr)
+        for violation in report["gate"]["violations"]:
+            print(f"  {format_gate_violation(violation)}", file=sys.stderr)
+        return 1
+
+    print("Tiny training/eval gate passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/vulca/learning/tiny_training_eval.py
+++ b/src/vulca/learning/tiny_training_eval.py
@@ -1,0 +1,307 @@
+"""Canonical provider-free tiny training/eval gate."""
+from __future__ import annotations
+
+import json
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+from vulca.learning.seed_cases import DEFAULT_SEED_MANIFEST
+from vulca.learning.tiny_action_model import (
+    POLICY_TINY_ACTION_MODEL,
+    write_tiny_action_model_predictions,
+)
+from vulca.learning.tiny_baseline_model import (
+    POLICY_TINY_AGENT,
+    write_tiny_baseline_predictions,
+)
+from vulca.learning.tiny_dataset import (
+    DATASET_SPLITS,
+    build_tiny_dataset_comparison_report,
+    load_tiny_dataset_examples,
+    write_tiny_dataset,
+)
+
+
+SCHEMA_VERSION = 1
+REPORT_CASE_TYPE = "learning_tiny_training_eval_gate_report"
+DEFAULT_OUTPUT_DIR = Path("build/tiny_training_eval_gate")
+DEFAULT_MANUAL_CURATED_CASE_SOURCE_MANIFEST = Path(
+    "docs/benchmarks/learning/manual_curated_case_source_manifest_v1.json"
+)
+DEFAULT_MIN_ACTION_ACCURACY: Mapping[str, float] = {
+    POLICY_TINY_ACTION_MODEL: 1.0,
+}
+DEFAULT_MAX_MISMATCHES: Mapping[str, int] = {
+    POLICY_TINY_ACTION_MODEL: 0,
+}
+
+
+def run_tiny_training_eval_gate(
+    *,
+    repo_root: str | Path,
+    output_dir: str | Path = DEFAULT_OUTPUT_DIR,
+    report_path: str | Path | None = None,
+    manifest_path: str | Path | None = DEFAULT_SEED_MANIFEST,
+    case_log_paths: Sequence[str | Path] = (),
+    case_source_manifest_path: str | Path | None = DEFAULT_MANUAL_CURATED_CASE_SOURCE_MANIFEST,
+    include_local_seeds: bool = True,
+    eval_split: str = "test",
+    train_split: str = "train",
+    min_action_accuracy: Mapping[str, float] | None = None,
+    max_mismatches: Mapping[str, int] | None = None,
+    require_no_missing_predictions: bool = True,
+) -> dict[str, Any]:
+    """Export the tiny dataset, run fixed predictors, compare them, and gate."""
+    _validate_split(eval_split, label="eval_split")
+    _validate_split(train_split, label="train_split")
+
+    root = Path(repo_root)
+    output = Path(output_dir)
+    output.mkdir(parents=True, exist_ok=True)
+    dataset_path = output / "tiny_dataset.jsonl"
+    tiny_agent_path = output / "tiny_agent_v0.predictions.jsonl"
+    tiny_action_model_path = output / "tiny_action_model_v1.predictions.jsonl"
+    comparison_report_path = output / "tiny_dataset_comparison.json"
+    resolved_report_path = Path(report_path) if report_path else output / "tiny_training_eval_report.json"
+    resolved_manifest_path = manifest_path or DEFAULT_SEED_MANIFEST
+
+    resolved_case_source_manifest = _resolve_optional_repo_path(
+        root,
+        case_source_manifest_path,
+    )
+    dataset_result = write_tiny_dataset(
+        repo_root=root,
+        output_path=dataset_path,
+        manifest_path=resolved_manifest_path,
+        case_log_paths=case_log_paths,
+        case_source_manifest_path=resolved_case_source_manifest,
+        include_local_seeds=include_local_seeds,
+    )
+    tiny_agent_result = write_tiny_baseline_predictions(
+        dataset_path=dataset_path,
+        output_path=tiny_agent_path,
+        policy_name=POLICY_TINY_AGENT,
+        split=eval_split,
+        train_split=train_split,
+    )
+    tiny_action_model_result = write_tiny_action_model_predictions(
+        dataset_path=dataset_path,
+        output_path=tiny_action_model_path,
+        split=eval_split,
+        train_split=train_split,
+    )
+    comparison_report = build_tiny_dataset_comparison_report(
+        load_tiny_dataset_examples(dataset_path),
+        train_split=train_split,
+        eval_split=eval_split,
+        prediction_paths=(tiny_agent_path, tiny_action_model_path),
+    )
+    comparison_report_path.write_text(
+        json.dumps(comparison_report, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+    min_thresholds = dict(DEFAULT_MIN_ACTION_ACCURACY)
+    min_thresholds.update(min_action_accuracy or {})
+    max_thresholds = dict(DEFAULT_MAX_MISMATCHES)
+    max_thresholds.update(max_mismatches or {})
+    gate = build_tiny_training_eval_gate_result(
+        comparison_report,
+        min_action_accuracy=min_thresholds,
+        max_mismatches=max_thresholds,
+        require_no_missing_predictions=require_no_missing_predictions,
+    )
+
+    report = {
+        "schema_version": SCHEMA_VERSION,
+        "case_type": REPORT_CASE_TYPE,
+        "train_split": train_split,
+        "eval_split": eval_split,
+        "inputs": {
+            "repo_root": str(root),
+            "source_manifest": str(resolved_manifest_path),
+            "case_log_paths": [str(path) for path in case_log_paths],
+            "case_source_manifest_path": str(resolved_case_source_manifest or ""),
+            "include_local_seeds": bool(include_local_seeds),
+        },
+        "artifacts": {
+            "dataset_path": str(dataset_path),
+            "dataset_index_path": dataset_result.index_path,
+            "tiny_agent_v0_prediction_path": str(tiny_agent_path),
+            "tiny_action_model_v1_prediction_path": str(tiny_action_model_path),
+            "comparison_report_path": str(comparison_report_path),
+            "report_path": str(resolved_report_path),
+        },
+        "dataset": asdict(dataset_result),
+        "predictions": {
+            POLICY_TINY_AGENT: asdict(tiny_agent_result),
+            POLICY_TINY_ACTION_MODEL: asdict(tiny_action_model_result),
+        },
+        "comparison": comparison_report,
+        "gate": gate,
+    }
+    resolved_report_path.parent.mkdir(parents=True, exist_ok=True)
+    resolved_report_path.write_text(
+        json.dumps(report, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return report
+
+
+def build_tiny_training_eval_gate_result(
+    comparison_report: Mapping[str, Any],
+    *,
+    min_action_accuracy: Mapping[str, float],
+    max_mismatches: Mapping[str, int],
+    require_no_missing_predictions: bool = True,
+) -> dict[str, Any]:
+    policy_reports = _mapping(comparison_report.get("policy_reports"))
+    violations: list[dict[str, Any]] = []
+
+    for policy, threshold in sorted(min_action_accuracy.items()):
+        metrics = _mapping(policy_reports.get(policy))
+        actual = metrics.get("action_accuracy")
+        if actual is None or float(actual) < float(threshold):
+            violations.append(
+                {
+                    "policy": str(policy),
+                    "metric": "action_accuracy",
+                    "actual": actual,
+                    "expected": f">= {_format_number(float(threshold))}",
+                }
+            )
+
+    for policy, threshold in sorted(max_mismatches.items()):
+        metrics = _mapping(policy_reports.get(policy))
+        actual = metrics.get("mismatch_count")
+        if actual is None or int(actual) > int(threshold):
+            violations.append(
+                {
+                    "policy": str(policy),
+                    "metric": "mismatch_count",
+                    "actual": actual,
+                    "expected": f"<= {int(threshold)}",
+                }
+            )
+
+    if require_no_missing_predictions:
+        for policy, metrics_value in sorted(policy_reports.items()):
+            metrics = _mapping(metrics_value)
+            if "missing_count" not in metrics:
+                continue
+            actual = int(metrics.get("missing_count") or 0)
+            if actual > 0:
+                violations.append(
+                    {
+                        "policy": str(policy),
+                        "metric": "missing_count",
+                        "actual": actual,
+                        "expected": "== 0",
+                    }
+                )
+
+    return {
+        "passed": not violations,
+        "thresholds": {
+            "min_action_accuracy": {
+                policy: float(value)
+                for policy, value in sorted(min_action_accuracy.items())
+            },
+            "max_mismatches": {
+                policy: int(value) for policy, value in sorted(max_mismatches.items())
+            },
+            "require_no_missing_predictions": bool(require_no_missing_predictions),
+        },
+        "violations": violations,
+    }
+
+
+def parse_policy_float_thresholds(values: Sequence[str]) -> dict[str, float]:
+    thresholds: dict[str, float] = {}
+    for raw in values:
+        policy, value = _split_policy_threshold(raw)
+        try:
+            thresholds[policy] = float(value)
+        except ValueError as exc:
+            raise ValueError(
+                f"invalid threshold value {value!r} for policy {policy!r}"
+            ) from exc
+    return thresholds
+
+
+def parse_policy_int_thresholds(values: Sequence[str]) -> dict[str, int]:
+    thresholds: dict[str, int] = {}
+    for raw in values:
+        policy, value = _split_policy_threshold(raw)
+        try:
+            number = float(value)
+        except ValueError as exc:
+            raise ValueError(
+                f"invalid threshold value {value!r} for policy {policy!r}"
+            ) from exc
+        count = int(number)
+        if count != number:
+            raise ValueError(
+                f"integer threshold required for policy {policy!r}: {value!r}"
+            )
+        thresholds[policy] = count
+    return thresholds
+
+
+def format_gate_violation(violation: Mapping[str, Any]) -> str:
+    policy = str(violation.get("policy") or "")
+    metric = str(violation.get("metric") or "")
+    actual = violation.get("actual")
+    expected = str(violation.get("expected") or "")
+    if metric == "action_accuracy":
+        threshold = expected.replace(">= ", "")
+        return f"{policy} action_accuracy {actual} < {threshold}"
+    if metric == "mismatch_count":
+        threshold = expected.replace("<= ", "")
+        return f"{policy} mismatch_count {actual} > {threshold}"
+    if metric == "missing_count":
+        return f"{policy} missing_count {actual} > 0"
+    return f"{policy} {metric} {actual} violates {expected}"
+
+
+def _split_policy_threshold(raw: str) -> tuple[str, str]:
+    if "=" not in raw:
+        raise ValueError(f"invalid tiny gate threshold {raw!r}; expected POLICY=VALUE")
+    policy, value = raw.split("=", 1)
+    policy = policy.strip()
+    value = value.strip()
+    if not policy:
+        raise ValueError(f"invalid tiny gate threshold {raw!r}; policy is required")
+    if not value:
+        raise ValueError(f"invalid tiny gate threshold {raw!r}; value is required")
+    return policy, value
+
+
+def _resolve_optional_repo_path(
+    repo_root: Path,
+    path: str | Path | None,
+) -> Path | None:
+    if not path:
+        return None
+    resolved = Path(path)
+    if not resolved.is_absolute():
+        resolved = repo_root / resolved
+    return resolved
+
+
+def _validate_split(value: str, *, label: str) -> None:
+    if value not in DATASET_SPLITS:
+        raise ValueError(f"unsupported {label} {value!r}; expected one of {DATASET_SPLITS}")
+
+
+def _format_number(value: float) -> str:
+    if value.is_integer():
+        return f"{value:.1f}"
+    return str(value)
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    if isinstance(value, Mapping):
+        return value
+    return {}

--- a/tests/test_tiny_training_eval_gate.py
+++ b/tests/test_tiny_training_eval_gate.py
@@ -1,0 +1,109 @@
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+CLI_ENV = dict(
+    os.environ,
+    PYTHONPATH=str(ROOT / "src") + os.pathsep + os.environ.get("PYTHONPATH", ""),
+)
+GATE_SCRIPT = ROOT / "scripts" / "tiny_training_eval_gate.py"
+
+
+def _run_gate(tmp_path, *extra_args):
+    output_dir = tmp_path / "tiny_training_eval"
+    report_path = tmp_path / "tiny_training_eval_report.json"
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(GATE_SCRIPT),
+            "--repo-root",
+            str(ROOT),
+            "--output-dir",
+            str(output_dir),
+            "--report",
+            str(report_path),
+            *extra_args,
+        ],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        env=CLI_ENV,
+        cwd=ROOT,
+    )
+    return result, output_dir, report_path
+
+
+def test_tiny_training_eval_gate_command_writes_dataset_predictions_and_report(tmp_path):
+    result, output_dir, report_path = _run_gate(tmp_path)
+
+    assert result.returncode == 0, result.stderr
+    assert (output_dir / "tiny_dataset.jsonl").exists()
+    assert (output_dir / "tiny_agent_v0.predictions.jsonl").exists()
+    assert (output_dir / "tiny_action_model_v1.predictions.jsonl").exists()
+    assert (output_dir / "tiny_dataset_comparison.json").exists()
+    assert report_path.exists()
+
+    report = json.loads(report_path.read_text(encoding="utf-8"))
+    assert report["case_type"] == "learning_tiny_training_eval_gate_report"
+    assert report["gate"]["passed"] is True
+    assert report["artifacts"]["dataset_path"] == str(output_dir / "tiny_dataset.jsonl")
+    assert report["artifacts"]["comparison_report_path"] == str(
+        output_dir / "tiny_dataset_comparison.json"
+    )
+    assert report["dataset"]["example_count"] == 20
+    assert report["dataset"]["counts_by_split"]["test"] == 5
+
+
+def test_tiny_training_eval_gate_report_includes_required_policies(tmp_path):
+    result, _, report_path = _run_gate(tmp_path)
+
+    assert result.returncode == 0, result.stderr
+    report = json.loads(report_path.read_text(encoding="utf-8"))
+    policy_reports = report["comparison"]["policy_reports"]
+    assert set(policy_reports) >= {
+        "majority_action",
+        "redraw_observable_signal",
+        "tiny_agent_v0",
+        "tiny_action_model_v1",
+    }
+
+
+def test_tiny_training_eval_gate_fails_below_action_accuracy_threshold(tmp_path):
+    result, _, report_path = _run_gate(
+        tmp_path,
+        "--min-action-accuracy",
+        "tiny_action_model_v1=1.01",
+    )
+
+    assert result.returncode == 1
+    assert "Tiny training/eval gate failed" in result.stderr
+    assert "tiny_action_model_v1 action_accuracy 1.0 < 1.01" in result.stderr
+    report = json.loads(report_path.read_text(encoding="utf-8"))
+    assert report["gate"]["passed"] is False
+    assert report["gate"]["violations"] == [
+        {
+            "policy": "tiny_action_model_v1",
+            "metric": "action_accuracy",
+            "actual": 1.0,
+            "expected": ">= 1.01",
+        }
+    ]
+
+
+def test_tiny_training_eval_gate_passes_for_current_seeds_and_manual_curated_cases(tmp_path):
+    result, _, report_path = _run_gate(tmp_path)
+
+    assert result.returncode == 0, result.stderr
+    report = json.loads(report_path.read_text(encoding="utf-8"))
+    policy_reports = report["comparison"]["policy_reports"]
+    assert policy_reports["tiny_action_model_v1"]["missing_count"] == 0
+    assert policy_reports["tiny_action_model_v1"]["mismatch_count"] == 0
+    assert policy_reports["tiny_action_model_v1"]["action_accuracy"] == 1.0
+    assert (
+        policy_reports["tiny_action_model_v1"]["action_accuracy"]
+        >= policy_reports["tiny_agent_v0"]["action_accuracy"]
+    )


### PR DESCRIPTION
## Summary
- Add a provider-free tiny training/eval gate that exports local seeds plus the manual curated manifest by default.
- Generate `tiny_agent_v0` and `tiny_action_model_v1` prediction JSONL files, write a comparison report, and emit a stable gate report.
- Add a CI step to run the canonical tiny training/eval gate.

## Test Plan
- `/opt/homebrew/bin/python3 -m pytest tests/test_tiny_training_eval_gate.py tests/test_tiny_action_model.py tests/test_tiny_baseline_predict.py tests/test_tiny_dataset_export.py -q`
- `/opt/homebrew/bin/python3 -m py_compile src/vulca/learning/tiny_training_eval.py scripts/tiny_training_eval_gate.py tests/test_tiny_training_eval_gate.py`
- `ruff check src/ tests/ scripts/tiny_training_eval_gate.py`
- `git diff --check`
- `/opt/homebrew/bin/python3 scripts/tiny_training_eval_gate.py --output-dir build/tiny-training-eval-smoke --report build/tiny-training-eval-smoke/report.json`