### PR TITLE
fix(learning): balance tiny dataset splits by source

### DIFF
--- a/src/vulca/learning/tiny_dataset.py
+++ b/src/vulca/learning/tiny_dataset.py
@@ -652,7 +652,7 @@ def _assign_dataset_splits(examples: list[dict[str, Any]]) -> None:
         groups.setdefault(case_type, []).append(example)
 
     for case_type in sorted(groups):
-        group = groups[case_type]
+        group = _source_interleaved_examples(groups[case_type])
         counts = _split_counts(len(group))
         cursor = 0
         for split in DATASET_SPLITS:
@@ -660,6 +660,43 @@ def _assign_dataset_splits(examples: list[dict[str, Any]]) -> None:
             for example in group[cursor : cursor + count]:
                 example["split"] = split
             cursor += count
+
+
+def _source_interleaved_examples(examples: Sequence[dict[str, Any]]) -> list[dict[str, Any]]:
+    buckets: dict[str, list[dict[str, Any]]] = {}
+    for example in examples:
+        buckets.setdefault(_source_kind_for_split(example), []).append(example)
+
+    for items in buckets.values():
+        items.sort(key=_split_stable_key)
+
+    ordered: list[dict[str, Any]] = []
+    source_kinds = sorted(buckets)
+    cursors: dict[str, int] = {source_kind: 0 for source_kind in source_kinds}
+    while len(ordered) < len(examples):
+        for source_kind in source_kinds:
+            cursor = cursors[source_kind]
+            bucket = buckets[source_kind]
+            if cursor >= len(bucket):
+                continue
+            ordered.append(bucket[cursor])
+            cursors[source_kind] = cursor + 1
+    return ordered
+
+
+def _source_kind_for_split(example: Mapping[str, Any]) -> str:
+    source = _mapping(example.get("source"))
+    return str(source.get("kind") or "unknown")
+
+
+def _split_stable_key(example: Mapping[str, Any]) -> tuple[str, str, str]:
+    source = _mapping(example.get("source"))
+    source_case = _mapping(example.get("source_case"))
+    return (
+        str(source.get("source_id") or source.get("kind") or ""),
+        str(source_case.get("case_id") or ""),
+        str(example.get("example_id") or ""),
+    )
 
 
 def _split_counts(total: int) -> dict[str, int]:

--- a/tests/test_combined_learning_sources_v1.py
+++ b/tests/test_combined_learning_sources_v1.py
@@ -90,6 +90,9 @@ def test_combined_case_source_manifest_v1_runs_aggregated_eval_gate(tmp_path):
     assert bucket_metrics["source.kind"]["local_seed"]["example_count"] == 12
     assert bucket_metrics["source.kind"]["manual_case_log"]["example_count"] == 8
     assert bucket_metrics["source.kind"]["user_case_log"]["example_count"] == 5
+    assert bucket_metrics["source.kind"]["local_seed"]["eval_example_count"] >= 1
+    assert bucket_metrics["source.kind"]["manual_case_log"]["eval_example_count"] >= 1
+    assert bucket_metrics["source.kind"]["user_case_log"]["eval_example_count"] >= 1
     assert bucket_metrics["source_id"]["manual_curated_cases_v1"]["example_count"] == 8
     assert bucket_metrics["source_id"]["real_user_cases_v1"]["example_count"] == 5
 

--- a/tests/test_tiny_action_model.py
+++ b/tests/test_tiny_action_model.py
@@ -44,23 +44,23 @@ def test_tiny_action_model_predicts_complete_frozen_test_split(tmp_path):
         item["case_id"]: item
         for item in predictions
     }
-    assert by_case_id["redraw_20260505T144500Z_0d13fd902885"][
+    assert by_case_id["redraw_20260505T144500Z_f2741106fbf5"][
         "recommended_action"
-    ] == "manual_review"
-    assert by_case_id["redraw_20260505T144500Z_0d13fd902885"][
+    ] == "adjust_route"
+    assert by_case_id["redraw_20260505T144500Z_f2741106fbf5"][
         "failure_hint"
-    ] == "pasteback_mismatch"
-    assert by_case_id["redraw_20260505T144500Z_0d13fd902885"][
+    ] == "route_error"
+    assert by_case_id["redraw_20260505T144500Z_f2741106fbf5"][
         "source_policy"
     ] == "train_sparse_feature_classifier"
-    assert by_case_id["redraw_20260505T144500Z_0d13fd902885"][
+    assert by_case_id["redraw_20260505T144500Z_f2741106fbf5"][
         "explanation"
     ]["fallback_reason"] == "failure_hint_prior"
-    assert by_case_id["layer_generate_20260505T144500Z_b4ac612ba871"][
+    assert by_case_id["layer_generate_20260505T144500Z_e3c92ef7660d"][
         "recommended_action"
     ] == "accept"
     assert "case_type:layer_generate_case" in by_case_id[
-        "layer_generate_20260505T144500Z_b4ac612ba871"
+        "layer_generate_20260505T144500Z_e3c92ef7660d"
     ]["explanation"]["matched_features"]
 
 
@@ -196,15 +196,6 @@ def test_tiny_action_model_uses_manual_curated_failure_signals(tmp_path):
     )
 
     by_case_id = {item["case_id"]: item for item in predictions}
-    assert by_case_id["manual_v1_redraw_mask_leak"][
-        "recommended_action"
-    ] == "adjust_mask"
-    assert by_case_id["manual_v1_layer_generate_layer_order"][
-        "recommended_action"
-    ] == "manual_review"
-    assert by_case_id["manual_v1_layer_generate_prompt_ambiguity"][
-        "recommended_action"
-    ] == "adjust_prompt"
     assert by_case_id["manual_v1_decompose_under_segmentation"][
         "recommended_action"
     ] == "split_layer_further"
@@ -245,3 +236,38 @@ def test_tiny_action_model_uses_redraw_instruction_failure_priors():
     assert prediction["recommended_action"] == "adjust_instruction"
     assert prediction["failure_hint"] == "missing_detail"
     assert prediction["explanation"]["fallback_reason"] == "failure_hint_prior"
+
+
+def test_tiny_action_model_uses_curated_failure_priors_without_split_coupling():
+    from vulca.learning.tiny_action_model import TinyActionClassifier
+
+    classifier = TinyActionClassifier.fit([])
+
+    for failure_hint, expected_action in {
+        "mask_leak": "adjust_mask",
+        "layer_order": "manual_review",
+        "prompt_ambiguity": "adjust_prompt",
+        "style_drift": "adjust_prompt",
+    }.items():
+        prediction = classifier.predict(
+            {
+                "example_id": f"example-{failure_hint}",
+                "input": {
+                    "case_record": {
+                        "case_type": "layer_generate_case",
+                        "quality": {
+                            "failures": [failure_hint],
+                            "gate_passed": False,
+                        },
+                    }
+                },
+                "source_case": {
+                    "case_id": f"manual_{failure_hint}",
+                    "case_type": "layer_generate_case",
+                },
+            }
+        )
+
+        assert prediction["recommended_action"] == expected_action
+        assert prediction["failure_hint"] == failure_hint
+        assert prediction["explanation"]["fallback_reason"] == "failure_hint_prior"

--- a/tests/test_training_effectiveness_report.py
+++ b/tests/test_training_effectiveness_report.py
@@ -60,11 +60,11 @@ def test_training_effectiveness_report_uses_combined_real_manual_and_seed_data(t
     assert report["effectiveness"]["baseline_policy"] == "tiny_agent_v0"
     assert report["effectiveness"]["action_accuracy"] == 1.0
     assert report["effectiveness"]["mismatch_count"] == 0
-    assert report["effectiveness"]["accuracy_delta_vs_baseline"] > 0.6
-    assert (
-        report["effectiveness"]["policy_ranking"][0]["policy_name"]
-        == "tiny_action_model_v1"
-    )
+    assert report["effectiveness"]["accuracy_delta_vs_baseline"] > 0
+    ranked = {
+        item["policy_name"]: item for item in report["effectiveness"]["policy_ranking"]
+    }
+    assert ranked["tiny_action_model_v1"]["action_accuracy"] == 1.0
     assert Path(report["artifacts"]["aggregated_report_path"]).exists()
 
 
@@ -81,16 +81,9 @@ def test_training_effectiveness_report_surfaces_eval_coverage_gaps(tmp_path):
         (item["bucket"], item["value"]): item
         for item in report["data_gaps"]
     }
-    assert gaps[("source.kind", "local_seed")] == {
-        "bucket": "source.kind",
-        "value": "local_seed",
-        "example_count": 12,
-        "eval_example_count": 0,
-        "min_eval_examples": 1,
-        "reason": "insufficient_eval_coverage",
-    }
-    assert gaps[("targets.failure_type", "pasteback_mismatch")]["example_count"] == 2
-    assert gaps[("targets.failure_type", "pasteback_mismatch")]["eval_example_count"] == 0
+    assert not any(item["bucket"] == "source.kind" for item in report["data_gaps"])
+    assert any(item["bucket"] == "targets.failure_type" for item in report["data_gaps"])
+    assert ("source.kind", "local_seed") not in gaps
 
 
 def test_training_effectiveness_report_script_writes_report_and_prints_summary(tmp_path):
@@ -104,9 +97,9 @@ def test_training_effectiveness_report_script_writes_report_and_prints_summary(t
     assert "Dataset examples: 25" in result.stdout
     assert "Eval examples: 6" in result.stdout
     assert "tiny_action_model_v1 action_accuracy: 1.0" in result.stdout
-    assert "tiny_agent_v0 action_accuracy: 0.3333333333333333" in result.stdout
+    assert "tiny_agent_v0 action_accuracy: 0.6666666666666666" in result.stdout
     assert "Data gaps:" in result.stdout
-    assert "source.kind local_seed: eval 0/12" in result.stdout
+    assert "source.kind local_seed: eval 0/12" not in result.stdout
 
 
 def test_training_effectiveness_report_script_can_fail_on_data_gaps(tmp_path):
@@ -115,4 +108,5 @@ def test_training_effectiveness_report_script_can_fail_on_data_gaps(tmp_path):
     assert result.returncode == 1
     assert report_path.exists()
     assert "Training effectiveness data coverage gaps:" in result.stderr
-    assert "source.kind local_seed eval 0 < 1" in result.stderr
+    assert "source.kind local_seed eval 0 < 1" not in result.stderr
+    assert "targets.failure_type" in result.stderr


### PR DESCRIPTION
## Summary
- make tiny dataset split assignment source-aware within each case_type while preserving train/dev/test counts
- prevent source-order bias where local_seed examples were all assigned to train in the combined dataset
- update combined/training-effectiveness expectations so source.kind no longer appears as a coverage gap
- keep curated tiny_action_model priors covered without depending on a specific split membership

## Current combined baseline after split balancing
- dataset examples: 25
- eval examples: 6
- eval source mix: local_seed=4, manual_case_log=1, user_case_log=1
- tiny_action_model_v1 action_accuracy: 1.0
- tiny_agent_v0 action_accuracy: 0.6666666666666666
- accuracy delta vs baseline: 0.33333333333333337
- tiny gate passed: true
- remaining data gaps: 11, all targets.failure_type coverage gaps, no source.kind gaps

## Verification
- PYTHONPATH=src python3 -m pytest tests/test_combined_learning_sources_v1.py tests/test_training_effectiveness_report.py tests/test_tiny_dataset_export.py tests/test_tiny_action_model.py tests/test_aggregated_case_source_eval.py tests/test_tiny_training_eval_gate.py tests/test_real_user_cases_v1.py tests/test_manual_curated_cases_v1.py -q
- ruff check src/vulca/learning/tiny_dataset.py tests/test_combined_learning_sources_v1.py tests/test_training_effectiveness_report.py tests/test_tiny_action_model.py
- python3 -m py_compile src/vulca/learning/tiny_dataset.py
- git diff --check
- python3 scripts/training_effectiveness_report.py --repo-root . --output-dir build/tmp_balanced_split_effectiveness_smoke --report build/tmp_balanced_split_effectiveness_smoke/report.json