### PR TITLE
Catalog open-source model candidates

### DIFF
--- a/docs/benchmarks/learning/open_source_model_catalog_v1.json
+++ b/docs/benchmarks/learning/open_source_model_catalog_v1.json
@@ -1,0 +1,238 @@
+{
+  "schema_version": 1,
+  "case_type": "learning_open_source_model_catalog",
+  "created_at": "2026-05-06T00:00:00Z",
+  "default_runtime_enabled": false,
+  "default_training_input": false,
+  "requires_explicit_enablement": true,
+  "requires_reviewed_case_conversion": true,
+  "pilot_policy": {
+    "requires_license_review_before_download": true,
+    "requires_model_card_review_before_runtime": true,
+    "requires_manual_review_before_training": true,
+    "allow_weight_download_by_default": false,
+    "output_kind": "open_model_candidate_signals"
+  },
+  "models": [
+    {
+      "id": "qwen_image_edit",
+      "name": "Qwen-Image-Edit",
+      "source_url": "https://huggingface.co/Qwen/Qwen-Image-Edit",
+      "license": "apache-2.0",
+      "license_risk": "permissive",
+      "model_role": "open_image_edit_provider",
+      "target_case_types": [
+        "redraw_case",
+        "layer_generate_case"
+      ],
+      "target_workflows": [
+        "redraw_candidate_generation",
+        "layer_generate_provider_trial",
+        "text_and_style_editing"
+      ],
+      "recommended_use": "pilot_open_image_edit_provider_for_case_generation_and_provider_comparison",
+      "intake_status": "recommended_pilot",
+      "default_runtime_enabled": false,
+      "default_training_input": false,
+      "output_training_policy": "candidate_cases_only",
+      "requires_manual_review_for_training_labels": true,
+      "evidence_urls": [
+        "https://huggingface.co/Qwen/Qwen-Image-Edit"
+      ],
+      "risks": [
+        "20B model may require GPU or hosted inference for acceptable latency",
+        "edited images do not provide Vulca failure labels without review",
+        "provider comparison must separate image quality from user action labels"
+      ]
+    },
+    {
+      "id": "segment_anything_sam_vit",
+      "name": "Segment Anything Model",
+      "source_url": "https://github.com/facebookresearch/segment-anything",
+      "license": "apache-2.0",
+      "license_risk": "permissive",
+      "model_role": "mask_proposal",
+      "target_case_types": [
+        "decompose_case",
+        "redraw_case"
+      ],
+      "target_workflows": [
+        "mask_proposal",
+        "layer_boundary_candidates",
+        "pasteback_mask_review"
+      ],
+      "recommended_use": "pilot_mask_proposals_for_decompose_and_redraw_boundary_review",
+      "intake_status": "recommended_pilot",
+      "default_runtime_enabled": false,
+      "default_training_input": false,
+      "output_training_policy": "quality_signals_only",
+      "requires_manual_review_for_training_labels": true,
+      "evidence_urls": [
+        "https://github.com/facebookresearch/segment-anything",
+        "https://tensorflow.google.cn/datasets/catalog/segment_anything"
+      ],
+      "risks": [
+        "mask proposals are class-agnostic and do not define editable layer roles",
+        "SA-1B dataset terms are custom even though the model license is permissive",
+        "mask quality signals must not become action labels without review"
+      ]
+    },
+    {
+      "id": "grounding_dino",
+      "name": "Grounding DINO",
+      "source_url": "https://github.com/IDEA-Research/GroundingDINO",
+      "license": "apache-2.0",
+      "license_risk": "permissive",
+      "model_role": "text_grounded_detection",
+      "target_case_types": [
+        "decompose_case",
+        "layer_generate_case"
+      ],
+      "target_workflows": [
+        "text_to_box_grounding",
+        "semantic_layer_candidate_discovery",
+        "prompt_object_coverage_review"
+      ],
+      "recommended_use": "pilot_grounded_object_boxes_for_layer_generation_and_decompose_review",
+      "intake_status": "recommended_pilot",
+      "default_runtime_enabled": false,
+      "default_training_input": false,
+      "output_training_policy": "quality_signals_only",
+      "requires_manual_review_for_training_labels": true,
+      "evidence_urls": [
+        "https://github.com/IDEA-Research/GroundingDINO",
+        "https://github.com/IDEA-Research/GroundingDINO/blob/main/LICENSE"
+      ],
+      "risks": [
+        "grounded boxes are not layer masks",
+        "text prompts can bias detection toward expected objects",
+        "object coverage signals require human review before training"
+      ]
+    },
+    {
+      "id": "florence_2",
+      "name": "Florence-2",
+      "source_url": "https://huggingface.co/microsoft/Florence-2-base",
+      "license": "mit",
+      "license_risk": "permissive",
+      "model_role": "vision_caption_grounding_ocr",
+      "target_case_types": [
+        "redraw_case",
+        "decompose_case",
+        "layer_generate_case"
+      ],
+      "target_workflows": [
+        "caption_observable_signals",
+        "ocr_text_preservation_review",
+        "dense_region_description"
+      ],
+      "recommended_use": "pilot_observable_signal_extraction_for_case_review_and_tiny_router_features",
+      "intake_status": "recommended_pilot",
+      "default_runtime_enabled": false,
+      "default_training_input": false,
+      "output_training_policy": "quality_signals_only",
+      "requires_manual_review_for_training_labels": true,
+      "evidence_urls": [
+        "https://huggingface.co/microsoft/Florence-2-base"
+      ],
+      "risks": [
+        "caption and OCR signals can miss subtle visual failures",
+        "vision-language outputs are weak labels until reviewed",
+        "dense descriptions may over-explain artifacts that users would ignore"
+      ]
+    },
+    {
+      "id": "openai_clip",
+      "name": "OpenAI CLIP",
+      "source_url": "https://github.com/openai/CLIP",
+      "license": "mit",
+      "license_risk": "permissive",
+      "model_role": "image_text_similarity_evaluator",
+      "target_case_types": [
+        "redraw_case",
+        "layer_generate_case"
+      ],
+      "target_workflows": [
+        "prompt_image_similarity",
+        "candidate_ranking_baseline",
+        "style_drift_screening"
+      ],
+      "recommended_use": "catalog_similarity_baseline_only_for_evaluator_comparison",
+      "intake_status": "catalog_only",
+      "default_runtime_enabled": false,
+      "default_training_input": false,
+      "output_training_policy": "quality_signals_only",
+      "requires_manual_review_for_training_labels": true,
+      "evidence_urls": [
+        "https://github.com/openai/CLIP",
+        "https://github.com/openai/CLIP/blob/main/LICENSE"
+      ],
+      "risks": [
+        "similarity scores do not identify actionable fixes",
+        "CLIP can reward prompt overlap while missing edit preservation failures",
+        "should be compared against user decisions rather than used as ground truth"
+      ]
+    },
+    {
+      "id": "flux_kontext_dev",
+      "name": "FLUX.1 Kontext dev",
+      "source_url": "https://huggingface.co/black-forest-labs/FLUX.1-Kontext-dev",
+      "license": "flux-1-dev-non-commercial-license",
+      "license_risk": "non_commercial",
+      "model_role": "open_weight_image_edit_reference",
+      "target_case_types": [
+        "redraw_case",
+        "layer_generate_case"
+      ],
+      "target_workflows": [
+        "research_reference_image_editing",
+        "non_commercial_benchmark_comparison"
+      ],
+      "recommended_use": "reference_only_until_license_review_or_commercial_terms",
+      "intake_status": "blocked_non_commercial",
+      "default_runtime_enabled": false,
+      "default_training_input": false,
+      "output_training_policy": "blocked_for_training",
+      "requires_manual_review_for_training_labels": true,
+      "evidence_urls": [
+        "https://huggingface.co/black-forest-labs/FLUX.1-Kontext-dev"
+      ],
+      "risks": [
+        "non-commercial model license blocks default product runtime use",
+        "gated access requires accepting additional terms",
+        "outputs must not be used for training without license review"
+      ]
+    },
+    {
+      "id": "stable_diffusion_3_5_large",
+      "name": "Stable Diffusion 3.5 Large",
+      "source_url": "https://huggingface.co/stabilityai/stable-diffusion-3.5-large",
+      "license": "stabilityai-ai-community",
+      "license_risk": "commercial_license_required",
+      "model_role": "open_weight_generation_reference",
+      "target_case_types": [
+        "redraw_case",
+        "layer_generate_case"
+      ],
+      "target_workflows": [
+        "generation_reference",
+        "style_and_prompt_coverage_comparison"
+      ],
+      "recommended_use": "catalog_only_until_stability_license_review",
+      "intake_status": "blocked_pending_license_review",
+      "default_runtime_enabled": false,
+      "default_training_input": false,
+      "output_training_policy": "blocked_for_training",
+      "requires_manual_review_for_training_labels": true,
+      "evidence_urls": [
+        "https://huggingface.co/stabilityai/stable-diffusion-3.5-large",
+        "https://huggingface.co/stabilityai/stable-diffusion-3.5-large/blob/main/LICENSE.md"
+      ],
+      "risks": [
+        "community license has business and revenue-dependent conditions",
+        "not an instruction-editing specialist by default",
+        "must not be used as a silent training source"
+      ]
+    }
+  ]
+}

--- a/docs/superpowers/plans/2026-05-06-open-source-model-catalog-v1.md
+++ b/docs/superpowers/plans/2026-05-06-open-source-model-catalog-v1.md
@@ -1,0 +1,37 @@
+# Open Source Model Catalog v1
+
+Status: implemented
+
+## Goal
+
+Record the open and open-weight model candidates that can support Vulca learning workflows without silently changing runtime behavior, downloading weights, or treating model outputs as reviewed training labels.
+
+## Scope
+
+- Add a static model catalog under `docs/benchmarks/learning/`.
+- Separate permissive pilots from non-commercial or license-review-blocked references.
+- Require explicit enablement before runtime use.
+- Require manual review before any model output can become training data.
+
+## Initial Pilot Order
+
+1. `qwen_image_edit`: image editing provider candidate for `redraw_case` and `layer_generate_case`.
+2. `segment_anything_sam_vit`: mask proposal and layer boundary signal candidate for `decompose_case` and `redraw_case`.
+3. `grounding_dino`: text-grounded detection signal candidate for layer coverage review.
+4. `florence_2`: caption, OCR, and dense-region signal candidate for case review features.
+
+## Blocked References
+
+- `flux_kontext_dev`: non-commercial license, keep as reference only until license review or commercial terms.
+- `stable_diffusion_3_5_large`: community/commercial license boundary requires review before product runtime or training use.
+
+## Non-Goals
+
+- Do not download model weights.
+- Do not integrate runtime providers.
+- Do not add model outputs to `combined_case_source_manifest_v1`.
+- Do not train from generated outputs without human-reviewed conversion into case logs.
+
+## Verification
+
+- `tests/test_open_source_model_catalog_v1.py` validates schema, safety defaults, pilot priorities, and blocked models.

--- a/tests/test_open_source_model_catalog_v1.py
+++ b/tests/test_open_source_model_catalog_v1.py
@@ -1,0 +1,144 @@
+import json
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+CATALOG = ROOT / "docs/benchmarks/learning/open_source_model_catalog_v1.json"
+
+REQUIRED_MODEL_FIELDS = {
+    "id",
+    "name",
+    "source_url",
+    "license",
+    "license_risk",
+    "model_role",
+    "target_case_types",
+    "target_workflows",
+    "recommended_use",
+    "intake_status",
+    "default_runtime_enabled",
+    "output_training_policy",
+    "requires_manual_review_for_training_labels",
+    "risks",
+}
+
+ALLOWED_CASE_TYPES = {"redraw_case", "decompose_case", "layer_generate_case"}
+ALLOWED_LICENSE_RISKS = {
+    "permissive",
+    "non_commercial",
+    "commercial_license_required",
+    "license_review_required",
+}
+ALLOWED_OUTPUT_POLICIES = {
+    "candidate_cases_only",
+    "quality_signals_only",
+    "benchmark_reference_only",
+    "blocked_for_training",
+}
+
+
+def _load_catalog() -> dict:
+    return json.loads(CATALOG.read_text(encoding="utf-8"))
+
+
+def test_open_source_model_catalog_v1_schema_and_safety_defaults():
+    catalog = _load_catalog()
+
+    assert catalog["schema_version"] == 1
+    assert catalog["case_type"] == "learning_open_source_model_catalog"
+    assert catalog["default_runtime_enabled"] is False
+    assert catalog["default_training_input"] is False
+    assert catalog["requires_explicit_enablement"] is True
+    assert catalog["requires_reviewed_case_conversion"] is True
+    assert catalog["pilot_policy"] == {
+        "requires_license_review_before_download": True,
+        "requires_model_card_review_before_runtime": True,
+        "requires_manual_review_before_training": True,
+        "allow_weight_download_by_default": False,
+        "output_kind": "open_model_candidate_signals",
+    }
+
+    models = catalog["models"]
+    assert len(models) >= 6
+    assert len({item["id"] for item in models}) == len(models)
+
+    serialized = CATALOG.read_text(encoding="utf-8")
+    assert "/Users/" not in serialized
+    assert "private://local_path/" not in serialized
+
+    for item in models:
+        assert REQUIRED_MODEL_FIELDS.issubset(item)
+        assert item["source_url"].startswith("https://")
+        assert item["license"]
+        assert item["license_risk"] in ALLOWED_LICENSE_RISKS
+        assert item["intake_status"] in {
+            "recommended_pilot",
+            "catalog_only",
+            "blocked_pending_license_review",
+            "blocked_non_commercial",
+        }
+        assert item["default_runtime_enabled"] is False
+        assert item["output_training_policy"] in ALLOWED_OUTPUT_POLICIES
+        assert item["requires_manual_review_for_training_labels"] is True
+        assert item["target_case_types"]
+        assert set(item["target_case_types"]).issubset(ALLOWED_CASE_TYPES)
+        assert item["risks"]
+
+
+def test_open_source_model_catalog_prioritizes_current_vulca_roles():
+    models = {item["id"]: item for item in _load_catalog()["models"]}
+
+    assert models["qwen_image_edit"]["intake_status"] == "recommended_pilot"
+    assert models["qwen_image_edit"]["license"] == "apache-2.0"
+    assert models["qwen_image_edit"]["model_role"] == "open_image_edit_provider"
+    assert set(models["qwen_image_edit"]["target_case_types"]) == {
+        "redraw_case",
+        "layer_generate_case",
+    }
+    assert models["qwen_image_edit"]["output_training_policy"] == "candidate_cases_only"
+
+    assert models["segment_anything_sam_vit"]["intake_status"] == "recommended_pilot"
+    assert models["segment_anything_sam_vit"]["model_role"] == "mask_proposal"
+    assert "decompose_case" in models["segment_anything_sam_vit"]["target_case_types"]
+
+    assert models["grounding_dino"]["intake_status"] == "recommended_pilot"
+    assert models["grounding_dino"]["model_role"] == "text_grounded_detection"
+    assert "layer_generate_case" in models["grounding_dino"]["target_case_types"]
+
+    assert models["florence_2"]["license"] == "mit"
+    assert models["florence_2"]["model_role"] == "vision_caption_grounding_ocr"
+
+
+def test_open_source_model_catalog_blocks_noncommercial_or_unclear_models():
+    models = {item["id"]: item for item in _load_catalog()["models"]}
+
+    assert models["flux_kontext_dev"]["license_risk"] == "non_commercial"
+    assert models["flux_kontext_dev"]["intake_status"] == "blocked_non_commercial"
+    assert models["flux_kontext_dev"]["output_training_policy"] == "blocked_for_training"
+
+    assert models["stable_diffusion_3_5_large"]["license_risk"] == (
+        "commercial_license_required"
+    )
+    assert models["stable_diffusion_3_5_large"]["intake_status"] == (
+        "blocked_pending_license_review"
+    )
+    assert models["stable_diffusion_3_5_large"]["default_runtime_enabled"] is False
+
+
+def test_open_source_model_catalog_keeps_models_out_of_training_by_default():
+    catalog = _load_catalog()
+
+    for item in catalog["models"]:
+        assert item["default_training_input"] is False
+        assert item["recommended_use"] != "default_training"
+        assert "human_reviewed" not in item["output_training_policy"]
+
+    recommended = {
+        item["id"] for item in catalog["models"] if item["intake_status"] == "recommended_pilot"
+    }
+    assert {
+        "qwen_image_edit",
+        "segment_anything_sam_vit",
+        "grounding_dino",
+        "florence_2",
+    }.issubset(recommended)


### PR DESCRIPTION
## Summary
- add an open-source/open-weight model catalog for Vulca learning workflows
- mark Qwen-Image-Edit, SAM, GroundingDINO, and Florence-2 as recommended pilots with explicit enablement only
- block FLUX Kontext dev and SD3.5 Large from default runtime/training until license review
- document that model outputs are candidate signals only and require human-reviewed case conversion before training

## Verification
- PYTHONPATH=src /opt/homebrew/bin/python3.11 -m pytest tests/test_open_source_model_catalog_v1.py tests/test_external_dataset_catalog_v1.py -q
- /opt/homebrew/bin/python3.11 -m json.tool docs/benchmarks/learning/open_source_model_catalog_v1.json >/dev/null
- ruff check tests/test_open_source_model_catalog_v1.py
- git diff --cached --check