### PR TITLE
feat(learning): add training effectiveness report

### DIFF
--- a/scripts/training_effectiveness_report.py
+++ b/scripts/training_effectiveness_report.py
@@ -1,0 +1,148 @@
+"""Write the combined tiny training effectiveness report."""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Sequence
+
+
+ROOT = Path(__file__).resolve().parent.parent
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from vulca.learning.tiny_dataset import DATASET_SPLITS  # noqa: E402
+from vulca.learning.training_effectiveness import (  # noqa: E402
+    DEFAULT_COMBINED_CASE_SOURCE_MANIFEST,
+    DEFAULT_OUTPUT_DIR,
+    format_data_gap,
+    run_training_effectiveness_report,
+)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Run the combined tiny learning eval and write a training "
+            "effectiveness report with policy deltas and data coverage gaps."
+        )
+    )
+    parser.add_argument(
+        "--repo-root",
+        default=str(ROOT),
+        help="Repository root (default: this script's repository).",
+    )
+    parser.add_argument(
+        "--output-dir",
+        default=str(DEFAULT_OUTPUT_DIR),
+        help="Directory for generated aggregate artifacts.",
+    )
+    parser.add_argument(
+        "--report",
+        default="",
+        help="Stable JSON report path (default: OUTPUT_DIR/training_effectiveness_report.json).",
+    )
+    parser.add_argument(
+        "--case-source-manifest",
+        default=str(DEFAULT_COMBINED_CASE_SOURCE_MANIFEST),
+        help="Combined reviewed case source manifest.",
+    )
+    parser.add_argument(
+        "--no-local-seeds",
+        action="store_true",
+        help="Only export records from the case source manifest.",
+    )
+    parser.add_argument(
+        "--split",
+        default="test",
+        choices=DATASET_SPLITS,
+        help="Dataset split to predict and compare.",
+    )
+    parser.add_argument(
+        "--train-split",
+        default="train",
+        choices=DATASET_SPLITS,
+        help="Dataset split used to fit train-derived policies.",
+    )
+    parser.add_argument(
+        "--min-eval-examples-per-bucket",
+        type=int,
+        default=1,
+        help="Minimum eval examples required before a bucket is no longer reported as a data gap.",
+    )
+    parser.add_argument(
+        "--fail-on-data-gaps",
+        action="store_true",
+        help="Return non-zero when coverage gaps remain.",
+    )
+    parser.add_argument(
+        "--pretty",
+        action="store_true",
+        help="Print the full JSON report to stdout after writing it.",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        report = run_training_effectiveness_report(
+            repo_root=args.repo_root,
+            output_dir=args.output_dir,
+            report_path=args.report or None,
+            case_source_manifest_path=args.case_source_manifest,
+            include_local_seeds=not args.no_local_seeds,
+            eval_split=args.split,
+            train_split=args.train_split,
+            min_eval_examples_per_bucket=args.min_eval_examples_per_bucket,
+        )
+    except (ValueError, FileNotFoundError, json.JSONDecodeError) as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 2
+
+    if args.pretty:
+        print(json.dumps(report, indent=2, sort_keys=True))
+
+    dataset = report["dataset"]
+    effectiveness = report["effectiveness"]
+    print(f"Training effectiveness report: {report['artifacts']['report_path']}")
+    print(f"Aggregated eval report: {report['artifacts']['aggregated_report_path']}")
+    print(f"Dataset examples: {dataset['example_count']}")
+    print(f"Eval examples: {dataset['eval_example_count']}")
+    print(
+        f"{effectiveness['evaluated_policy']} action_accuracy: "
+        f"{effectiveness['action_accuracy']}"
+    )
+    print(
+        f"{effectiveness['baseline_policy']} action_accuracy: "
+        f"{effectiveness['baseline_action_accuracy']}"
+    )
+    print(
+        "Accuracy delta vs baseline: "
+        f"{effectiveness['accuracy_delta_vs_baseline']}"
+    )
+    print(f"Tiny gate passed: {effectiveness['gate_passed']}")
+    print(f"Data gaps: {len(report['data_gaps'])}")
+    for gap in report["data_gaps"][:10]:
+        print(
+            f"  {gap['bucket']} {gap['value']}: "
+            f"eval {gap['eval_example_count']}/{gap['example_count']}"
+        )
+
+    if not effectiveness["gate_passed"]:
+        print("Training effectiveness gate failed:", file=sys.stderr)
+        for violation in effectiveness["gate"].get("violations", []) or []:
+            print(f"  {violation}", file=sys.stderr)
+        return 1
+
+    if args.fail_on_data_gaps and report["data_gaps"]:
+        print("Training effectiveness data coverage gaps:", file=sys.stderr)
+        for gap in report["data_gaps"]:
+            print(f"  {format_data_gap(gap)}", file=sys.stderr)
+        return 1
+
+    print(f"Training effectiveness status: {report['status']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/vulca/learning/training_effectiveness.py
+++ b/src/vulca/learning/training_effectiveness.py
@@ -1,0 +1,268 @@
+"""Training effectiveness report for combined tiny learning sources."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+from vulca.learning.aggregated_case_source_eval import run_aggregated_case_source_eval
+from vulca.learning.tiny_action_model import POLICY_TINY_ACTION_MODEL
+from vulca.learning.tiny_baseline_model import POLICY_TINY_AGENT
+from vulca.learning.tiny_dataset import DATASET_SPLITS
+
+
+SCHEMA_VERSION = 1
+REPORT_CASE_TYPE = "learning_training_effectiveness_report"
+DEFAULT_OUTPUT_DIR = Path("build/training_effectiveness_report")
+DEFAULT_REPORT_NAME = "training_effectiveness_report.json"
+DEFAULT_COMBINED_CASE_SOURCE_MANIFEST = Path(
+    "docs/benchmarks/learning/combined_case_source_manifest_v1.json"
+)
+DEFAULT_EVALUATED_POLICY = POLICY_TINY_ACTION_MODEL
+DEFAULT_BASELINE_POLICY = POLICY_TINY_AGENT
+DEFAULT_COVERAGE_BUCKETS: tuple[str, ...] = (
+    "source.kind",
+    "source_case.case_type",
+    "targets.failure_type",
+)
+
+
+def run_training_effectiveness_report(
+    *,
+    repo_root: str | Path,
+    output_dir: str | Path = DEFAULT_OUTPUT_DIR,
+    report_path: str | Path | None = None,
+    case_source_manifest_path: str | Path = DEFAULT_COMBINED_CASE_SOURCE_MANIFEST,
+    include_local_seeds: bool = True,
+    eval_split: str = "test",
+    train_split: str = "train",
+    min_eval_examples_per_bucket: int = 1,
+) -> dict[str, Any]:
+    """Run combined tiny eval and summarize model effectiveness plus data gaps."""
+    _validate_split(eval_split, label="eval_split")
+    _validate_split(train_split, label="train_split")
+    if min_eval_examples_per_bucket < 0:
+        raise ValueError("min_eval_examples_per_bucket must be >= 0")
+
+    root = Path(repo_root).resolve()
+    output = Path(output_dir)
+    output.mkdir(parents=True, exist_ok=True)
+    resolved_report_path = Path(report_path) if report_path else output / DEFAULT_REPORT_NAME
+    resolved_manifest_path = _resolve_repo_path(root, case_source_manifest_path)
+    aggregated_output_dir = output / "aggregated"
+    aggregated_report = run_aggregated_case_source_eval(
+        repo_root=root,
+        output_dir=aggregated_output_dir,
+        case_source_manifest_paths=[resolved_manifest_path],
+        include_default_case_source_manifest=False,
+        include_local_seeds=include_local_seeds,
+        eval_split=eval_split,
+        train_split=train_split,
+    )
+    data_gaps = _build_data_gaps(
+        aggregated_report,
+        min_eval_examples=min_eval_examples_per_bucket,
+    )
+    effectiveness = _build_effectiveness_summary(aggregated_report)
+    gate_passed = bool(effectiveness["gate_passed"])
+    if not gate_passed:
+        status = "failed_gate"
+    elif data_gaps:
+        status = "passed_with_data_gaps"
+    else:
+        status = "passed"
+
+    dataset_summary = _mapping(aggregated_report.get("dataset_summary"))
+    counts_by_split = _mapping(dataset_summary.get("counts_by_split"))
+    report = {
+        "schema_version": SCHEMA_VERSION,
+        "case_type": REPORT_CASE_TYPE,
+        "status": status,
+        "train_split": train_split,
+        "eval_split": eval_split,
+        "inputs": {
+            "repo_root": str(root),
+            "case_source_manifest_path": str(resolved_manifest_path),
+            "include_local_seeds": bool(include_local_seeds),
+            "min_eval_examples_per_bucket": int(min_eval_examples_per_bucket),
+        },
+        "artifacts": {
+            "report_path": str(resolved_report_path),
+            "aggregated_report_path": aggregated_report["artifacts"]["report_path"],
+            "tiny_training_eval_report_path": aggregated_report["artifacts"][
+                "tiny_training_eval_report_path"
+            ],
+            "dataset_path": aggregated_report["artifacts"]["dataset_path"],
+            "dataset_index_path": aggregated_report["artifacts"]["dataset_index_path"],
+            "comparison_report_path": aggregated_report["artifacts"][
+                "comparison_report_path"
+            ],
+        },
+        "dataset": {
+            "example_count": int(dataset_summary.get("example_count") or 0),
+            "eval_example_count": int(counts_by_split.get(eval_split) or 0),
+            "counts_by_split": dict(counts_by_split),
+            "counts_by_source_kind": dict(
+                _mapping(dataset_summary.get("counts_by_source_kind"))
+            ),
+            "counts_by_source_case_type": dict(
+                _mapping(dataset_summary.get("counts_by_source_case_type"))
+            ),
+            "target_counts": dict(_mapping(dataset_summary.get("target_counts"))),
+        },
+        "coverage": _build_coverage_summary(aggregated_report),
+        "effectiveness": effectiveness,
+        "data_gaps": data_gaps,
+    }
+
+    resolved_report_path.parent.mkdir(parents=True, exist_ok=True)
+    resolved_report_path.write_text(
+        json.dumps(report, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return report
+
+
+def format_data_gap(gap: Mapping[str, Any]) -> str:
+    bucket = str(gap.get("bucket") or "")
+    value = str(gap.get("value") or "")
+    eval_count = int(gap.get("eval_example_count") or 0)
+    minimum = int(gap.get("min_eval_examples") or 0)
+    return f"{bucket} {value} eval {eval_count} < {minimum}"
+
+
+def _build_effectiveness_summary(aggregated_report: Mapping[str, Any]) -> dict[str, Any]:
+    policy_reports = _mapping(
+        _mapping(aggregated_report.get("policy_comparison")).get("policy_reports")
+    )
+    evaluated = _mapping(policy_reports.get(DEFAULT_EVALUATED_POLICY))
+    baseline = _mapping(policy_reports.get(DEFAULT_BASELINE_POLICY))
+    action_accuracy = _float_or_none(evaluated.get("action_accuracy"))
+    baseline_accuracy = _float_or_none(baseline.get("action_accuracy"))
+    accuracy_delta = None
+    if action_accuracy is not None and baseline_accuracy is not None:
+        accuracy_delta = action_accuracy - baseline_accuracy
+
+    gate = _mapping(_mapping(aggregated_report.get("tiny_training_eval")).get("gate"))
+    return {
+        "gate_passed": bool(gate.get("passed")),
+        "evaluated_policy": DEFAULT_EVALUATED_POLICY,
+        "baseline_policy": DEFAULT_BASELINE_POLICY,
+        "action_accuracy": action_accuracy,
+        "baseline_action_accuracy": baseline_accuracy,
+        "accuracy_delta_vs_baseline": accuracy_delta,
+        "mismatch_count": int(evaluated.get("mismatch_count") or 0),
+        "missing_count": int(evaluated.get("missing_count") or 0),
+        "gate": dict(gate),
+        "policy_ranking": _policy_ranking(policy_reports),
+    }
+
+
+def _policy_ranking(policy_reports: Mapping[str, Any]) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for policy_name, report_value in policy_reports.items():
+        report = _mapping(report_value)
+        rows.append(
+            {
+                "policy_name": str(policy_name),
+                "action_accuracy": _float_or_none(report.get("action_accuracy")),
+                "mismatch_count": int(report.get("mismatch_count") or 0),
+                "missing_count": int(report.get("missing_count") or 0),
+            }
+        )
+    return sorted(
+        rows,
+        key=lambda item: (
+            item["action_accuracy"] is None,
+            -(item["action_accuracy"] or 0.0),
+            item["mismatch_count"],
+            item["policy_name"],
+        ),
+    )
+
+
+def _build_coverage_summary(aggregated_report: Mapping[str, Any]) -> dict[str, Any]:
+    bucket_metrics = _mapping(aggregated_report.get("bucket_metrics"))
+    return {
+        "source_kind": _compact_bucket_counts(bucket_metrics, "source.kind"),
+        "source_case_type": _compact_bucket_counts(bucket_metrics, "source_case.case_type"),
+        "failure_type": _compact_bucket_counts(bucket_metrics, "targets.failure_type"),
+    }
+
+
+def _compact_bucket_counts(
+    bucket_metrics: Mapping[str, Any],
+    bucket: str,
+) -> dict[str, dict[str, int]]:
+    rows: dict[str, dict[str, int]] = {}
+    for value, metrics_value in _mapping(bucket_metrics.get(bucket)).items():
+        metrics = _mapping(metrics_value)
+        rows[str(value)] = {
+            "example_count": int(metrics.get("example_count") or 0),
+            "eval_example_count": int(metrics.get("eval_example_count") or 0),
+        }
+    return dict(sorted(rows.items()))
+
+
+def _build_data_gaps(
+    aggregated_report: Mapping[str, Any],
+    *,
+    min_eval_examples: int,
+) -> list[dict[str, Any]]:
+    if min_eval_examples <= 0:
+        return []
+
+    gaps: list[dict[str, Any]] = []
+    bucket_metrics = _mapping(aggregated_report.get("bucket_metrics"))
+    for bucket in DEFAULT_COVERAGE_BUCKETS:
+        for value, metrics_value in _mapping(bucket_metrics.get(bucket)).items():
+            if bucket == "targets.failure_type" and value == "unlabeled":
+                continue
+            metrics = _mapping(metrics_value)
+            example_count = int(metrics.get("example_count") or 0)
+            eval_count = int(metrics.get("eval_example_count") or 0)
+            if example_count <= 0 or eval_count >= min_eval_examples:
+                continue
+            gaps.append(
+                {
+                    "bucket": bucket,
+                    "value": str(value),
+                    "example_count": example_count,
+                    "eval_example_count": eval_count,
+                    "min_eval_examples": int(min_eval_examples),
+                    "reason": "insufficient_eval_coverage",
+                }
+            )
+    return sorted(
+        gaps,
+        key=lambda item: (
+            item["bucket"],
+            item["eval_example_count"],
+            -item["example_count"],
+            item["value"],
+        ),
+    )
+
+
+def _resolve_repo_path(repo_root: Path, path: str | Path) -> Path:
+    resolved = Path(path)
+    if not resolved.is_absolute():
+        resolved = repo_root / resolved
+    return resolved
+
+
+def _validate_split(value: str, *, label: str) -> None:
+    if value not in DATASET_SPLITS:
+        raise ValueError(f"unsupported {label} {value!r}; expected one of {DATASET_SPLITS}")
+
+
+def _float_or_none(value: Any) -> float | None:
+    if value is None:
+        return None
+    return float(value)
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    if isinstance(value, Mapping):
+        return value
+    return {}

--- a/tests/test_training_effectiveness_report.py
+++ b/tests/test_training_effectiveness_report.py
@@ -1,0 +1,118 @@
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+CLI_ENV = dict(
+    os.environ,
+    PYTHONPATH=str(ROOT / "src") + os.pathsep + os.environ.get("PYTHONPATH", ""),
+)
+REPORT_SCRIPT = ROOT / "scripts" / "training_effectiveness_report.py"
+
+
+def _run_report(tmp_path, *extra_args):
+    output_dir = tmp_path / "training_effectiveness"
+    report_path = tmp_path / "training_effectiveness_report.json"
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(REPORT_SCRIPT),
+            "--repo-root",
+            str(ROOT),
+            "--output-dir",
+            str(output_dir),
+            "--report",
+            str(report_path),
+            *extra_args,
+        ],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        env=CLI_ENV,
+        cwd=ROOT,
+    )
+    return result, output_dir, report_path
+
+
+def test_training_effectiveness_report_uses_combined_real_manual_and_seed_data(tmp_path):
+    from vulca.learning.training_effectiveness import run_training_effectiveness_report
+
+    report = run_training_effectiveness_report(
+        repo_root=ROOT,
+        output_dir=tmp_path / "effectiveness",
+        report_path=tmp_path / "training_effectiveness_report.json",
+    )
+
+    assert report["case_type"] == "learning_training_effectiveness_report"
+    assert report["status"] == "passed_with_data_gaps"
+    assert report["dataset"]["example_count"] == 25
+    assert report["dataset"]["eval_example_count"] == 6
+    assert report["dataset"]["counts_by_source_kind"] == {
+        "local_seed": 12,
+        "manual_case_log": 8,
+        "user_case_log": 5,
+    }
+    assert report["effectiveness"]["gate_passed"] is True
+    assert report["effectiveness"]["evaluated_policy"] == "tiny_action_model_v1"
+    assert report["effectiveness"]["baseline_policy"] == "tiny_agent_v0"
+    assert report["effectiveness"]["action_accuracy"] == 1.0
+    assert report["effectiveness"]["mismatch_count"] == 0
+    assert report["effectiveness"]["accuracy_delta_vs_baseline"] > 0.6
+    assert (
+        report["effectiveness"]["policy_ranking"][0]["policy_name"]
+        == "tiny_action_model_v1"
+    )
+    assert Path(report["artifacts"]["aggregated_report_path"]).exists()
+
+
+def test_training_effectiveness_report_surfaces_eval_coverage_gaps(tmp_path):
+    from vulca.learning.training_effectiveness import run_training_effectiveness_report
+
+    report = run_training_effectiveness_report(
+        repo_root=ROOT,
+        output_dir=tmp_path / "effectiveness",
+        report_path=tmp_path / "training_effectiveness_report.json",
+    )
+
+    gaps = {
+        (item["bucket"], item["value"]): item
+        for item in report["data_gaps"]
+    }
+    assert gaps[("source.kind", "local_seed")] == {
+        "bucket": "source.kind",
+        "value": "local_seed",
+        "example_count": 12,
+        "eval_example_count": 0,
+        "min_eval_examples": 1,
+        "reason": "insufficient_eval_coverage",
+    }
+    assert gaps[("targets.failure_type", "pasteback_mismatch")]["example_count"] == 2
+    assert gaps[("targets.failure_type", "pasteback_mismatch")]["eval_example_count"] == 0
+
+
+def test_training_effectiveness_report_script_writes_report_and_prints_summary(tmp_path):
+    result, _, report_path = _run_report(tmp_path)
+
+    assert result.returncode == 0, result.stderr
+    assert report_path.exists()
+    report = json.loads(report_path.read_text(encoding="utf-8"))
+    assert report["case_type"] == "learning_training_effectiveness_report"
+    assert "Training effectiveness report:" in result.stdout
+    assert "Dataset examples: 25" in result.stdout
+    assert "Eval examples: 6" in result.stdout
+    assert "tiny_action_model_v1 action_accuracy: 1.0" in result.stdout
+    assert "tiny_agent_v0 action_accuracy: 0.3333333333333333" in result.stdout
+    assert "Data gaps:" in result.stdout
+    assert "source.kind local_seed: eval 0/12" in result.stdout
+
+
+def test_training_effectiveness_report_script_can_fail_on_data_gaps(tmp_path):
+    result, _, report_path = _run_report(tmp_path, "--fail-on-data-gaps")
+
+    assert result.returncode == 1
+    assert report_path.exists()
+    assert "Training effectiveness data coverage gaps:" in result.stderr
+    assert "source.kind local_seed eval 0 < 1" in result.stderr


### PR DESCRIPTION
## Summary
- add a combined training effectiveness report over local seeds, manual curated cases, and real user cases
- summarize tiny_action_model_v1 vs tiny_agent_v0 accuracy, gate status, policy ranking, and generated artifacts
- surface data coverage gaps, with an optional --fail-on-data-gaps mode for future stricter gating

## Current combined baseline
- dataset examples: 25
- eval examples: 6
- tiny_action_model_v1 action_accuracy: 1.0
- tiny_agent_v0 action_accuracy: 0.3333333333333333
- accuracy delta vs baseline: 0.6666666666666667
- status: passed_with_data_gaps
- data gaps: 11, including source.kind local_seed eval 0/12 and several failure types without eval holdout coverage

## Verification
- PYTHONPATH=src python3 -m pytest tests/test_training_effectiveness_report.py tests/test_combined_learning_sources_v1.py tests/test_aggregated_case_source_eval.py tests/test_tiny_training_eval_gate.py tests/test_tiny_action_model.py -q
- ruff check src/vulca/learning/training_effectiveness.py scripts/training_effectiveness_report.py tests/test_training_effectiveness_report.py
- python3 -m py_compile src/vulca/learning/training_effectiveness.py scripts/training_effectiveness_report.py
- git diff --check
- python3 scripts/training_effectiveness_report.py --repo-root . --output-dir build/tmp_training_effectiveness_smoke --report build/tmp_training_effectiveness_smoke/report.json