### PR TITLE
Add Florence local signal runner

### DIFF
--- a/docs/superpowers/plans/2026-05-06-florence-local-signal-runner-v1.md
+++ b/docs/superpowers/plans/2026-05-06-florence-local-signal-runner-v1.md
@@ -1,0 +1,50 @@
+# Florence Local Signal Runner v1
+
+Status: implemented
+
+## Goal
+
+Add the first explicit local model runner behind the open-model signal adapter. The runner targets Florence-2 caption/OCR signals and keeps outputs as reviewable weak signals, not training labels.
+
+## Runtime Boundary
+
+- Default adapter behavior remains dry-run.
+- Local Florence execution requires `--enable-local-runner florence_2`.
+- Weight download is disabled unless `--allow-weight-download` is passed.
+- Outputs remain `assistant_labeled` plus `needs_human_review`.
+- Outputs are not added to `combined_case_source_manifest_v1`.
+- Private source refs and missing images are skipped without leaking the original path.
+
+## CLI Pilot
+
+Cached-weights-only pilot:
+
+```bash
+PYTHONPATH=src python scripts/open_model_signal_adapter.py \
+  --model florence_2 \
+  --enable-local-runner florence_2 \
+  --max-examples 3 \
+  --output build/open_model_signal_adapter/florence_local_signals.jsonl \
+  --report build/open_model_signal_adapter/florence_local_signal_report.json
+```
+
+Explicit download pilot:
+
+```bash
+PYTHONPATH=src python scripts/open_model_signal_adapter.py \
+  --model florence_2 \
+  --enable-local-runner florence_2 \
+  --allow-weight-download \
+  --max-examples 3
+```
+
+## Non-Goals
+
+- Do not add SAM local execution in this branch.
+- Do not train a model from Florence outputs.
+- Do not treat captions or OCR as accepted labels.
+- Do not call cloud providers.
+
+## Verification
+
+- `tests/test_florence_signal_runner.py` covers local runner normalization, private source skips, adapter enablement, and CLI flags.

--- a/scripts/open_model_signal_adapter.py
+++ b/scripts/open_model_signal_adapter.py
@@ -63,6 +63,39 @@ def main(argv: Sequence[str] | None = None) -> int:
         help="Open model id to include; repeat for multiple models.",
     )
     parser.add_argument(
+        "--enable-local-runner",
+        action="append",
+        default=[],
+        help=(
+            "Explicitly run a local model runner for the given model id. "
+            "Currently supports florence_2."
+        ),
+    )
+    parser.add_argument(
+        "--max-examples",
+        type=int,
+        default=None,
+        help="Limit source examples before model expansion for local pilot runs.",
+    )
+    parser.add_argument(
+        "--allow-weight-download",
+        action="store_true",
+        help=(
+            "Allow local runners to download open model weights. Without this, "
+            "local runners use cached weights only."
+        ),
+    )
+    parser.add_argument(
+        "--florence-model-id",
+        default="microsoft/Florence-2-base",
+        help="Florence-2 model id for --enable-local-runner florence_2.",
+    )
+    parser.add_argument(
+        "--florence-device",
+        default="auto",
+        help="Florence-2 device for local runner execution: auto, cpu, mps, or cuda.",
+    )
+    parser.add_argument(
         "--no-local-seeds",
         action="store_true",
         help="Only use records from the case source manifest.",
@@ -83,8 +116,13 @@ def main(argv: Sequence[str] | None = None) -> int:
             case_source_manifest_path=args.case_source_manifest,
             model_ids=tuple(args.model) or DEFAULT_MODEL_IDS,
             include_local_seeds=not args.no_local_seeds,
+            enable_local_runners=tuple(args.enable_local_runner),
+            max_examples=args.max_examples,
+            allow_weight_download=args.allow_weight_download,
+            florence_model_id=args.florence_model_id,
+            florence_device=args.florence_device,
         )
-    except (FileNotFoundError, ValueError, json.JSONDecodeError) as exc:
+    except (FileNotFoundError, RuntimeError, ValueError, json.JSONDecodeError) as exc:
         print(f"Error: {exc}", file=sys.stderr)
         return 2
 

--- a/src/vulca/learning/florence_signal_runner.py
+++ b/src/vulca/learning/florence_signal_runner.py
@@ -1,0 +1,315 @@
+"""Explicit local Florence-2 runner for open-model signal records.
+
+The runner is opt-in and produces reviewable signals only. It does not turn
+model output into training labels.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping, Protocol
+
+from PIL import Image
+
+
+DEFAULT_FLORENCE_MODEL_ID = "microsoft/Florence-2-base"
+
+
+class FlorenceSignalBackend(Protocol):
+    def run(
+        self,
+        image_path: str | Path,
+        *,
+        case_record: Mapping[str, Any],
+        model_spec: Mapping[str, Any],
+    ) -> Mapping[str, Any]:
+        """Run Florence on a local image and return raw signal fields."""
+
+
+@dataclass(frozen=True)
+class ResolvedSourceImage:
+    path: Path | None
+    ref_kind: str
+
+
+def build_florence2_signal_runner(
+    *,
+    repo_root: str | Path,
+    backend: FlorenceSignalBackend | None = None,
+    model_id: str = DEFAULT_FLORENCE_MODEL_ID,
+    device: str = "auto",
+    allow_weight_download: bool = False,
+) -> Any:
+    """Build a local Florence-2 signal runner.
+
+    ``allow_weight_download`` defaults to False, so the real backend uses
+    local cached weights unless the caller explicitly opts into downloads.
+    """
+    root = Path(repo_root)
+    resolved_backend = backend or Florence2LocalBackend(
+        model_id=model_id,
+        device=device,
+        local_files_only=not allow_weight_download,
+    )
+
+    def run(example: Mapping[str, Any], model_spec: Mapping[str, Any]) -> dict[str, Any]:
+        case_record = _case_record_from_example(example)
+        source = resolve_case_source_image_path(case_record, repo_root=root)
+        if source.path is None:
+            return {
+                "status": "skipped",
+                "skip_reason": "source_image_unavailable",
+                "signal_source": "local_runner",
+                "label_source": "assistant_labeled",
+                "review_status": "needs_human_review",
+                "source_image": {
+                    "available": False,
+                    "ref_kind": source.ref_kind,
+                },
+            }
+
+        image_info = _image_info(source.path)
+        backend_signals = dict(
+            resolved_backend.run(
+                source.path,
+                case_record=case_record,
+                model_spec=model_spec,
+            )
+        )
+        normalized = _normalize_backend_signals(backend_signals)
+        normalized.update(
+            {
+                "status": "completed",
+                "signal_source": "local_runner",
+                "label_source": "assistant_labeled",
+                "review_status": "needs_human_review",
+                "source_image": {
+                    "available": True,
+                    "ref_kind": source.ref_kind,
+                    "width": image_info["width"],
+                    "height": image_info["height"],
+                },
+            }
+        )
+        return normalized
+
+    return run
+
+
+def resolve_case_source_image_path(
+    case_record: Mapping[str, Any],
+    *,
+    repo_root: str | Path,
+) -> ResolvedSourceImage:
+    """Resolve a case source image to a local path without leaking private refs."""
+    ref = _source_image_ref(case_record)
+    if not ref:
+        return ResolvedSourceImage(path=None, ref_kind="missing")
+    ref_kind = _ref_kind(ref)
+    if ref_kind in {"private_uri", "remote_url"}:
+        return ResolvedSourceImage(path=None, ref_kind=ref_kind)
+
+    candidate = Path(ref)
+    if not candidate.is_absolute():
+        candidate = Path(repo_root) / candidate
+    if not candidate.exists():
+        return ResolvedSourceImage(path=None, ref_kind=ref_kind)
+    return ResolvedSourceImage(path=candidate, ref_kind=ref_kind)
+
+
+class Florence2LocalBackend:
+    """Lazy Florence-2 backend using transformers when explicitly enabled."""
+
+    def __init__(
+        self,
+        *,
+        model_id: str = DEFAULT_FLORENCE_MODEL_ID,
+        device: str = "auto",
+        local_files_only: bool = True,
+        max_new_tokens: int = 256,
+        num_beams: int = 3,
+    ) -> None:
+        self.model_id = model_id
+        self.device = device
+        self.local_files_only = local_files_only
+        self.max_new_tokens = max_new_tokens
+        self.num_beams = num_beams
+        self._processor = None
+        self._model = None
+        self._torch = None
+
+    def run(
+        self,
+        image_path: str | Path,
+        *,
+        case_record: Mapping[str, Any],
+        model_spec: Mapping[str, Any],
+    ) -> Mapping[str, Any]:
+        processor, model, torch, device = self._load()
+        image = Image.open(image_path).convert("RGB")
+        caption = self._run_task(
+            "<CAPTION>",
+            image=image,
+            processor=processor,
+            model=model,
+            torch=torch,
+            device=device,
+        )
+        ocr = self._run_task(
+            "<OCR>",
+            image=image,
+            processor=processor,
+            model=model,
+            torch=torch,
+            device=device,
+        )
+        return {
+            "caption_candidates": _as_text_list(caption),
+            "ocr_text": _as_text_list(ocr),
+            "dense_region_descriptions": [],
+        }
+
+    def _load(self):
+        if self._processor is not None and self._model is not None:
+            return self._processor, self._model, self._torch, self._resolved_device()
+
+        try:
+            import torch
+            from transformers import AutoModelForCausalLM, AutoProcessor
+        except ImportError as exc:
+            raise RuntimeError(
+                "Florence-2 local runner requires transformers and torch. "
+                "Install vulca[layers-full] or the equivalent optional deps."
+            ) from exc
+
+        device = self._resolved_device(torch)
+        self._processor = AutoProcessor.from_pretrained(
+            self.model_id,
+            trust_remote_code=True,
+            local_files_only=self.local_files_only,
+        )
+        self._model = AutoModelForCausalLM.from_pretrained(
+            self.model_id,
+            trust_remote_code=True,
+            local_files_only=self.local_files_only,
+            torch_dtype=torch.float32,
+        ).to(device).eval()
+        self._torch = torch
+        return self._processor, self._model, self._torch, device
+
+    def _resolved_device(self, torch_module=None) -> str:
+        torch = torch_module or self._torch
+        if self.device != "auto":
+            return self.device
+        if torch is None:
+            return "cpu"
+        if (
+            getattr(torch.backends, "mps", None) is not None
+            and torch.backends.mps.is_available()
+        ):
+            return "mps"
+        if torch.cuda.is_available():
+            return "cuda"
+        return "cpu"
+
+    def _run_task(
+        self,
+        task: str,
+        *,
+        image: Image.Image,
+        processor,
+        model,
+        torch,
+        device: str,
+    ) -> Any:
+        inputs = processor(text=task, images=image, return_tensors="pt")
+        inputs = {
+            key: value.to(device) if hasattr(value, "to") else value
+            for key, value in inputs.items()
+        }
+        with torch.no_grad():
+            generated = model.generate(
+                input_ids=inputs["input_ids"],
+                pixel_values=inputs["pixel_values"],
+                max_new_tokens=self.max_new_tokens,
+                num_beams=self.num_beams,
+                do_sample=False,
+            )
+        decoded = processor.batch_decode(generated, skip_special_tokens=False)[0]
+        parsed = processor.post_process_generation(
+            decoded,
+            task=task,
+            image_size=image.size,
+        )
+        if isinstance(parsed, Mapping):
+            return parsed.get(task, parsed)
+        return parsed
+
+
+def _case_record_from_example(example: Mapping[str, Any]) -> Mapping[str, Any]:
+    input_block = example.get("input")
+    if isinstance(input_block, Mapping):
+        case_record = input_block.get("case_record")
+        if isinstance(case_record, Mapping):
+            return case_record
+    return {}
+
+
+def _source_image_ref(case_record: Mapping[str, Any]) -> str:
+    direct = str(case_record.get("source_image") or "")
+    if direct:
+        return direct
+    for key in ("input", "inputs"):
+        nested = case_record.get(key)
+        if isinstance(nested, Mapping):
+            value = str(nested.get("source_image") or "")
+            if value:
+                return value
+    return ""
+
+
+def _ref_kind(ref: str) -> str:
+    if not ref:
+        return "missing"
+    if ref.startswith("private://"):
+        return "private_uri"
+    if ref.startswith("http://") or ref.startswith("https://"):
+        return "remote_url"
+    if Path(ref).is_absolute():
+        return "absolute_path"
+    return "repo_relative"
+
+
+def _image_info(path: Path) -> dict[str, int]:
+    with Image.open(path) as image:
+        return {"width": int(image.width), "height": int(image.height)}
+
+
+def _normalize_backend_signals(signals: Mapping[str, Any]) -> dict[str, Any]:
+    caption_candidates = _as_text_list(signals.get("caption_candidates"))
+    ocr_text = _as_text_list(signals.get("ocr_text"))
+    dense_region_descriptions = _as_text_list(signals.get("dense_region_descriptions"))
+    return {
+        "caption_candidates": caption_candidates,
+        "ocr_text": ocr_text,
+        "ocr_text_count": len(ocr_text),
+        "dense_region_descriptions": dense_region_descriptions,
+    }
+
+
+def _as_text_list(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return [value] if value else []
+    if isinstance(value, Mapping):
+        texts: list[str] = []
+        for child in value.values():
+            texts.extend(_as_text_list(child))
+        return texts
+    if isinstance(value, (list, tuple)):
+        texts = []
+        for item in value:
+            texts.extend(_as_text_list(item))
+        return texts
+    return [str(value)]

--- a/src/vulca/learning/open_model_signals.py
+++ b/src/vulca/learning/open_model_signals.py
@@ -35,6 +35,7 @@ DEFAULT_MODEL_IDS: tuple[str, ...] = (
 ELIGIBLE_INTAKE_STATUSES: frozenset[str] = frozenset({"recommended_pilot"})
 
 SignalRunner = Callable[[Mapping[str, Any], Mapping[str, Any]], Mapping[str, Any]]
+LocalRunnerFactory = Callable[..., SignalRunner]
 
 
 def run_open_model_signal_adapter(
@@ -47,8 +48,17 @@ def run_open_model_signal_adapter(
     model_ids: Sequence[str] = DEFAULT_MODEL_IDS,
     include_local_seeds: bool = True,
     runners: Mapping[str, SignalRunner] | None = None,
+    enable_local_runners: Sequence[str] = (),
+    local_runner_factories: Mapping[str, LocalRunnerFactory] | None = None,
+    max_examples: int | None = None,
+    allow_weight_download: bool = False,
+    florence_model_id: str = "microsoft/Florence-2-base",
+    florence_device: str = "auto",
 ) -> dict[str, Any]:
     """Write dry-run or injected open-model signal records and a summary report."""
+    if max_examples is not None and max_examples < 0:
+        raise ValueError("max_examples must be >= 0")
+
     root = Path(repo_root)
     resolved_catalog_path = _resolve_repo_path(root, model_catalog_path)
     resolved_manifest_path = _resolve_repo_path(root, case_source_manifest_path)
@@ -64,14 +74,26 @@ def run_open_model_signal_adapter(
         case_source_manifest_path=resolved_manifest_path,
         include_local_seeds=include_local_seeds,
     )
+    if max_examples is not None:
+        examples = examples[:max_examples]
     model_specs = select_open_model_specs(
         resolved_catalog_path,
         model_ids=model_ids,
     )
+    runner_map = _build_runner_map(
+        root,
+        runners=runners,
+        enable_local_runners=enable_local_runners,
+        local_runner_factories=local_runner_factories,
+        model_ids=[str(item.get("id") or "") for item in model_specs],
+        allow_weight_download=allow_weight_download,
+        florence_model_id=florence_model_id,
+        florence_device=florence_device,
+    )
     records = build_open_model_signal_records(
         examples,
         model_specs=model_specs,
-        runners=runners,
+        runners=runner_map,
     )
 
     _write_jsonl(resolved_output_path, records)
@@ -85,6 +107,9 @@ def run_open_model_signal_adapter(
         output_path=resolved_output_path,
         report_path=resolved_report_path,
         include_local_seeds=include_local_seeds,
+        enable_local_runners=enable_local_runners,
+        max_examples=max_examples,
+        weight_download_enabled=allow_weight_download,
     )
     resolved_report_path.parent.mkdir(parents=True, exist_ok=True)
     resolved_report_path.write_text(
@@ -188,6 +213,9 @@ def build_open_model_signal_report(
     output_path: str | Path,
     report_path: str | Path,
     include_local_seeds: bool,
+    enable_local_runners: Sequence[str] = (),
+    max_examples: int | None = None,
+    weight_download_enabled: bool = False,
 ) -> dict[str, Any]:
     """Summarize signal-record coverage and safety policy."""
     counts_by_model: Counter[str] = Counter()
@@ -212,6 +240,8 @@ def build_open_model_signal_report(
             "case_source_manifest_path": _safe_repo_path(case_source_manifest_path),
             "include_local_seeds": bool(include_local_seeds),
             "model_ids": [str(item.get("id") or "") for item in model_specs],
+            "enable_local_runners": [str(item) for item in enable_local_runners],
+            "max_examples": max_examples,
         },
         "artifacts": {
             "output_path": _safe_artifact_path(repo_root, output_path),
@@ -229,8 +259,10 @@ def build_open_model_signal_report(
         },
         "runtime": {
             "downloads_weights": False,
+            "weight_download_enabled": bool(weight_download_enabled),
             "calls_model_provider": False,
             "uses_injected_runner": _uses_injected_runner(records),
+            "uses_local_runner": _uses_local_runner(records),
             "default_runtime_enabled": False,
         },
     }
@@ -249,7 +281,7 @@ def _build_signal_record(
     runner_output = dict(runner(example, model_spec)) if runner is not None else {}
     if runner_output:
         signals = dict(runner_output)
-        signals["signal_source"] = "injected_runner"
+        signals.setdefault("signal_source", "injected_runner")
     else:
         signals = _dry_run_signals(input_case, model_spec=model_spec)
     output_policy = str(model_spec.get("output_training_policy") or "")
@@ -316,6 +348,46 @@ def _dry_run_signals(
             ),
         },
     }
+
+
+def _build_runner_map(
+    repo_root: Path,
+    *,
+    runners: Mapping[str, SignalRunner] | None,
+    enable_local_runners: Sequence[str],
+    local_runner_factories: Mapping[str, LocalRunnerFactory] | None,
+    model_ids: Sequence[str],
+    allow_weight_download: bool,
+    florence_model_id: str,
+    florence_device: str,
+) -> dict[str, SignalRunner]:
+    runner_map = dict(runners or {})
+    model_id_set = {str(item) for item in model_ids}
+    factories = dict(local_runner_factories or {})
+    for raw_model_id in enable_local_runners:
+        model_id = str(raw_model_id)
+        if model_id not in model_id_set:
+            raise ValueError(
+                f"local runner {model_id!r} was enabled but the model is not selected"
+            )
+        if model_id in runner_map:
+            raise ValueError(f"runner for model {model_id!r} is already provided")
+        factory = factories.get(model_id)
+        if factory is None:
+            if model_id != "florence_2":
+                raise ValueError(f"no local runner is available for model {model_id!r}")
+            from vulca.learning.florence_signal_runner import (
+                build_florence2_signal_runner,
+            )
+
+            factory = build_florence2_signal_runner
+        runner_map[model_id] = factory(
+            repo_root=repo_root,
+            allow_weight_download=allow_weight_download,
+            model_id=florence_model_id,
+            device=florence_device,
+        )
+    return runner_map
 
 
 def _safe_model_summary(model_spec: Mapping[str, Any]) -> dict[str, Any]:
@@ -425,6 +497,15 @@ def _uses_injected_runner(records: Sequence[Mapping[str, Any]]) -> bool:
     for record in records:
         if str(_mapping(record.get("signals")).get("signal_source") or "") == (
             "injected_runner"
+        ):
+            return True
+    return False
+
+
+def _uses_local_runner(records: Sequence[Mapping[str, Any]]) -> bool:
+    for record in records:
+        if str(_mapping(record.get("signals")).get("signal_source") or "") == (
+            "local_runner"
         ):
             return True
     return False

--- a/tests/test_florence_signal_runner.py
+++ b/tests/test_florence_signal_runner.py
@@ -1,0 +1,214 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from PIL import Image
+
+
+ROOT = Path(__file__).resolve().parent.parent
+CATALOG = ROOT / "docs/benchmarks/learning/open_source_model_catalog_v1.json"
+COMBINED_MANIFEST = (
+    ROOT / "docs/benchmarks/learning/combined_case_source_manifest_v1.json"
+)
+
+
+def _example_with_source(source_image: str) -> dict:
+    return {
+        "example_id": "tiny_test",
+        "source_case": {
+            "case_type": "redraw_case",
+            "case_id": "case_test",
+            "schema_version": 1,
+        },
+        "input": {
+            "case_record": {
+                "case_type": "redraw_case",
+                "case_id": "case_test",
+                "source_image": source_image,
+            }
+        },
+    }
+
+
+class FakeFlorenceBackend:
+    def __init__(self):
+        self.calls = []
+
+    def run(self, image_path, *, case_record, model_spec):
+        self.calls.append(
+            {
+                "image_path": str(image_path),
+                "case_id": case_record["case_id"],
+                "model_id": model_spec["id"],
+            }
+        )
+        return {
+            "caption_candidates": ["a small red square"],
+            "ocr_text": ["SALE"],
+            "dense_region_descriptions": ["red square centered on canvas"],
+        }
+
+
+def test_florence_runner_returns_local_assistant_labeled_signals(tmp_path):
+    from vulca.learning.florence_signal_runner import build_florence2_signal_runner
+
+    image_path = tmp_path / "source.png"
+    Image.new("RGB", (8, 6), (255, 0, 0)).save(image_path)
+    backend = FakeFlorenceBackend()
+    runner = build_florence2_signal_runner(
+        repo_root=tmp_path,
+        backend=backend,
+    )
+
+    signals = runner(
+        _example_with_source("source.png"),
+        {"id": "florence_2", "model_role": "vision_caption_grounding_ocr"},
+    )
+
+    assert signals["status"] == "completed"
+    assert signals["signal_source"] == "local_runner"
+    assert signals["label_source"] == "assistant_labeled"
+    assert signals["review_status"] == "needs_human_review"
+    assert signals["caption_candidates"] == ["a small red square"]
+    assert signals["ocr_text"] == ["SALE"]
+    assert signals["ocr_text_count"] == 1
+    assert signals["source_image"] == {
+        "available": True,
+        "ref_kind": "repo_relative",
+        "width": 8,
+        "height": 6,
+    }
+    assert backend.calls == [
+        {
+            "image_path": str(image_path),
+            "case_id": "case_test",
+            "model_id": "florence_2",
+        }
+    ]
+
+
+def test_florence_runner_skips_private_or_missing_source_without_leaking_path(tmp_path):
+    from vulca.learning.florence_signal_runner import build_florence2_signal_runner
+
+    runner = build_florence2_signal_runner(
+        repo_root=tmp_path,
+        backend=FakeFlorenceBackend(),
+    )
+
+    signals = runner(
+        _example_with_source("private://local_path/abc/source.png"),
+        {"id": "florence_2", "model_role": "vision_caption_grounding_ocr"},
+    )
+
+    encoded = json.dumps(signals, sort_keys=True)
+    assert signals["status"] == "skipped"
+    assert signals["skip_reason"] == "source_image_unavailable"
+    assert signals["signal_source"] == "local_runner"
+    assert signals["review_status"] == "needs_human_review"
+    assert signals["source_image"] == {
+        "available": False,
+        "ref_kind": "private_uri",
+    }
+    assert "private://local_path" not in encoded
+    assert "/Users/" not in encoded
+
+
+def test_open_model_adapter_enables_florence_local_runner_with_factory(tmp_path):
+    from vulca.learning.florence_signal_runner import build_florence2_signal_runner
+    from vulca.learning.open_model_signals import run_open_model_signal_adapter
+
+    image_path = tmp_path / "source.png"
+    Image.new("RGB", (4, 3), (0, 0, 255)).save(image_path)
+    case_log = tmp_path / "cases.jsonl"
+    case_log.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "case_type": "redraw_case",
+                "case_id": "local_florence_case",
+                "created_at": "2026-05-06T00:00:00Z",
+                "source_image": str(image_path),
+                "review": {
+                    "human_accept": False,
+                    "failure_type": "style_drift",
+                    "preferred_action": "adjust_instruction",
+                },
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    manifest = tmp_path / "manifest.json"
+    manifest.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "case_type": "learning_tiny_case_source_manifest",
+                "sources": [
+                    {
+                        "source_id": "local_florence_case_log",
+                        "kind": "manual_case_log",
+                        "path": str(case_log),
+                        "privacy_scope": "project",
+                        "curation_status": "curated",
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    output_path = tmp_path / "signals.jsonl"
+    report_path = tmp_path / "report.json"
+    backend = FakeFlorenceBackend()
+
+    report = run_open_model_signal_adapter(
+        repo_root=ROOT,
+        output_path=output_path,
+        report_path=report_path,
+        model_catalog_path=CATALOG,
+        case_source_manifest_path=manifest,
+        model_ids=("florence_2",),
+        include_local_seeds=False,
+        enable_local_runners=("florence_2",),
+        local_runner_factories={
+            "florence_2": lambda **kwargs: build_florence2_signal_runner(
+                backend=backend,
+                **kwargs,
+            )
+        },
+    )
+
+    records = [
+        json.loads(line)
+        for line in output_path.read_text(encoding="utf-8").splitlines()
+    ]
+    assert report["record_count"] == 1
+    assert report["runtime"]["uses_local_runner"] is True
+    assert report["runtime"]["calls_model_provider"] is False
+    assert report["runtime"]["downloads_weights"] is False
+    assert report["runtime"]["weight_download_enabled"] is False
+    assert records[0]["signals"]["status"] == "completed"
+    assert records[0]["signals"]["signal_source"] == "local_runner"
+    assert records[0]["signals"]["label_source"] == "assistant_labeled"
+    assert records[0]["training_use"]["review_status"] == "needs_human_review"
+    assert "review" not in json.dumps(records[0]["input_summary"], sort_keys=True)
+
+
+def test_open_model_signal_adapter_cli_exposes_local_runner_flags():
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(ROOT / "scripts/open_model_signal_adapter.py"),
+            "--help",
+        ],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert "--enable-local-runner" in result.stdout
+    assert "--allow-weight-download" in result.stdout
+    assert "--max-examples" in result.stdout


### PR DESCRIPTION
## Summary
- add an explicit opt-in Florence-2 local runner for open-model signal records
- keep the default adapter path as dry-run; local runner only runs with --enable-local-runner florence_2
- keep weight download disabled unless --allow-weight-download is passed
- mark Florence outputs as assistant_labeled + needs_human_review, never as training input
- skip private or missing source images without leaking original private refs

## Smoke result
- Dry-run CLI with --model florence_2 --max-examples 3 generated 3 signal records from 3 examples
- Output grep found no /Users/, private://local_path/, review, or learning_targets leakage

## Verification
- PYTHONPATH=src /opt/homebrew/bin/python3.11 -m pytest tests/test_florence_signal_runner.py tests/test_open_model_signal_adapter.py tests/test_open_source_model_catalog_v1.py tests/test_combined_learning_sources_v1.py tests/test_tiny_dataset_export.py -q
- /opt/homebrew/bin/python3.11 -m py_compile src/vulca/learning/florence_signal_runner.py src/vulca/learning/open_model_signals.py scripts/open_model_signal_adapter.py
- ruff check src/vulca/learning/florence_signal_runner.py src/vulca/learning/open_model_signals.py scripts/open_model_signal_adapter.py tests/test_florence_signal_runner.py
- PYTHONPATH=src /opt/homebrew/bin/python3.11 scripts/open_model_signal_adapter.py --model florence_2 --max-examples 3 --output /tmp/vulca_florence_dry_signals.jsonl --report /tmp/vulca_florence_dry_report.json
- git diff --check