### PR TITLE
Add open model signal adapter

### DIFF
--- a/docs/superpowers/plans/2026-05-06-open-model-signal-adapter-v1.md
+++ b/docs/superpowers/plans/2026-05-06-open-model-signal-adapter-v1.md
@@ -1,0 +1,42 @@
+# Open Model Signal Adapter v1
+
+Status: implemented
+
+## Goal
+
+Create the first safe bridge from the open-source model catalog into Vulca learning cases. The adapter prepares reviewable signal records for Florence-2 and SAM-style workflows without downloading weights, calling providers, or adding generated outputs to training data.
+
+## Scope
+
+- Read reviewed tiny learning examples from the combined case source manifest.
+- Select only `recommended_pilot` models from `open_source_model_catalog_v1`.
+- Generate `learning_open_model_signal_record` JSONL records.
+- Write a summary report with coverage by model, case type, and source kind.
+- Support injected runners for explicit local experiments and tests.
+- Default to dry-run records when no runner is provided.
+
+## Safety Rules
+
+- Runtime is disabled by default.
+- Weight download is out of scope.
+- Blocked/non-commercial/license-review models cannot be selected by default.
+- Output records are not training data.
+- Every signal record requires human review before labels can be used for training.
+- Signal records summarize inputs and do not serialize raw case records, review labels, learning targets, local absolute paths, or private URI values.
+
+## Initial Models
+
+- `florence_2`: caption, OCR, and dense-region signal families across redraw, decompose, and layer generation cases.
+- `segment_anything_sam_vit`: mask proposal, boundary complexity, and mask coverage signal families for redraw and decompose cases.
+
+## Non-Goals
+
+- Do not integrate Hugging Face runtime.
+- Do not call Florence-2, SAM, or any provider.
+- Do not generate labels automatically.
+- Do not update `combined_case_source_manifest_v1`.
+- Do not affect redraw/decompose/layer generation runtime.
+
+## Verification
+
+- `tests/test_open_model_signal_adapter.py` covers dry-run export, model blocking, injected runner outputs, and CLI behavior.

--- a/scripts/open_model_signal_adapter.py
+++ b/scripts/open_model_signal_adapter.py
@@ -1,0 +1,104 @@
+"""Write safe open-model signal records for reviewed learning cases."""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Sequence
+
+
+ROOT = Path(__file__).resolve().parent.parent
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from vulca.learning.open_model_signals import (  # noqa: E402
+    DEFAULT_COMBINED_CASE_SOURCE_MANIFEST,
+    DEFAULT_MODEL_CATALOG,
+    DEFAULT_MODEL_IDS,
+    DEFAULT_OUTPUT_DIR,
+    DEFAULT_REPORT_NAME,
+    DEFAULT_SIGNAL_OUTPUT_NAME,
+    run_open_model_signal_adapter,
+)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Export reviewable Florence/SAM-style open-model signal records "
+            "without downloading weights or enabling runtime providers."
+        )
+    )
+    parser.add_argument(
+        "--repo-root",
+        default=str(ROOT),
+        help="Repository root (default: this script's repository).",
+    )
+    parser.add_argument(
+        "--output",
+        default=str(DEFAULT_OUTPUT_DIR / DEFAULT_SIGNAL_OUTPUT_NAME),
+        help="Output JSONL path for signal records.",
+    )
+    parser.add_argument(
+        "--report",
+        default=str(DEFAULT_OUTPUT_DIR / DEFAULT_REPORT_NAME),
+        help="Output JSON report path.",
+    )
+    parser.add_argument(
+        "--model-catalog",
+        default=str(DEFAULT_MODEL_CATALOG),
+        help="Open model catalog JSON path.",
+    )
+    parser.add_argument(
+        "--case-source-manifest",
+        default=str(DEFAULT_COMBINED_CASE_SOURCE_MANIFEST),
+        help="Combined reviewed case source manifest.",
+    )
+    parser.add_argument(
+        "--model",
+        action="append",
+        default=[],
+        help="Open model id to include; repeat for multiple models.",
+    )
+    parser.add_argument(
+        "--no-local-seeds",
+        action="store_true",
+        help="Only use records from the case source manifest.",
+    )
+    parser.add_argument(
+        "--pretty",
+        action="store_true",
+        help="Print the full JSON report to stdout.",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        report = run_open_model_signal_adapter(
+            repo_root=args.repo_root,
+            output_path=args.output,
+            report_path=args.report,
+            model_catalog_path=args.model_catalog,
+            case_source_manifest_path=args.case_source_manifest,
+            model_ids=tuple(args.model) or DEFAULT_MODEL_IDS,
+            include_local_seeds=not args.no_local_seeds,
+        )
+    except (FileNotFoundError, ValueError, json.JSONDecodeError) as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 2
+
+    if args.pretty:
+        print(json.dumps(report, indent=2, sort_keys=True))
+
+    print(f"Open model signal records: {report['artifacts']['output_path']}")
+    print(f"Open model signal report: {report['artifacts']['report_path']}")
+    print(f"Signal records: {report['record_count']}")
+    print(f"Examples: {report['example_count']}")
+    print(f"Models: {', '.join(report['inputs']['model_ids'])}")
+    print(f"Status: {report['status']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/vulca/learning/open_model_signals.py
+++ b/src/vulca/learning/open_model_signals.py
@@ -1,0 +1,436 @@
+"""Safe open-model signal extraction records for learning cases.
+
+This module does not download weights or call model providers. It builds a
+reviewable signal-record layer around case examples, with optional injected
+runners for tests or explicitly enabled local experiments.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+from collections import Counter
+from pathlib import Path
+from typing import Any, Callable, Mapping, Sequence
+
+from vulca.learning.tiny_dataset import build_tiny_dataset_examples
+from vulca.learning.training_effectiveness import (
+    DEFAULT_COMBINED_CASE_SOURCE_MANIFEST,
+)
+
+
+SCHEMA_VERSION = 1
+SIGNAL_RECORD_CASE_TYPE = "learning_open_model_signal_record"
+SIGNAL_REPORT_CASE_TYPE = "learning_open_model_signal_report"
+MODEL_CATALOG_CASE_TYPE = "learning_open_source_model_catalog"
+DEFAULT_MODEL_CATALOG = Path(
+    "docs/benchmarks/learning/open_source_model_catalog_v1.json"
+)
+DEFAULT_OUTPUT_DIR = Path("build/open_model_signal_adapter")
+DEFAULT_SIGNAL_OUTPUT_NAME = "open_model_signals.jsonl"
+DEFAULT_REPORT_NAME = "open_model_signal_report.json"
+DEFAULT_MODEL_IDS: tuple[str, ...] = (
+    "florence_2",
+    "segment_anything_sam_vit",
+)
+ELIGIBLE_INTAKE_STATUSES: frozenset[str] = frozenset({"recommended_pilot"})
+
+SignalRunner = Callable[[Mapping[str, Any], Mapping[str, Any]], Mapping[str, Any]]
+
+
+def run_open_model_signal_adapter(
+    *,
+    repo_root: str | Path,
+    output_path: str | Path | None = None,
+    report_path: str | Path | None = None,
+    model_catalog_path: str | Path = DEFAULT_MODEL_CATALOG,
+    case_source_manifest_path: str | Path = DEFAULT_COMBINED_CASE_SOURCE_MANIFEST,
+    model_ids: Sequence[str] = DEFAULT_MODEL_IDS,
+    include_local_seeds: bool = True,
+    runners: Mapping[str, SignalRunner] | None = None,
+) -> dict[str, Any]:
+    """Write dry-run or injected open-model signal records and a summary report."""
+    root = Path(repo_root)
+    resolved_catalog_path = _resolve_repo_path(root, model_catalog_path)
+    resolved_manifest_path = _resolve_repo_path(root, case_source_manifest_path)
+    resolved_output_path = Path(output_path) if output_path else (
+        root / DEFAULT_OUTPUT_DIR / DEFAULT_SIGNAL_OUTPUT_NAME
+    )
+    resolved_report_path = Path(report_path) if report_path else (
+        root / DEFAULT_OUTPUT_DIR / DEFAULT_REPORT_NAME
+    )
+
+    examples = build_tiny_dataset_examples(
+        repo_root=root,
+        case_source_manifest_path=resolved_manifest_path,
+        include_local_seeds=include_local_seeds,
+    )
+    model_specs = select_open_model_specs(
+        resolved_catalog_path,
+        model_ids=model_ids,
+    )
+    records = build_open_model_signal_records(
+        examples,
+        model_specs=model_specs,
+        runners=runners,
+    )
+
+    _write_jsonl(resolved_output_path, records)
+    report = build_open_model_signal_report(
+        records,
+        examples=examples,
+        model_specs=model_specs,
+        repo_root=root,
+        model_catalog_path=resolved_catalog_path,
+        case_source_manifest_path=resolved_manifest_path,
+        output_path=resolved_output_path,
+        report_path=resolved_report_path,
+        include_local_seeds=include_local_seeds,
+    )
+    resolved_report_path.parent.mkdir(parents=True, exist_ok=True)
+    resolved_report_path.write_text(
+        json.dumps(report, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return report
+
+
+def select_open_model_specs(
+    model_catalog_path: str | Path,
+    *,
+    model_ids: Sequence[str] = DEFAULT_MODEL_IDS,
+) -> tuple[dict[str, Any], ...]:
+    """Select recommended-pilot model specs from the open model catalog."""
+    catalog = load_open_model_catalog(model_catalog_path)
+    models = catalog.get("models")
+    if not isinstance(models, list):
+        raise ValueError("open model catalog models must be a list")
+
+    model_by_id = {
+        str(item.get("id") or ""): dict(item)
+        for item in models
+        if isinstance(item, Mapping)
+    }
+    selected: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for raw_model_id in model_ids:
+        model_id = str(raw_model_id)
+        if model_id in seen:
+            continue
+        seen.add(model_id)
+        model = model_by_id.get(model_id)
+        if model is None:
+            raise ValueError(f"unknown open model id {model_id!r}")
+        status = str(model.get("intake_status") or "")
+        if status not in ELIGIBLE_INTAKE_STATUSES:
+            raise ValueError(
+                f"open model {model_id!r} is not eligible for signal pilot: "
+                f"intake_status={status!r}"
+            )
+        if bool(model.get("default_runtime_enabled")):
+            raise ValueError(
+                f"open model {model_id!r} must not be enabled by default"
+            )
+        selected.append(model)
+    return tuple(selected)
+
+
+def load_open_model_catalog(path: str | Path) -> dict[str, Any]:
+    """Load and validate the open model catalog wrapper."""
+    catalog_path = Path(path)
+    catalog = json.loads(catalog_path.read_text(encoding="utf-8"))
+    if not isinstance(catalog, Mapping):
+        raise ValueError("open model catalog must be a JSON object")
+    if catalog.get("case_type") != MODEL_CATALOG_CASE_TYPE:
+        raise ValueError(
+            f"open model catalog case_type must be {MODEL_CATALOG_CASE_TYPE!r}"
+        )
+    return dict(catalog)
+
+
+def build_open_model_signal_records(
+    examples: Sequence[Mapping[str, Any]],
+    *,
+    model_specs: Sequence[Mapping[str, Any]],
+    runners: Mapping[str, SignalRunner] | None = None,
+) -> list[dict[str, Any]]:
+    """Build reviewable signal records for examples targeted by each model."""
+    runner_by_model = dict(runners or {})
+    records: list[dict[str, Any]] = []
+
+    for example in examples:
+        source_case = _mapping(example.get("source_case"))
+        case_type = str(source_case.get("case_type") or "")
+        for model_spec in model_specs:
+            target_case_types = {
+                str(item) for item in model_spec.get("target_case_types", []) or []
+            }
+            if case_type not in target_case_types:
+                continue
+            records.append(
+                _build_signal_record(
+                    example,
+                    model_spec=model_spec,
+                    runner=runner_by_model.get(str(model_spec.get("id") or "")),
+                )
+            )
+
+    return records
+
+
+def build_open_model_signal_report(
+    records: Sequence[Mapping[str, Any]],
+    *,
+    examples: Sequence[Mapping[str, Any]],
+    model_specs: Sequence[Mapping[str, Any]],
+    repo_root: str | Path,
+    model_catalog_path: str | Path,
+    case_source_manifest_path: str | Path,
+    output_path: str | Path,
+    report_path: str | Path,
+    include_local_seeds: bool,
+) -> dict[str, Any]:
+    """Summarize signal-record coverage and safety policy."""
+    counts_by_model: Counter[str] = Counter()
+    counts_by_case_type: Counter[str] = Counter()
+    counts_by_source_kind: Counter[str] = Counter()
+    for record in records:
+        counts_by_model[str(_mapping(record.get("model")).get("id") or "unknown")] += 1
+        counts_by_case_type[
+            str(_mapping(record.get("source_case")).get("case_type") or "unknown")
+        ] += 1
+        counts_by_source_kind[
+            str(_mapping(record.get("source")).get("kind") or "unknown")
+        ] += 1
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "case_type": SIGNAL_REPORT_CASE_TYPE,
+        "status": "needs_human_review",
+        "inputs": {
+            "repo_root": _safe_repo_root(repo_root),
+            "model_catalog_path": _safe_repo_path(model_catalog_path),
+            "case_source_manifest_path": _safe_repo_path(case_source_manifest_path),
+            "include_local_seeds": bool(include_local_seeds),
+            "model_ids": [str(item.get("id") or "") for item in model_specs],
+        },
+        "artifacts": {
+            "output_path": _safe_artifact_path(repo_root, output_path),
+            "report_path": _safe_artifact_path(repo_root, report_path),
+        },
+        "example_count": len(examples),
+        "record_count": len(records),
+        "counts_by_model": dict(sorted(counts_by_model.items())),
+        "counts_by_case_type": dict(sorted(counts_by_case_type.items())),
+        "counts_by_source_kind": dict(sorted(counts_by_source_kind.items())),
+        "training_use": {
+            "default_training_input": False,
+            "requires_manual_review_for_training_labels": True,
+            "review_status": "needs_human_review",
+        },
+        "runtime": {
+            "downloads_weights": False,
+            "calls_model_provider": False,
+            "uses_injected_runner": _uses_injected_runner(records),
+            "default_runtime_enabled": False,
+        },
+    }
+
+
+def _build_signal_record(
+    example: Mapping[str, Any],
+    *,
+    model_spec: Mapping[str, Any],
+    runner: SignalRunner | None,
+) -> dict[str, Any]:
+    source_case = _mapping(example.get("source_case"))
+    source = _safe_source_summary(_mapping(example.get("source")))
+    input_case = _mapping(_mapping(example.get("input")).get("case_record"))
+    model_id = str(model_spec.get("id") or "")
+    runner_output = dict(runner(example, model_spec)) if runner is not None else {}
+    if runner_output:
+        signals = dict(runner_output)
+        signals["signal_source"] = "injected_runner"
+    else:
+        signals = _dry_run_signals(input_case, model_spec=model_spec)
+    output_policy = str(model_spec.get("output_training_policy") or "")
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "case_type": SIGNAL_RECORD_CASE_TYPE,
+        "signal_id": _make_signal_id(example, model_id),
+        "example_id": str(example.get("example_id") or ""),
+        "source": source,
+        "source_case": {
+            "case_type": str(source_case.get("case_type") or ""),
+            "case_id": str(source_case.get("case_id") or ""),
+            "schema_version": int(source_case.get("schema_version") or 0),
+        },
+        "model": _safe_model_summary(model_spec),
+        "input_summary": _input_summary(input_case),
+        "signals": signals,
+        "training_use": {
+            "default_training_input": False,
+            "requires_manual_review_for_training_labels": bool(
+                model_spec.get("requires_manual_review_for_training_labels")
+            ),
+            "review_status": "needs_human_review",
+            "output_training_policy": output_policy,
+        },
+    }
+
+
+def _dry_run_signals(
+    case_record: Mapping[str, Any],
+    *,
+    model_spec: Mapping[str, Any],
+) -> dict[str, Any]:
+    model_role = str(model_spec.get("model_role") or "")
+    signal_families = {
+        "vision_caption_grounding_ocr": [
+            "caption_candidates",
+            "ocr_text_presence",
+            "dense_region_description",
+        ],
+        "mask_proposal": [
+            "mask_count_estimate",
+            "boundary_complexity",
+            "mask_coverage_candidates",
+        ],
+        "text_grounded_detection": [
+            "grounded_box_candidates",
+            "object_coverage",
+        ],
+    }.get(model_role, ["quality_signal"])
+
+    return {
+        "status": "dry_run_pending_model_execution",
+        "signal_source": "dry_run",
+        "model_role": model_role,
+        "planned_signal_families": signal_families,
+        "case_features": {
+            "has_source_image": bool(case_record.get("source_image")),
+            "has_outputs": bool(case_record.get("outputs")),
+            "has_quality_block": bool(case_record.get("quality")),
+            "has_layer_plan": bool(
+                _mapping(_mapping(case_record.get("inputs")).get("layer_plan"))
+            ),
+        },
+    }
+
+
+def _safe_model_summary(model_spec: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        "id": str(model_spec.get("id") or ""),
+        "name": str(model_spec.get("name") or ""),
+        "license": str(model_spec.get("license") or ""),
+        "license_risk": str(model_spec.get("license_risk") or ""),
+        "model_role": str(model_spec.get("model_role") or ""),
+        "output_training_policy": str(model_spec.get("output_training_policy") or ""),
+        "default_runtime_enabled": bool(model_spec.get("default_runtime_enabled")),
+    }
+
+
+def _safe_source_summary(source: Mapping[str, Any]) -> dict[str, Any]:
+    summary = {
+        "kind": str(source.get("kind") or ""),
+        "source_id": str(source.get("source_id") or ""),
+        "privacy_scope": str(source.get("privacy_scope") or ""),
+        "curation_status": str(source.get("curation_status") or ""),
+    }
+    if source.get("preferred_split"):
+        summary["preferred_split"] = str(source.get("preferred_split") or "")
+    if source.get("split"):
+        summary["split"] = str(source.get("split") or "")
+    return {key: value for key, value in summary.items() if value}
+
+
+def _input_summary(case_record: Mapping[str, Any]) -> dict[str, Any]:
+    inputs = _mapping(case_record.get("inputs"))
+    outputs = _mapping(case_record.get("outputs"))
+    quality = _mapping(case_record.get("quality"))
+    return {
+        "case_type": str(case_record.get("case_type") or ""),
+        "case_id": str(case_record.get("case_id") or ""),
+        "has_source_image": bool(case_record.get("source_image")),
+        "source_image_ref_kind": _ref_kind(str(case_record.get("source_image") or "")),
+        "input_keys": sorted(str(key) for key in inputs),
+        "output_keys": sorted(str(key) for key in outputs),
+        "quality_keys": sorted(str(key) for key in quality),
+    }
+
+
+def _ref_kind(ref: str) -> str:
+    if not ref:
+        return "missing"
+    if ref.startswith("private://"):
+        return "private_uri"
+    if ref.startswith("http://") or ref.startswith("https://"):
+        return "remote_url"
+    if Path(ref).is_absolute():
+        return "absolute_path"
+    return "repo_relative"
+
+
+def _make_signal_id(example: Mapping[str, Any], model_id: str) -> str:
+    seed = json.dumps(
+        {
+            "example_id": str(example.get("example_id") or ""),
+            "model_id": model_id,
+            "case_type": SIGNAL_RECORD_CASE_TYPE,
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    digest = hashlib.sha256(seed.encode("utf-8")).hexdigest()[:16]
+    return f"open_signal_{digest}"
+
+
+def _write_jsonl(path: str | Path, records: Sequence[Mapping[str, Any]]) -> None:
+    output_path = Path(path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with output_path.open("w", encoding="utf-8") as fh:
+        for record in records:
+            fh.write(json.dumps(dict(record), sort_keys=True, separators=(",", ":")))
+            fh.write("\n")
+
+
+def _resolve_repo_path(repo_root: str | Path, path: str | Path) -> Path:
+    resolved = Path(path)
+    if not resolved.is_absolute():
+        resolved = Path(repo_root) / resolved
+    return resolved
+
+
+def _safe_repo_path(path: str | Path) -> str:
+    parts = Path(path).parts
+    if "docs" in parts:
+        docs_index = parts.index("docs")
+        return str(Path(*parts[docs_index:]))
+    return Path(path).name
+
+
+def _safe_repo_root(path: str | Path) -> str:
+    return Path(path).name
+
+
+def _safe_artifact_path(repo_root: str | Path, path: str | Path) -> str:
+    artifact_path = Path(path)
+    try:
+        return str(artifact_path.relative_to(Path(repo_root)))
+    except ValueError:
+        return str(artifact_path)
+
+
+def _uses_injected_runner(records: Sequence[Mapping[str, Any]]) -> bool:
+    for record in records:
+        if str(_mapping(record.get("signals")).get("signal_source") or "") == (
+            "injected_runner"
+        ):
+            return True
+    return False
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    if isinstance(value, Mapping):
+        return value
+    return {}

--- a/tests/test_open_model_signal_adapter.py
+++ b/tests/test_open_model_signal_adapter.py
@@ -1,0 +1,173 @@
+import json
+import os
+import subprocess
+import sys
+from collections import Counter
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parent.parent
+CATALOG = ROOT / "docs/benchmarks/learning/open_source_model_catalog_v1.json"
+COMBINED_MANIFEST = (
+    ROOT / "docs/benchmarks/learning/combined_case_source_manifest_v1.json"
+)
+CLI_ENV = dict(
+    os.environ,
+    PYTHONPATH=str(ROOT / "src") + os.pathsep + os.environ.get("PYTHONPATH", ""),
+)
+
+
+def _read_jsonl(path: Path) -> list[dict]:
+    return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines()]
+
+
+def test_open_model_signal_adapter_writes_safe_dry_run_records(tmp_path):
+    from vulca.learning.open_model_signals import run_open_model_signal_adapter
+    from vulca.learning.tiny_dataset import build_tiny_dataset_examples
+
+    output_path = tmp_path / "signals.jsonl"
+    report_path = tmp_path / "report.json"
+
+    report = run_open_model_signal_adapter(
+        repo_root=ROOT,
+        output_path=output_path,
+        report_path=report_path,
+        model_catalog_path=CATALOG,
+        case_source_manifest_path=COMBINED_MANIFEST,
+        model_ids=("florence_2", "segment_anything_sam_vit"),
+    )
+
+    examples = build_tiny_dataset_examples(
+        repo_root=ROOT,
+        case_source_manifest_path=COMBINED_MANIFEST,
+    )
+    expected_count = sum(
+        1
+        for item in examples
+        if item["source_case"]["case_type"]
+        in {"redraw_case", "decompose_case", "layer_generate_case"}
+    )
+    expected_count += sum(
+        1
+        for item in examples
+        if item["source_case"]["case_type"] in {"redraw_case", "decompose_case"}
+    )
+
+    records = _read_jsonl(output_path)
+    encoded = output_path.read_text(encoding="utf-8")
+    assert len(records) == expected_count
+    assert report["record_count"] == expected_count
+    assert json.loads(report_path.read_text(encoding="utf-8")) == report
+    assert "/Users/" not in encoded
+    assert "private://local_path/" not in encoded
+
+    counts_by_model = Counter(item["model"]["id"] for item in records)
+    assert counts_by_model["florence_2"] == len(examples)
+    assert counts_by_model["segment_anything_sam_vit"] == sum(
+        1
+        for item in examples
+        if item["source_case"]["case_type"] in {"redraw_case", "decompose_case"}
+    )
+
+    first = records[0]
+    assert first["case_type"] == "learning_open_model_signal_record"
+    assert first["schema_version"] == 1
+    assert first["signal_id"].startswith("open_signal_")
+    assert first["model"]["default_runtime_enabled"] is False
+    assert first["training_use"] == {
+        "default_training_input": False,
+        "requires_manual_review_for_training_labels": True,
+        "review_status": "needs_human_review",
+        "output_training_policy": first["model"]["output_training_policy"],
+    }
+    assert first["signals"]["status"] == "dry_run_pending_model_execution"
+    assert first["signals"]["signal_source"] == "dry_run"
+    assert "review" not in json.dumps(first["input_summary"], sort_keys=True)
+    assert "learning_targets" not in json.dumps(first["input_summary"], sort_keys=True)
+
+
+def test_open_model_signal_adapter_rejects_blocked_models_by_default():
+    from vulca.learning.open_model_signals import select_open_model_specs
+
+    with pytest.raises(ValueError, match="not eligible for signal pilot"):
+        select_open_model_specs(
+            CATALOG,
+            model_ids=("flux_kontext_dev",),
+        )
+
+    with pytest.raises(ValueError, match="unknown open model id"):
+        select_open_model_specs(
+            CATALOG,
+            model_ids=("missing_model",),
+        )
+
+
+def test_open_model_signal_adapter_uses_injected_runner_outputs():
+    from vulca.learning.open_model_signals import (
+        build_open_model_signal_records,
+        select_open_model_specs,
+    )
+    from vulca.learning.tiny_dataset import build_tiny_dataset_examples
+
+    examples = build_tiny_dataset_examples(
+        repo_root=ROOT,
+        case_source_manifest_path=COMBINED_MANIFEST,
+    )
+    model_specs = select_open_model_specs(CATALOG, model_ids=("florence_2",))
+
+    def fake_florence_runner(example, model):
+        return {
+            "status": "completed",
+            "caption_candidates": [
+                f"{model['id']} saw {example['source_case']['case_type']}"
+            ],
+            "ocr_text_count": 0,
+        }
+
+    records = build_open_model_signal_records(
+        examples[:2],
+        model_specs=model_specs,
+        runners={"florence_2": fake_florence_runner},
+    )
+
+    assert len(records) == 2
+    assert records[0]["signals"]["status"] == "completed"
+    assert records[0]["signals"]["signal_source"] == "injected_runner"
+    assert records[0]["signals"]["caption_candidates"] == [
+        f"florence_2 saw {examples[0]['source_case']['case_type']}"
+    ]
+    assert records[0]["training_use"]["review_status"] == "needs_human_review"
+
+
+def test_open_model_signal_adapter_cli_writes_report(tmp_path):
+    output_path = tmp_path / "signals.jsonl"
+    report_path = tmp_path / "report.json"
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(ROOT / "scripts/open_model_signal_adapter.py"),
+            "--output",
+            str(output_path),
+            "--report",
+            str(report_path),
+            "--model",
+            "florence_2",
+            "--model",
+            "segment_anything_sam_vit",
+        ],
+        cwd=ROOT,
+        env=CLI_ENV,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    report = json.loads(report_path.read_text(encoding="utf-8"))
+    assert output_path.exists()
+    assert report["case_type"] == "learning_open_model_signal_report"
+    assert report["record_count"] == len(_read_jsonl(output_path))
+    assert "Open model signal records:" in result.stdout


### PR DESCRIPTION
## Summary
- add a safe open-model signal adapter for Florence-2 and SAM pilot signals
- export reviewable signal JSONL/report from the combined tiny learning cases
- keep runtime disabled: no weight downloads, no provider calls, no generated labels as training data
- block non-eligible catalog models by default and require human review before training use

## Smoke result
- Generated 77 signal records from 50 examples using florence_2 + segment_anything_sam_vit
- No /Users/, private://local_path/, review, or learning_targets leakage in generated signal JSONL

## Verification
- PYTHONPATH=src /opt/homebrew/bin/python3.11 -m pytest tests/test_open_model_signal_adapter.py tests/test_open_source_model_catalog_v1.py tests/test_combined_learning_sources_v1.py tests/test_tiny_dataset_export.py -q
- PYTHONPATH=src /opt/homebrew/bin/python3.11 scripts/open_model_signal_adapter.py --output /tmp/vulca_open_model_signals.jsonl --report /tmp/vulca_open_model_signal_report.json
- /opt/homebrew/bin/python3.11 -m py_compile src/vulca/learning/open_model_signals.py scripts/open_model_signal_adapter.py
- ruff check src/vulca/learning/open_model_signals.py scripts/open_model_signal_adapter.py tests/test_open_model_signal_adapter.py
- git diff --check