### PR TITLE
Add SAM local signal runner

### DIFF
--- a/docs/superpowers/plans/2026-05-06-sam-local-signal-runner-v1.md
+++ b/docs/superpowers/plans/2026-05-06-sam-local-signal-runner-v1.md
@@ -1,0 +1,51 @@
+# SAM Local Signal Runner v1
+
+Status: implemented
+
+## Goal
+
+Add an explicit local SAM signal runner behind the open-model signal adapter. The runner produces reviewable mask proposal signals for redraw and decompose cases: mask count, coverage candidates, total coverage, and lightweight boundary complexity.
+
+## Runtime Boundary
+
+- Default adapter behavior remains dry-run.
+- Local SAM execution requires `--enable-local-runner segment_anything_sam_vit`.
+- The real backend never downloads weights.
+- Real SAM execution requires `--sam-checkpoint`.
+- Outputs remain `assistant_labeled` plus `needs_human_review`.
+- Outputs are not added to `combined_case_source_manifest_v1`.
+- Private or missing source refs are skipped without leaking original refs.
+
+## CLI Pilot
+
+Dry-run smoke:
+
+```bash
+PYTHONPATH=src python scripts/open_model_signal_adapter.py \
+  --model segment_anything_sam_vit \
+  --max-examples 3
+```
+
+Explicit local SAM pilot:
+
+```bash
+PYTHONPATH=src python scripts/open_model_signal_adapter.py \
+  --model segment_anything_sam_vit \
+  --enable-local-runner segment_anything_sam_vit \
+  --sam-checkpoint /path/to/sam_vit_b.pth \
+  --sam-model-type vit_b \
+  --sam-points-per-side 16 \
+  --max-examples 3
+```
+
+## Non-Goals
+
+- Do not convert masks into accepted labels.
+- Do not train a model from SAM outputs.
+- Do not add SAM outputs to the combined training manifest.
+- Do not call cloud providers.
+- Do not auto-download checkpoints.
+
+## Verification
+
+- `tests/test_sam_signal_runner.py` covers mask normalization, private source skips, adapter enablement, and CLI flags.

--- a/scripts/open_model_signal_adapter.py
+++ b/scripts/open_model_signal_adapter.py
@@ -96,6 +96,30 @@ def main(argv: Sequence[str] | None = None) -> int:
         help="Florence-2 device for local runner execution: auto, cpu, mps, or cuda.",
     )
     parser.add_argument(
+        "--sam-checkpoint",
+        default="",
+        help=(
+            "Local SAM v1 checkpoint path for "
+            "--enable-local-runner segment_anything_sam_vit."
+        ),
+    )
+    parser.add_argument(
+        "--sam-model-type",
+        default="vit_b",
+        help="SAM model type for local runner execution, e.g. vit_b, vit_l, vit_h.",
+    )
+    parser.add_argument(
+        "--sam-device",
+        default="auto",
+        help="SAM device for local runner execution: auto, cpu, mps, or cuda.",
+    )
+    parser.add_argument(
+        "--sam-points-per-side",
+        type=int,
+        default=16,
+        help="SAM automatic mask generator points_per_side for local pilot runs.",
+    )
+    parser.add_argument(
         "--no-local-seeds",
         action="store_true",
         help="Only use records from the case source manifest.",
@@ -121,6 +145,10 @@ def main(argv: Sequence[str] | None = None) -> int:
             allow_weight_download=args.allow_weight_download,
             florence_model_id=args.florence_model_id,
             florence_device=args.florence_device,
+            sam_checkpoint=args.sam_checkpoint or None,
+            sam_model_type=args.sam_model_type,
+            sam_device=args.sam_device,
+            sam_points_per_side=args.sam_points_per_side,
         )
     except (FileNotFoundError, RuntimeError, ValueError, json.JSONDecodeError) as exc:
         print(f"Error: {exc}", file=sys.stderr)

--- a/src/vulca/learning/open_model_signals.py
+++ b/src/vulca/learning/open_model_signals.py
@@ -54,6 +54,10 @@ def run_open_model_signal_adapter(
     allow_weight_download: bool = False,
     florence_model_id: str = "microsoft/Florence-2-base",
     florence_device: str = "auto",
+    sam_checkpoint: str | Path | None = None,
+    sam_model_type: str = "vit_b",
+    sam_device: str = "auto",
+    sam_points_per_side: int = 16,
 ) -> dict[str, Any]:
     """Write dry-run or injected open-model signal records and a summary report."""
     if max_examples is not None and max_examples < 0:
@@ -89,6 +93,10 @@ def run_open_model_signal_adapter(
         allow_weight_download=allow_weight_download,
         florence_model_id=florence_model_id,
         florence_device=florence_device,
+        sam_checkpoint=sam_checkpoint,
+        sam_model_type=sam_model_type,
+        sam_device=sam_device,
+        sam_points_per_side=sam_points_per_side,
     )
     records = build_open_model_signal_records(
         examples,
@@ -360,6 +368,10 @@ def _build_runner_map(
     allow_weight_download: bool,
     florence_model_id: str,
     florence_device: str,
+    sam_checkpoint: str | Path | None,
+    sam_model_type: str,
+    sam_device: str,
+    sam_points_per_side: int,
 ) -> dict[str, SignalRunner]:
     runner_map = dict(runners or {})
     model_id_set = {str(item) for item in model_ids}
@@ -374,20 +386,77 @@ def _build_runner_map(
             raise ValueError(f"runner for model {model_id!r} is already provided")
         factory = factories.get(model_id)
         if factory is None:
-            if model_id != "florence_2":
-                raise ValueError(f"no local runner is available for model {model_id!r}")
-            from vulca.learning.florence_signal_runner import (
-                build_florence2_signal_runner,
-            )
+            if model_id == "florence_2":
+                from vulca.learning.florence_signal_runner import (
+                    build_florence2_signal_runner,
+                )
 
-            factory = build_florence2_signal_runner
-        runner_map[model_id] = factory(
-            repo_root=repo_root,
-            allow_weight_download=allow_weight_download,
-            model_id=florence_model_id,
-            device=florence_device,
-        )
+                factory = build_florence2_signal_runner
+                factory_kwargs = {
+                    "repo_root": repo_root,
+                    "allow_weight_download": allow_weight_download,
+                    "model_id": florence_model_id,
+                    "device": florence_device,
+                }
+            elif model_id == "segment_anything_sam_vit":
+                from vulca.learning.sam_signal_runner import (
+                    build_sam_vit_signal_runner,
+                )
+
+                factory = build_sam_vit_signal_runner
+                factory_kwargs = {
+                    "repo_root": repo_root,
+                    "checkpoint_path": sam_checkpoint,
+                    "model_type": sam_model_type,
+                    "device": sam_device,
+                    "points_per_side": sam_points_per_side,
+                }
+            else:
+                raise ValueError(f"no local runner is available for model {model_id!r}")
+        else:
+            factory_kwargs = _local_runner_factory_kwargs(
+                model_id,
+                repo_root=repo_root,
+                allow_weight_download=allow_weight_download,
+                florence_model_id=florence_model_id,
+                florence_device=florence_device,
+                sam_checkpoint=sam_checkpoint,
+                sam_model_type=sam_model_type,
+                sam_device=sam_device,
+                sam_points_per_side=sam_points_per_side,
+            )
+        runner_map[model_id] = factory(**factory_kwargs)
     return runner_map
+
+
+def _local_runner_factory_kwargs(
+    model_id: str,
+    *,
+    repo_root: Path,
+    allow_weight_download: bool,
+    florence_model_id: str,
+    florence_device: str,
+    sam_checkpoint: str | Path | None,
+    sam_model_type: str,
+    sam_device: str,
+    sam_points_per_side: int,
+) -> dict[str, Any]:
+    if model_id == "florence_2":
+        return {
+            "repo_root": repo_root,
+            "allow_weight_download": allow_weight_download,
+            "model_id": florence_model_id,
+            "device": florence_device,
+        }
+    if model_id == "segment_anything_sam_vit":
+        return {
+            "repo_root": repo_root,
+            "checkpoint_path": sam_checkpoint,
+            "model_type": sam_model_type,
+            "device": sam_device,
+            "points_per_side": sam_points_per_side,
+        }
+    return {"repo_root": repo_root}
 
 
 def _safe_model_summary(model_spec: Mapping[str, Any]) -> dict[str, Any]:

--- a/src/vulca/learning/sam_signal_runner.py
+++ b/src/vulca/learning/sam_signal_runner.py
@@ -1,0 +1,290 @@
+"""Explicit local SAM runner for open-model signal records.
+
+The runner is opt-in and produces reviewable mask proposal signals only. It
+does not convert masks into accepted decompose or redraw labels.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Mapping, Protocol
+
+from PIL import Image
+
+from vulca.learning.florence_signal_runner import resolve_case_source_image_path
+
+
+DEFAULT_SAM_MODEL_TYPE = "vit_b"
+DEFAULT_SAM_POINTS_PER_SIDE = 16
+
+
+class SamSignalBackend(Protocol):
+    def run(
+        self,
+        image_path: str | Path,
+        *,
+        case_record: Mapping[str, Any],
+        model_spec: Mapping[str, Any],
+    ) -> Mapping[str, Any]:
+        """Run SAM on a local image and return raw mask signal fields."""
+
+
+def build_sam_vit_signal_runner(
+    *,
+    repo_root: str | Path,
+    backend: SamSignalBackend | None = None,
+    checkpoint_path: str | Path | None = None,
+    model_type: str = DEFAULT_SAM_MODEL_TYPE,
+    device: str = "auto",
+    points_per_side: int = DEFAULT_SAM_POINTS_PER_SIDE,
+    **_: Any,
+) -> Any:
+    """Build a local SAM signal runner.
+
+    The real backend never downloads weights. A checkpoint path is required
+    when no test/experiment backend is injected.
+    """
+    root = Path(repo_root)
+    resolved_backend = backend or SamVitLocalBackend(
+        checkpoint_path=checkpoint_path,
+        model_type=model_type,
+        device=device,
+        points_per_side=points_per_side,
+    )
+
+    def run(example: Mapping[str, Any], model_spec: Mapping[str, Any]) -> dict[str, Any]:
+        case_record = _case_record_from_example(example)
+        source = resolve_case_source_image_path(case_record, repo_root=root)
+        if source.path is None:
+            return {
+                "status": "skipped",
+                "skip_reason": "source_image_unavailable",
+                "signal_source": "local_runner",
+                "label_source": "assistant_labeled",
+                "review_status": "needs_human_review",
+                "source_image": {
+                    "available": False,
+                    "ref_kind": source.ref_kind,
+                },
+            }
+
+        image_info = _image_info(source.path)
+        backend_signals = dict(
+            resolved_backend.run(
+                source.path,
+                case_record=case_record,
+                model_spec=model_spec,
+            )
+        )
+        normalized = _normalize_backend_signals(
+            backend_signals,
+            width=image_info["width"],
+            height=image_info["height"],
+        )
+        normalized.update(
+            {
+                "status": "completed",
+                "signal_source": "local_runner",
+                "label_source": "assistant_labeled",
+                "review_status": "needs_human_review",
+                "source_image": {
+                    "available": True,
+                    "ref_kind": source.ref_kind,
+                    "width": image_info["width"],
+                    "height": image_info["height"],
+                },
+            }
+        )
+        return normalized
+
+    return run
+
+
+class SamVitLocalBackend:
+    """Lazy SAM v1 automatic mask backend."""
+
+    def __init__(
+        self,
+        *,
+        checkpoint_path: str | Path | None,
+        model_type: str = DEFAULT_SAM_MODEL_TYPE,
+        device: str = "auto",
+        points_per_side: int = DEFAULT_SAM_POINTS_PER_SIDE,
+    ) -> None:
+        self.checkpoint_path = Path(checkpoint_path) if checkpoint_path else None
+        self.model_type = model_type
+        self.device = device
+        self.points_per_side = int(points_per_side)
+        self._generator = None
+
+    def run(
+        self,
+        image_path: str | Path,
+        *,
+        case_record: Mapping[str, Any],
+        model_spec: Mapping[str, Any],
+    ) -> Mapping[str, Any]:
+        generator = self._load()
+        import numpy as np
+
+        image = np.array(Image.open(image_path).convert("RGB"))
+        masks = generator.generate(image)
+        return {
+            "masks": masks,
+            "boundary_complexity": _estimate_boundary_complexity(masks),
+        }
+
+    def _load(self):
+        if self._generator is not None:
+            return self._generator
+        if self.checkpoint_path is None:
+            raise RuntimeError(
+                "SAM local runner requires --sam-checkpoint when no backend is injected."
+            )
+        if not self.checkpoint_path.exists():
+            raise RuntimeError("SAM checkpoint path does not exist")
+
+        try:
+            import torch
+            from segment_anything import SamAutomaticMaskGenerator, sam_model_registry
+        except ImportError as exc:
+            raise RuntimeError(
+                "SAM local runner requires segment-anything and torch. "
+                "Install vulca[sam] and provide --sam-checkpoint."
+            ) from exc
+
+        device = self._resolved_device(torch)
+        sam = sam_model_registry[self.model_type](checkpoint=str(self.checkpoint_path))
+        sam.to(device=device)
+        self._generator = SamAutomaticMaskGenerator(
+            sam,
+            points_per_side=self.points_per_side,
+        )
+        return self._generator
+
+    def _resolved_device(self, torch_module) -> str:
+        if self.device != "auto":
+            return self.device
+        if (
+            getattr(torch_module.backends, "mps", None) is not None
+            and torch_module.backends.mps.is_available()
+        ):
+            return "mps"
+        if torch_module.cuda.is_available():
+            return "cuda"
+        return "cpu"
+
+
+def _case_record_from_example(example: Mapping[str, Any]) -> Mapping[str, Any]:
+    input_block = example.get("input")
+    if isinstance(input_block, Mapping):
+        case_record = input_block.get("case_record")
+        if isinstance(case_record, Mapping):
+            return case_record
+    return {}
+
+
+def _image_info(path: Path) -> dict[str, int]:
+    with Image.open(path) as image:
+        return {"width": int(image.width), "height": int(image.height)}
+
+
+def _normalize_backend_signals(
+    signals: Mapping[str, Any],
+    *,
+    width: int,
+    height: int,
+) -> dict[str, Any]:
+    masks = signals.get("masks") or []
+    candidates = [
+        _normalize_mask_candidate(mask, width=width, height=height)
+        for mask in masks
+        if isinstance(mask, Mapping)
+    ]
+    candidates = [candidate for candidate in candidates if candidate is not None]
+    total_pct = round(sum(float(item["area_pct"]) for item in candidates), 4)
+    return {
+        "mask_count": len(candidates),
+        "total_mask_area_pct": total_pct,
+        "mask_coverage_candidates": candidates,
+        "boundary_complexity": _normalize_boundary_complexity(
+            signals.get("boundary_complexity")
+        ),
+    }
+
+
+def _normalize_mask_candidate(
+    mask: Mapping[str, Any],
+    *,
+    width: int,
+    height: int,
+) -> dict[str, Any] | None:
+    area_pixels = _mask_area_pixels(mask)
+    canvas_pixels = max(int(width) * int(height), 1)
+    if area_pixels <= 0:
+        return None
+    return {
+        "area_pct": round(area_pixels / canvas_pixels * 100.0, 4),
+        "bbox": _bbox(mask.get("bbox")),
+        "predicted_iou": _optional_float(mask.get("predicted_iou")),
+        "stability_score": _optional_float(mask.get("stability_score")),
+    }
+
+
+def _mask_area_pixels(mask: Mapping[str, Any]) -> int:
+    value = mask.get("area_pixels", mask.get("area"))
+    try:
+        return max(int(value or 0), 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _bbox(value: Any) -> list[int]:
+    if isinstance(value, (list, tuple)):
+        return [int(float(item)) for item in list(value)[:4]]
+    return []
+
+
+def _optional_float(value: Any) -> float | None:
+    if value is None:
+        return None
+    try:
+        return round(float(value), 4)
+    except (TypeError, ValueError):
+        return None
+
+
+def _normalize_boundary_complexity(value: Any) -> dict[str, Any]:
+    if not isinstance(value, Mapping):
+        return {}
+    normalized: dict[str, Any] = {}
+    for key, item in value.items():
+        if isinstance(item, float):
+            normalized[str(key)] = round(float(item), 4)
+        elif isinstance(item, int):
+            normalized[str(key)] = int(item)
+        else:
+            normalized[str(key)] = item
+    return normalized
+
+
+def _estimate_boundary_complexity(masks: list[Mapping[str, Any]]) -> dict[str, Any]:
+    if not masks:
+        return {"mean_edge_density": 0.0, "high_complexity_mask_count": 0}
+    # Lightweight placeholder from SAM metadata only; pixel-boundary analysis can
+    # be added later without changing the public signal schema.
+    high_complexity = 0
+    densities: list[float] = []
+    for mask in masks:
+        area = max(_mask_area_pixels(mask), 1)
+        bbox = _bbox(mask.get("bbox"))
+        if len(bbox) == 4:
+            perimeter = max(2 * (bbox[2] + bbox[3]), 0)
+            density = perimeter / area
+            densities.append(density)
+            if density > 1.0:
+                high_complexity += 1
+    mean = sum(densities) / len(densities) if densities else 0.0
+    return {
+        "mean_edge_density": round(mean, 4),
+        "high_complexity_mask_count": high_complexity,
+    }

--- a/tests/test_sam_signal_runner.py
+++ b/tests/test_sam_signal_runner.py
@@ -1,0 +1,247 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from PIL import Image
+
+
+ROOT = Path(__file__).resolve().parent.parent
+CATALOG = ROOT / "docs/benchmarks/learning/open_source_model_catalog_v1.json"
+
+
+def _example_with_source(source_image: str, case_type: str = "decompose_case") -> dict:
+    return {
+        "example_id": "tiny_test",
+        "source_case": {
+            "case_type": case_type,
+            "case_id": "case_test",
+            "schema_version": 1,
+        },
+        "input": {
+            "case_record": {
+                "case_type": case_type,
+                "case_id": "case_test",
+                "source_image": source_image,
+            }
+        },
+    }
+
+
+class FakeSamBackend:
+    def __init__(self):
+        self.calls = []
+
+    def run(self, image_path, *, case_record, model_spec):
+        self.calls.append(
+            {
+                "image_path": str(image_path),
+                "case_id": case_record["case_id"],
+                "model_id": model_spec["id"],
+            }
+        )
+        return {
+            "masks": [
+                {
+                    "area_pixels": 8,
+                    "bbox": [0, 0, 4, 2],
+                    "predicted_iou": 0.91,
+                    "stability_score": 0.87,
+                },
+                {
+                    "area_pixels": 4,
+                    "bbox": [4, 2, 2, 2],
+                    "predicted_iou": 0.72,
+                    "stability_score": 0.66,
+                },
+            ],
+            "boundary_complexity": {
+                "mean_edge_density": 0.18,
+                "high_complexity_mask_count": 1,
+            },
+        }
+
+
+def test_sam_runner_returns_mask_coverage_and_boundary_signals(tmp_path):
+    from vulca.learning.sam_signal_runner import build_sam_vit_signal_runner
+
+    image_path = tmp_path / "source.png"
+    Image.new("RGB", (8, 6), (255, 255, 255)).save(image_path)
+    backend = FakeSamBackend()
+    runner = build_sam_vit_signal_runner(
+        repo_root=tmp_path,
+        backend=backend,
+    )
+
+    signals = runner(
+        _example_with_source("source.png"),
+        {"id": "segment_anything_sam_vit", "model_role": "mask_proposal"},
+    )
+
+    assert signals["status"] == "completed"
+    assert signals["signal_source"] == "local_runner"
+    assert signals["label_source"] == "assistant_labeled"
+    assert signals["review_status"] == "needs_human_review"
+    assert signals["mask_count"] == 2
+    assert signals["total_mask_area_pct"] == 25.0
+    assert signals["mask_coverage_candidates"] == [
+        {
+            "area_pct": 16.6667,
+            "bbox": [0, 0, 4, 2],
+            "predicted_iou": 0.91,
+            "stability_score": 0.87,
+        },
+        {
+            "area_pct": 8.3333,
+            "bbox": [4, 2, 2, 2],
+            "predicted_iou": 0.72,
+            "stability_score": 0.66,
+        },
+    ]
+    assert signals["boundary_complexity"] == {
+        "mean_edge_density": 0.18,
+        "high_complexity_mask_count": 1,
+    }
+    assert signals["source_image"] == {
+        "available": True,
+        "ref_kind": "repo_relative",
+        "width": 8,
+        "height": 6,
+    }
+    assert backend.calls == [
+        {
+            "image_path": str(image_path),
+            "case_id": "case_test",
+            "model_id": "segment_anything_sam_vit",
+        }
+    ]
+
+
+def test_sam_runner_skips_private_source_without_leaking_ref(tmp_path):
+    from vulca.learning.sam_signal_runner import build_sam_vit_signal_runner
+
+    runner = build_sam_vit_signal_runner(
+        repo_root=tmp_path,
+        backend=FakeSamBackend(),
+    )
+
+    signals = runner(
+        _example_with_source("private://local_path/abc/source.png"),
+        {"id": "segment_anything_sam_vit", "model_role": "mask_proposal"},
+    )
+
+    encoded = json.dumps(signals, sort_keys=True)
+    assert signals["status"] == "skipped"
+    assert signals["skip_reason"] == "source_image_unavailable"
+    assert signals["signal_source"] == "local_runner"
+    assert signals["review_status"] == "needs_human_review"
+    assert signals["source_image"] == {
+        "available": False,
+        "ref_kind": "private_uri",
+    }
+    assert "private://local_path" not in encoded
+    assert "/Users/" not in encoded
+
+
+def test_open_model_adapter_enables_sam_local_runner_with_factory(tmp_path):
+    from vulca.learning.open_model_signals import run_open_model_signal_adapter
+    from vulca.learning.sam_signal_runner import build_sam_vit_signal_runner
+
+    image_path = tmp_path / "source.png"
+    Image.new("RGB", (4, 3), (0, 255, 0)).save(image_path)
+    case_log = tmp_path / "cases.jsonl"
+    case_log.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "case_type": "decompose_case",
+                "case_id": "local_sam_case",
+                "created_at": "2026-05-06T00:00:00Z",
+                "input": {
+                    "source_image": str(image_path),
+                },
+                "review": {
+                    "human_accept": False,
+                    "failure_type": "under_segmentation",
+                    "preferred_action": "split_layer_further",
+                },
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    manifest = tmp_path / "manifest.json"
+    manifest.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "case_type": "learning_tiny_case_source_manifest",
+                "sources": [
+                    {
+                        "source_id": "local_sam_case_log",
+                        "kind": "manual_case_log",
+                        "path": str(case_log),
+                        "privacy_scope": "project",
+                        "curation_status": "curated",
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    output_path = tmp_path / "signals.jsonl"
+    report_path = tmp_path / "report.json"
+    backend = FakeSamBackend()
+
+    report = run_open_model_signal_adapter(
+        repo_root=ROOT,
+        output_path=output_path,
+        report_path=report_path,
+        model_catalog_path=CATALOG,
+        case_source_manifest_path=manifest,
+        model_ids=("segment_anything_sam_vit",),
+        include_local_seeds=False,
+        enable_local_runners=("segment_anything_sam_vit",),
+        local_runner_factories={
+            "segment_anything_sam_vit": lambda **kwargs: build_sam_vit_signal_runner(
+                backend=backend,
+                **kwargs,
+            )
+        },
+    )
+
+    records = [
+        json.loads(line)
+        for line in output_path.read_text(encoding="utf-8").splitlines()
+    ]
+    assert report["record_count"] == 1
+    assert report["runtime"]["uses_local_runner"] is True
+    assert report["runtime"]["calls_model_provider"] is False
+    assert report["runtime"]["downloads_weights"] is False
+    assert records[0]["signals"]["status"] == "completed"
+    assert records[0]["signals"]["signal_source"] == "local_runner"
+    assert records[0]["signals"]["label_source"] == "assistant_labeled"
+    assert records[0]["signals"]["mask_count"] == 2
+    assert records[0]["training_use"]["review_status"] == "needs_human_review"
+    assert "review" not in json.dumps(records[0]["input_summary"], sort_keys=True)
+
+
+def test_open_model_signal_adapter_cli_exposes_sam_local_runner_flags():
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(ROOT / "scripts/open_model_signal_adapter.py"),
+            "--help",
+        ],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert "--enable-local-runner" in result.stdout
+    assert "--sam-checkpoint" in result.stdout
+    assert "--sam-model-type" in result.stdout
+    assert "--sam-device" in result.stdout
+    assert "--sam-points-per-side" in result.stdout


### PR DESCRIPTION
## Summary
- add an explicit opt-in SAM local runner for open-model signal records
- expose --enable-local-runner segment_anything_sam_vit plus SAM checkpoint/model/device parameters
- keep default adapter path as dry-run; real SAM execution requires --sam-checkpoint and never auto-downloads weights
- normalize SAM mask proposals into reviewable mask_count, coverage, total area, and boundary complexity signals
- keep outputs assistant_labeled + needs_human_review and out of training data
- skip private or missing source images without leaking private refs

## Smoke result
- Dry-run CLI with --model segment_anything_sam_vit --max-examples 3 generated 3 signal records from 3 examples
- Explicit local SAM without --sam-checkpoint returns a clear error instead of downloading or half-running
- Output grep found no /Users/, private://local_path/, review, or learning_targets leakage

## Verification
- PYTHONPATH=src /opt/homebrew/bin/python3.11 -m pytest tests/test_sam_signal_runner.py tests/test_florence_signal_runner.py tests/test_open_model_signal_adapter.py tests/test_open_source_model_catalog_v1.py tests/test_combined_learning_sources_v1.py tests/test_tiny_dataset_export.py -q
- /opt/homebrew/bin/python3.11 -m py_compile src/vulca/learning/sam_signal_runner.py src/vulca/learning/florence_signal_runner.py src/vulca/learning/open_model_signals.py scripts/open_model_signal_adapter.py
- ruff check src/vulca/learning/sam_signal_runner.py src/vulca/learning/open_model_signals.py scripts/open_model_signal_adapter.py tests/test_sam_signal_runner.py
- PYTHONPATH=src /opt/homebrew/bin/python3.11 scripts/open_model_signal_adapter.py --model segment_anything_sam_vit --max-examples 3 --output /tmp/vulca_sam_dry_signals.jsonl --report /tmp/vulca_sam_dry_report.json
- git diff --check