### PR TITLE
Add data expansion backlog

### DIFF
--- a/scripts/data_expansion_backlog.py
+++ b/scripts/data_expansion_backlog.py
@@ -1,0 +1,127 @@
+"""Write the tiny learning data expansion backlog."""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Sequence
+
+
+ROOT = Path(__file__).resolve().parent.parent
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from vulca.learning.data_expansion_backlog import (  # noqa: E402
+    DEFAULT_OUTPUT_DIR,
+    run_data_expansion_backlog,
+)
+from vulca.learning.model_selection_report import (  # noqa: E402
+    DEFAULT_COMBINED_CASE_SOURCE_MANIFEST,
+)
+from vulca.learning.tiny_dataset import DATASET_SPLITS  # noqa: E402
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Build a case-collection backlog from the model-selection review table, "
+            "prioritizing decompose/layer_generate buckets that need more real cases."
+        )
+    )
+    parser.add_argument(
+        "--repo-root",
+        default=str(ROOT),
+        help="Repository root (default: this script's repository).",
+    )
+    parser.add_argument(
+        "--output-dir",
+        default=str(DEFAULT_OUTPUT_DIR),
+        help="Directory for generated backlog artifacts.",
+    )
+    parser.add_argument(
+        "--report",
+        default="",
+        help="Stable JSON report path (default: OUTPUT_DIR/data_expansion_backlog_report.json).",
+    )
+    parser.add_argument(
+        "--case-source-manifest",
+        default=str(DEFAULT_COMBINED_CASE_SOURCE_MANIFEST),
+        help="Combined reviewed case source manifest.",
+    )
+    parser.add_argument(
+        "--no-local-seeds",
+        action="store_true",
+        help="Only export records from the case source manifest.",
+    )
+    parser.add_argument(
+        "--split",
+        default="test",
+        choices=DATASET_SPLITS,
+        help="Dataset split to inspect for expansion backlog.",
+    )
+    parser.add_argument(
+        "--train-split",
+        default="train",
+        choices=DATASET_SPLITS,
+        help="Dataset split used to fit train-derived policies.",
+    )
+    parser.add_argument(
+        "--real-cases-per-item",
+        type=int,
+        default=2,
+        help="Requested new real user cases per backlog item.",
+    )
+    parser.add_argument(
+        "--manual-cases-per-item",
+        type=int,
+        default=1,
+        help="Requested new manually curated cases per backlog item.",
+    )
+    parser.add_argument(
+        "--pretty",
+        action="store_true",
+        help="Print the full JSON report to stdout after writing it.",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        report = run_data_expansion_backlog(
+            repo_root=args.repo_root,
+            output_dir=args.output_dir,
+            report_path=args.report or None,
+            case_source_manifest_path=args.case_source_manifest,
+            include_local_seeds=not args.no_local_seeds,
+            eval_split=args.split,
+            train_split=args.train_split,
+            requested_real_cases_per_item=args.real_cases_per_item,
+            requested_manual_cases_per_item=args.manual_cases_per_item,
+        )
+    except (ValueError, FileNotFoundError, json.JSONDecodeError) as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 2
+
+    if args.pretty:
+        print(json.dumps(report, indent=2, sort_keys=True))
+
+    summary = report["summary"]
+    artifacts = report["artifacts"]
+    print(f"Data expansion backlog: {artifacts['report_path']}")
+    print(f"JSON: {artifacts['backlog_json_path']}")
+    print(f"CSV: {artifacts['backlog_csv_path']}")
+    print(f"Backlog items: {summary['backlog_item_count']}")
+    print(f"Requested real cases: {summary['requested_real_case_count']}")
+    print(f"Requested manual cases: {summary['requested_manual_case_count']}")
+    print("Top backlog items:")
+    for item in report["backlog_items"][:5]:
+        print(
+            f"  {item['priority_tier']} {item['backlog_id']}: "
+            f"real={item['requested_real_cases']} manual={item['requested_manual_cases']}"
+        )
+    print(f"Data expansion backlog status: {report['status']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/vulca/learning/data_expansion_backlog.py
+++ b/src/vulca/learning/data_expansion_backlog.py
@@ -1,0 +1,375 @@
+"""Data expansion backlog derived from model-selection review rows."""
+from __future__ import annotations
+
+import csv
+import json
+from collections import Counter
+from pathlib import Path
+from typing import Any, Mapping
+
+from vulca.learning.model_selection_report import DEFAULT_COMBINED_CASE_SOURCE_MANIFEST
+from vulca.learning.model_selection_review_table import (
+    DEFAULT_OUTPUT_DIR as REVIEW_TABLE_OUTPUT_DIR,
+    run_model_selection_review_table,
+)
+from vulca.learning.tiny_dataset import DATASET_SPLITS, load_tiny_dataset_examples
+
+
+SCHEMA_VERSION = 1
+REPORT_CASE_TYPE = "learning_data_expansion_backlog"
+DEFAULT_OUTPUT_DIR = Path("build/data_expansion_backlog")
+DEFAULT_REPORT_NAME = "data_expansion_backlog_report.json"
+DEFAULT_BACKLOG_JSON_NAME = "data_expansion_backlog.json"
+DEFAULT_BACKLOG_CSV_NAME = "data_expansion_backlog.csv"
+CSV_COLUMNS: tuple[str, ...] = (
+    "priority_tier",
+    "priority_score",
+    "backlog_id",
+    "case_type",
+    "failure_type",
+    "requested_real_cases",
+    "requested_manual_cases",
+    "current_eval_count",
+    "current_real_eval_count",
+    "target_actions",
+    "source_kind_counts",
+    "priority_reason",
+    "collection_prompt",
+)
+
+
+def run_data_expansion_backlog(
+    *,
+    repo_root: str | Path,
+    output_dir: str | Path = DEFAULT_OUTPUT_DIR,
+    report_path: str | Path | None = None,
+    case_source_manifest_path: str | Path = DEFAULT_COMBINED_CASE_SOURCE_MANIFEST,
+    include_local_seeds: bool = True,
+    eval_split: str = "test",
+    train_split: str = "train",
+    min_eval_examples_per_bucket: int = 1,
+    min_workload_eval_examples: int = 8,
+    requested_real_cases_per_item: int = 2,
+    requested_manual_cases_per_item: int = 1,
+) -> dict[str, Any]:
+    """Build actionable case-collection tasks from model-selection review rows."""
+    _validate_split(eval_split, label="eval_split")
+    _validate_split(train_split, label="train_split")
+    if requested_real_cases_per_item < 0:
+        raise ValueError("requested_real_cases_per_item must be >= 0")
+    if requested_manual_cases_per_item < 0:
+        raise ValueError("requested_manual_cases_per_item must be >= 0")
+
+    root = Path(repo_root).resolve()
+    output = Path(output_dir)
+    output.mkdir(parents=True, exist_ok=True)
+    resolved_report_path = Path(report_path) if report_path else output / DEFAULT_REPORT_NAME
+    review_report = run_model_selection_review_table(
+        repo_root=root,
+        output_dir=output / "model_selection_review",
+        case_source_manifest_path=case_source_manifest_path,
+        include_local_seeds=include_local_seeds,
+        eval_split=eval_split,
+        train_split=train_split,
+        min_eval_examples_per_bucket=min_eval_examples_per_bucket,
+        min_workload_eval_examples=min_workload_eval_examples,
+    )
+    review_rows = _load_review_rows(review_report)
+    dataset_path = Path(str(review_report["artifacts"]["dataset_path"]))
+    examples = load_tiny_dataset_examples(dataset_path)
+    example_by_case_id = {
+        str(_mapping(item.get("source_case")).get("case_id") or ""): item
+        for item in examples
+    }
+    items = _build_backlog_items(
+        review_rows,
+        example_by_case_id=example_by_case_id,
+        requested_real_cases=requested_real_cases_per_item,
+        requested_manual_cases=requested_manual_cases_per_item,
+    )
+
+    backlog_json_path = output / DEFAULT_BACKLOG_JSON_NAME
+    backlog_csv_path = output / DEFAULT_BACKLOG_CSV_NAME
+    backlog_json_path.write_text(
+        json.dumps(items, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    _write_csv(backlog_csv_path, items)
+
+    report = {
+        "schema_version": SCHEMA_VERSION,
+        "case_type": REPORT_CASE_TYPE,
+        "status": "ready_for_case_collection",
+        "train_split": train_split,
+        "eval_split": eval_split,
+        "inputs": {
+            "repo_root": str(root),
+            "case_source_manifest_path": str(_resolve_repo_path(root, case_source_manifest_path)),
+            "include_local_seeds": bool(include_local_seeds),
+            "min_eval_examples_per_bucket": int(min_eval_examples_per_bucket),
+            "min_workload_eval_examples": int(min_workload_eval_examples),
+            "requested_real_cases_per_item": int(requested_real_cases_per_item),
+            "requested_manual_cases_per_item": int(requested_manual_cases_per_item),
+        },
+        "artifacts": {
+            "report_path": str(resolved_report_path),
+            "backlog_json_path": str(backlog_json_path),
+            "backlog_csv_path": str(backlog_csv_path),
+            "review_table_report_path": review_report["artifacts"]["report_path"],
+            "review_table_jsonl_path": review_report["artifacts"][
+                "review_table_jsonl_path"
+            ],
+            "dataset_path": str(dataset_path),
+        },
+        "summary": _build_summary(
+            items,
+            source_review_row_count=int(review_report["summary"]["row_count"]),
+        ),
+        "backlog_items": items,
+    }
+    resolved_report_path.parent.mkdir(parents=True, exist_ok=True)
+    resolved_report_path.write_text(
+        json.dumps(report, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return report
+
+
+def _build_backlog_items(
+    review_rows: list[Mapping[str, Any]],
+    *,
+    example_by_case_id: Mapping[str, Mapping[str, Any]],
+    requested_real_cases: int,
+    requested_manual_cases: int,
+) -> list[dict[str, Any]]:
+    buckets: dict[tuple[str, str], list[Mapping[str, Any]]] = {}
+    for row in review_rows:
+        if row.get("workload_decision") != "collect_more_real_cases":
+            continue
+        failure_type = str(row.get("failure_type") or "")
+        if not failure_type:
+            continue
+        case_type = str(row.get("case_type") or "")
+        buckets.setdefault((case_type, failure_type), []).append(row)
+
+    items = [
+        _build_item(
+            case_type=case_type,
+            failure_type=failure_type,
+            rows=rows,
+            example_by_case_id=example_by_case_id,
+            requested_real_cases=requested_real_cases,
+            requested_manual_cases=requested_manual_cases,
+        )
+        for (case_type, failure_type), rows in buckets.items()
+    ]
+    return sorted(
+        items,
+        key=lambda item: (
+            -int(item["priority_score"]),
+            str(item["case_type"]),
+            str(item["failure_type"]),
+        ),
+    )
+
+
+def _build_item(
+    *,
+    case_type: str,
+    failure_type: str,
+    rows: list[Mapping[str, Any]],
+    example_by_case_id: Mapping[str, Mapping[str, Any]],
+    requested_real_cases: int,
+    requested_manual_cases: int,
+) -> dict[str, Any]:
+    source_kind_counts: Counter[str] = Counter()
+    target_actions: Counter[str] = Counter()
+    examples: list[dict[str, str]] = []
+    priority_score = 0
+    real_count = 0
+    synthetic_count = 0
+    manual_count = 0
+    for row in rows:
+        source_kind = str(row.get("source_kind") or "")
+        source_kind_counts[source_kind] += 1
+        if source_kind == "user_case_log":
+            real_count += 1
+        elif source_kind == "synthetic_case_log":
+            synthetic_count += 1
+        elif source_kind == "manual_case_log":
+            manual_count += 1
+        action = str(row.get("target_action") or "")
+        if action:
+            target_actions[action] += 1
+        priority_score += int(row.get("priority_score") or 0)
+        examples.append(_example_summary(row, example_by_case_id=example_by_case_id))
+
+    priority_tier = _priority_tier(priority_score, real_count=real_count)
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "backlog_id": f"{case_type}__{failure_type}",
+        "case_type": case_type,
+        "failure_type": failure_type,
+        "workload_decision": "collect_more_real_cases",
+        "priority_tier": priority_tier,
+        "priority_score": priority_score,
+        "priority_reason": _priority_reason(
+            case_type=case_type,
+            failure_type=failure_type,
+            real_count=real_count,
+            synthetic_count=synthetic_count,
+            manual_count=manual_count,
+            source_kind_counts=source_kind_counts,
+        ),
+        "requested_real_cases": int(requested_real_cases),
+        "requested_manual_cases": int(requested_manual_cases),
+        "current_eval_count": len(rows),
+        "current_real_eval_count": real_count,
+        "current_synthetic_eval_count": synthetic_count,
+        "current_manual_eval_count": manual_count,
+        "source_kind_counts": dict(sorted(source_kind_counts.items())),
+        "target_actions": dict(sorted(target_actions.items())),
+        "collection_prompt": _collection_prompt(
+            case_type=case_type,
+            failure_type=failure_type,
+            target_actions=target_actions,
+            requested_real_cases=requested_real_cases,
+            requested_manual_cases=requested_manual_cases,
+        ),
+        "seed_examples": examples,
+    }
+
+
+def _example_summary(
+    row: Mapping[str, Any],
+    *,
+    example_by_case_id: Mapping[str, Mapping[str, Any]],
+) -> dict[str, str]:
+    case_id = str(row.get("case_id") or "")
+    example = _mapping(example_by_case_id.get(case_id))
+    source = _mapping(example.get("source"))
+    source_case = _mapping(example.get("source_case"))
+    return {
+        "case_id": case_id,
+        "example_id": str(row.get("example_id") or ""),
+        "source_kind": str(row.get("source_kind") or ""),
+        "source_id": str(row.get("source_id") or ""),
+        "target_action": str(row.get("target_action") or ""),
+        "source_case_type": str(source_case.get("case_type") or row.get("case_type") or ""),
+        "source_index": str(source.get("index") if source.get("index") is not None else ""),
+    }
+
+
+def _priority_tier(priority_score: int, *, real_count: int) -> str:
+    if real_count > 0 or priority_score >= 100:
+        return "P0"
+    if priority_score >= 75:
+        return "P1"
+    return "P2"
+
+
+def _priority_reason(
+    *,
+    case_type: str,
+    failure_type: str,
+    real_count: int,
+    synthetic_count: int,
+    manual_count: int,
+    source_kind_counts: Counter[str],
+) -> str:
+    fragments = [
+        f"{case_type}/{failure_type} is marked collect_more_real_cases",
+        f"eval sources={dict(sorted(source_kind_counts.items()))}",
+    ]
+    if real_count:
+        fragments.append("real user case signal exists and should be expanded")
+    else:
+        fragments.append("no real user case coverage yet")
+    if synthetic_count:
+        fragments.append("synthetic holdout coverage exists")
+    if manual_count:
+        fragments.append("manual curated coverage exists")
+    return "; ".join(fragments)
+
+
+def _collection_prompt(
+    *,
+    case_type: str,
+    failure_type: str,
+    target_actions: Counter[str],
+    requested_real_cases: int,
+    requested_manual_cases: int,
+) -> str:
+    action_text = ", ".join(
+        f"{action} x{count}" for action, count in sorted(target_actions.items())
+    )
+    return (
+        f"Collect {requested_real_cases} real user cases and "
+        f"{requested_manual_cases} manual curated case for {case_type} "
+        f"failure_type={failure_type}. Preserve labels, artifacts, and privacy; "
+        f"target preferred_action distribution: {action_text or 'unlabeled'}."
+    )
+
+
+def _load_review_rows(review_report: Mapping[str, Any]) -> list[Mapping[str, Any]]:
+    path = Path(str(review_report["artifacts"]["review_table_jsonl_path"]))
+    return [
+        json.loads(line)
+        for line in path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+
+
+def _build_summary(
+    items: list[Mapping[str, Any]],
+    *,
+    source_review_row_count: int,
+) -> dict[str, Any]:
+    return {
+        "source_review_row_count": int(source_review_row_count),
+        "backlog_item_count": len(items),
+        "requested_real_case_count": sum(
+            int(item.get("requested_real_cases") or 0) for item in items
+        ),
+        "requested_manual_case_count": sum(
+            int(item.get("requested_manual_cases") or 0) for item in items
+        ),
+        "case_type_counts": dict(
+            sorted(Counter(str(item.get("case_type") or "") for item in items).items())
+        ),
+    }
+
+
+def _write_csv(path: Path, items: list[Mapping[str, Any]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=CSV_COLUMNS)
+        writer.writeheader()
+        for item in items:
+            writer.writerow({column: _csv_value(item.get(column)) for column in CSV_COLUMNS})
+
+
+def _csv_value(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, (dict, list)):
+        return json.dumps(value, sort_keys=True, separators=(",", ":"))
+    return str(value)
+
+
+def _resolve_repo_path(repo_root: Path, path: str | Path) -> Path:
+    resolved = Path(path)
+    if not resolved.is_absolute():
+        resolved = repo_root / resolved
+    return resolved
+
+
+def _validate_split(value: str, *, label: str) -> None:
+    if value not in DATASET_SPLITS:
+        raise ValueError(f"unsupported {label} {value!r}; expected one of {DATASET_SPLITS}")
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    if isinstance(value, Mapping):
+        return value
+    return {}

--- a/tests/test_data_expansion_backlog.py
+++ b/tests/test_data_expansion_backlog.py
@@ -1,0 +1,149 @@
+import csv
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+CLI_ENV = dict(
+    os.environ,
+    PYTHONPATH=str(ROOT / "src") + os.pathsep + os.environ.get("PYTHONPATH", ""),
+)
+BACKLOG_SCRIPT = ROOT / "scripts" / "data_expansion_backlog.py"
+
+
+def _run_backlog(tmp_path, *extra_args):
+    output_dir = tmp_path / "data_expansion_backlog"
+    report_path = tmp_path / "data_expansion_backlog_report.json"
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(BACKLOG_SCRIPT),
+            "--repo-root",
+            str(ROOT),
+            "--output-dir",
+            str(output_dir),
+            "--report",
+            str(report_path),
+            *extra_args,
+        ],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        env=CLI_ENV,
+        cwd=ROOT,
+    )
+    return result, output_dir, report_path
+
+
+def test_data_expansion_backlog_targets_decompose_and_layer_generate_gaps(tmp_path):
+    from vulca.learning.data_expansion_backlog import run_data_expansion_backlog
+
+    report = run_data_expansion_backlog(
+        repo_root=ROOT,
+        output_dir=tmp_path / "backlog",
+        report_path=tmp_path / "backlog_report.json",
+    )
+
+    assert report["case_type"] == "learning_data_expansion_backlog"
+    assert report["status"] == "ready_for_case_collection"
+    assert report["summary"] == {
+        "source_review_row_count": 17,
+        "backlog_item_count": 7,
+        "requested_real_case_count": 14,
+        "requested_manual_case_count": 7,
+        "case_type_counts": {
+            "decompose_case": 3,
+            "layer_generate_case": 4,
+        },
+    }
+    assert Path(report["artifacts"]["backlog_json_path"]).exists()
+    assert Path(report["artifacts"]["backlog_csv_path"]).exists()
+
+    items = report["backlog_items"]
+    assert [item["backlog_id"] for item in items] == [
+        "layer_generate_case__prompt_ambiguity",
+        "decompose_case__occlusion",
+        "decompose_case__over_segmentation",
+        "layer_generate_case__layer_order",
+        "layer_generate_case__provider_failure",
+        "layer_generate_case__style_drift",
+        "decompose_case__under_segmentation",
+    ]
+    assert all(item["workload_decision"] == "collect_more_real_cases" for item in items)
+    assert all(item["requested_real_cases"] == 2 for item in items)
+    assert all(item["requested_manual_cases"] == 1 for item in items)
+    assert all(item["collection_prompt"] for item in items)
+    assert not any(item["case_type"] == "redraw_case" for item in items)
+
+
+def test_data_expansion_backlog_prioritizes_real_user_signal_and_actions(tmp_path):
+    from vulca.learning.data_expansion_backlog import run_data_expansion_backlog
+
+    report = run_data_expansion_backlog(
+        repo_root=ROOT,
+        output_dir=tmp_path / "backlog",
+        report_path=tmp_path / "backlog_report.json",
+    )
+
+    by_id = {item["backlog_id"]: item for item in report["backlog_items"]}
+    prompt = by_id["layer_generate_case__prompt_ambiguity"]
+    assert prompt["priority_tier"] == "P0"
+    assert prompt["current_real_eval_count"] == 1
+    assert prompt["target_actions"] == {"manual_review": 1}
+    assert prompt["source_kind_counts"]["user_case_log"] == 1
+    assert "real user case" in prompt["priority_reason"]
+
+    occlusion = by_id["decompose_case__occlusion"]
+    assert occlusion["priority_tier"] == "P1"
+    assert occlusion["current_real_eval_count"] == 0
+    assert occlusion["target_actions"] == {"fallback_to_agent": 1}
+    assert occlusion["source_kind_counts"]["synthetic_case_log"] == 1
+
+
+def test_data_expansion_backlog_writes_csv_for_parallel_case_sessions(tmp_path):
+    from vulca.learning.data_expansion_backlog import run_data_expansion_backlog
+
+    report = run_data_expansion_backlog(
+        repo_root=ROOT,
+        output_dir=tmp_path / "backlog",
+        report_path=tmp_path / "backlog_report.json",
+    )
+
+    with Path(report["artifacts"]["backlog_csv_path"]).open(
+        newline="",
+        encoding="utf-8",
+    ) as handle:
+        rows = list(csv.DictReader(handle))
+
+    assert len(rows) == 7
+    assert rows[0].keys() >= {
+        "priority_tier",
+        "priority_score",
+        "backlog_id",
+        "case_type",
+        "failure_type",
+        "requested_real_cases",
+        "requested_manual_cases",
+        "target_actions",
+        "collection_prompt",
+    }
+    assert rows[0]["backlog_id"] == "layer_generate_case__prompt_ambiguity"
+    assert rows[0]["requested_real_cases"] == "2"
+
+
+def test_data_expansion_backlog_script_writes_artifacts_and_summary(tmp_path):
+    result, _, report_path = _run_backlog(tmp_path)
+
+    assert result.returncode == 0, result.stderr
+    assert report_path.exists()
+    report = json.loads(report_path.read_text(encoding="utf-8"))
+    assert Path(report["artifacts"]["backlog_json_path"]).exists()
+    assert Path(report["artifacts"]["backlog_csv_path"]).exists()
+    assert "Data expansion backlog:" in result.stdout
+    assert "Backlog items: 7" in result.stdout
+    assert "Requested real cases: 14" in result.stdout
+    assert "Requested manual cases: 7" in result.stdout
+    assert "layer_generate_case__prompt_ambiguity" in result.stdout


### PR DESCRIPTION
## Summary
- add a data expansion backlog generator derived from the model-selection review table
- target only collect_more_real_cases buckets with failure labels, excluding promoted redraw guardrail rows
- export JSON + CSV backlog items with requested real/manual case counts and collection prompts
- add CLI summary for parallel case-collection sessions

## Current smoke output
- backlog items: 7
- requested real cases: 14
- requested manual cases: 7
- first item: layer_generate_case__prompt_ambiguity
- targeted buckets: decompose occlusion/over_segmentation/under_segmentation and layer_generate prompt_ambiguity/layer_order/provider_failure/style_drift

## Verification
- PYTHONPATH=src /opt/homebrew/bin/python3.11 -m pytest tests/test_data_expansion_backlog.py tests/test_model_selection_review_table.py tests/test_model_selection_report.py tests/test_training_effectiveness_report.py tests/test_tiny_training_eval_gate.py tests/test_aggregated_case_source_eval.py tests/test_taxonomy_holdout_cases_v1.py tests/test_combined_learning_sources_v1.py tests/test_tiny_dataset_export.py tests/test_tiny_action_model.py tests/test_manual_curated_cases_v1.py tests/test_real_user_cases_v1.py -q
- ruff check src/vulca/learning/data_expansion_backlog.py scripts/data_expansion_backlog.py tests/test_data_expansion_backlog.py
- /opt/homebrew/bin/python3.11 -m py_compile src/vulca/learning/data_expansion_backlog.py scripts/data_expansion_backlog.py
- git diff --check
- /opt/homebrew/bin/python3.11 scripts/data_expansion_backlog.py --repo-root . --output-dir build/tmp_data_expansion_backlog_smoke --report build/tmp_data_expansion_backlog_smoke/report.json