### PR TITLE
feat(learning): add open model signal promotion gate

### DIFF
--- a/docs/superpowers/plans/2026-05-06-open-model-signal-review-promotion-v1.md
+++ b/docs/superpowers/plans/2026-05-06-open-model-signal-review-promotion-v1.md
@@ -1,0 +1,61 @@
+# Open-Model Signal Review Promotion V1
+
+## Goal
+
+Add a human review gate between open-model signal generation and tiny training
+data use. Florence/SAM/GroundingDINO-style local or injected runners can produce
+weak visual signals, but those records must not become training features unless
+a reviewer explicitly promotes them.
+
+## Scope
+
+- Add `vulca.learning.open_model_signal_review` for reviewing one signal record
+  and writing a promoted-only signal pack plus a promotion manifest.
+- Add `scripts/open_model_signal_review.py` with `review` and `promote`
+  subcommands.
+- Add an explicit `auxiliary_signal_manifest_path` input to tiny dataset export
+  and the tiny training/eval gate.
+- Add low-weight sparse features for reviewed auxiliary signals in
+  `tiny_action_model_v1`.
+
+## Safety Policy
+
+- Open-model signals remain excluded from default training input.
+- Dry-run and skipped signal records cannot be promoted; promotion requires a
+  completed local/injected signal.
+- Promotion writes a separate JSONL pack and manifest; the manifest declares
+  `requires_explicit_dataset_flag: true`.
+- Dataset export only attaches auxiliary signals when the promotion manifest is
+  passed explicitly.
+- Auxiliary signals are features only, not replacement labels. Human review
+  labels in source case logs remain the target source of truth.
+
+## Verification
+
+Run:
+
+```bash
+PYTHONPATH=src /opt/homebrew/bin/python3.11 -m pytest \
+  tests/test_open_model_signal_review.py \
+  tests/test_open_model_signal_adapter.py \
+  tests/test_tiny_dataset_export.py \
+  tests/test_tiny_action_model.py \
+  tests/test_tiny_training_eval_gate.py -q
+
+/opt/homebrew/bin/python3.11 -m py_compile \
+  src/vulca/learning/open_model_signal_review.py \
+  src/vulca/learning/tiny_dataset.py \
+  src/vulca/learning/tiny_action_model.py \
+  src/vulca/learning/tiny_training_eval.py \
+  scripts/open_model_signal_review.py \
+  scripts/tiny_training_eval_gate.py
+
+ruff check \
+  src/vulca/learning/open_model_signal_review.py \
+  src/vulca/learning/tiny_dataset.py \
+  src/vulca/learning/tiny_action_model.py \
+  src/vulca/learning/tiny_training_eval.py \
+  scripts/open_model_signal_review.py \
+  scripts/tiny_training_eval_gate.py \
+  tests/test_open_model_signal_review.py
+```

--- a/scripts/open_model_signal_review.py
+++ b/scripts/open_model_signal_review.py
@@ -1,0 +1,109 @@
+"""Review and promote open-model signal records for auxiliary training use."""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Sequence
+
+
+ROOT = Path(__file__).resolve().parent.parent
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from vulca.learning.open_model_signal_review import (  # noqa: E402
+    REVIEW_DECISIONS,
+    review_open_model_signal_log,
+    write_promoted_open_model_signal_pack,
+)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Human-review open-model signal records and explicitly promote "
+            "reviewed signals into an auxiliary-signal manifest."
+        )
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    review = sub.add_parser("review", help="Review one signal record by signal_id.")
+    review.add_argument("--input", required=True, help="Input signal JSONL path.")
+    review.add_argument("--output", default="", help="Reviewed JSONL output path.")
+    review.add_argument("--signal-id", required=True, help="Signal id to review.")
+    review.add_argument(
+        "--decision",
+        required=True,
+        choices=sorted(REVIEW_DECISIONS),
+        help="Human review decision.",
+    )
+    review.add_argument("--reviewer", default="", help="Reviewer identifier.")
+    review.add_argument("--reviewed-at", default="", help="UTC review timestamp.")
+    review.add_argument("--notes", default="", help="Review notes.")
+
+    promote = sub.add_parser(
+        "promote",
+        help="Write a promoted-only signal JSONL plus promotion manifest.",
+    )
+    promote.add_argument("--input", required=True, help="Reviewed signal JSONL path.")
+    promote.add_argument("--output", required=True, help="Promoted signal JSONL path.")
+    promote.add_argument("--manifest", required=True, help="Promotion manifest path.")
+    promote.add_argument("--source-id", required=True, help="Promotion source id.")
+    promote.add_argument(
+        "--pretty",
+        action="store_true",
+        help="Print the pack result as pretty JSON.",
+    )
+
+    args = parser.parse_args(argv)
+
+    try:
+        if args.command == "review":
+            result = review_open_model_signal_log(
+                args.input,
+                signal_id=args.signal_id,
+                decision=args.decision,
+                output_path=args.output or None,
+                reviewer=args.reviewer,
+                reviewed_at=args.reviewed_at or None,
+                notes=args.notes,
+            )
+            print(f"Reviewed signal: {result.signal_id}")
+            print(f"Review status: {result.review_status}")
+            print(f"Reviewed output: {result.output_path}")
+            return 0
+
+        result = write_promoted_open_model_signal_pack(
+            input_path=args.input,
+            output_path=args.output,
+            manifest_path=args.manifest,
+            source_id=args.source_id,
+        )
+    except (ValueError, FileNotFoundError, json.JSONDecodeError) as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 2
+
+    if args.pretty:
+        print(
+            json.dumps(
+                {
+                    "output_path": result.output_path,
+                    "manifest_path": result.manifest_path,
+                    "source_id": result.source_id,
+                    "promoted_count": result.promoted_count,
+                    "counts_by_model": result.counts_by_model,
+                },
+                indent=2,
+                sort_keys=True,
+            )
+        )
+    print(f"Promoted signal output: {result.output_path}")
+    print(f"Promotion manifest: {result.manifest_path}")
+    print(f"Promoted signals: {result.promoted_count}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tiny_training_eval_gate.py
+++ b/scripts/tiny_training_eval_gate.py
@@ -69,6 +69,14 @@ def main(argv: Sequence[str] | None = None) -> int:
         ),
     )
     parser.add_argument(
+        "--auxiliary-signal-manifest",
+        default="",
+        help=(
+            "Explicit reviewed open-model signal promotion manifest to attach "
+            "as auxiliary training features."
+        ),
+    )
+    parser.add_argument(
         "--no-case-source-manifest",
         action="store_true",
         help="Do not include the default manual curated case source manifest.",
@@ -134,6 +142,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             case_source_manifest_path=(
                 None if args.no_case_source_manifest else args.case_source_manifest
             ),
+            auxiliary_signal_manifest_path=args.auxiliary_signal_manifest or None,
             include_local_seeds=not args.no_local_seeds,
             eval_split=args.split,
             train_split=args.train_split,

--- a/src/vulca/cli.py
+++ b/src/vulca/cli.py
@@ -453,6 +453,14 @@ def main(argv: list[str] | None = None) -> None:
         help="JSON manifest describing user/manual/synthetic reviewed case logs",
     )
     cases_export.add_argument(
+        "--auxiliary-signal-manifest",
+        default="",
+        help=(
+            "Explicit open-model signal promotion manifest to attach as "
+            "reviewed auxiliary training features"
+        ),
+    )
+    cases_export.add_argument(
         "--no-local-seeds",
         action="store_true",
         help="Only export records from --case-log inputs",
@@ -1797,6 +1805,9 @@ def _cmd_cases(args: argparse.Namespace) -> None:
                 manifest_path=args.manifest or DEFAULT_SEED_MANIFEST,
                 case_log_paths=args.case_log,
                 case_source_manifest_path=args.case_source_manifest or None,
+                auxiliary_signal_manifest_path=(
+                    args.auxiliary_signal_manifest or None
+                ),
                 include_local_seeds=not args.no_local_seeds,
             )
         except (

--- a/src/vulca/learning/open_model_signal_review.py
+++ b/src/vulca/learning/open_model_signal_review.py
@@ -1,0 +1,371 @@
+"""Human review and explicit promotion for open-model signal records."""
+from __future__ import annotations
+
+import json
+import os
+from collections import Counter
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+from vulca.layers.redraw_cases import utc_now_iso
+from vulca.learning.case_review import load_cases, write_cases
+from vulca.learning.open_model_signals import (
+    SCHEMA_VERSION as SIGNAL_SCHEMA_VERSION,
+    SIGNAL_RECORD_CASE_TYPE,
+)
+
+
+SCHEMA_VERSION = 1
+PROMOTION_MANIFEST_CASE_TYPE = "learning_open_model_signal_promotion_manifest"
+OPEN_MODEL_SIGNAL_LOG_KIND = "open_model_signal_log"
+REVIEWED_AUXILIARY_SIGNAL_STATUS = "reviewed_auxiliary_signal"
+PROJECT_PRIVACY_SCOPE = "project"
+DECISION_PROMOTE = "promote"
+DECISION_REJECT = "reject"
+DECISION_HOLD = "hold"
+REVIEW_DECISIONS: frozenset[str] = frozenset(
+    {DECISION_PROMOTE, DECISION_REJECT, DECISION_HOLD}
+)
+REVIEW_STATUS_BY_DECISION: Mapping[str, str] = {
+    DECISION_PROMOTE: "reviewed_promoted",
+    DECISION_REJECT: "reviewed_rejected",
+    DECISION_HOLD: "needs_more_context",
+}
+
+
+@dataclass(frozen=True)
+class OpenModelSignalReviewResult:
+    signal_id: str
+    output_path: str
+    updated: bool
+    decision: str
+    review_status: str
+
+
+@dataclass(frozen=True)
+class PromotedOpenModelSignalPackResult:
+    output_path: str
+    manifest_path: str
+    source_id: str
+    promoted_count: int
+    counts_by_model: dict[str, int]
+
+
+def review_open_model_signal_log(
+    input_path: str | Path,
+    *,
+    signal_id: str,
+    decision: str,
+    output_path: str | Path | None = None,
+    reviewer: str = "",
+    reviewed_at: str | None = None,
+    notes: str = "",
+) -> OpenModelSignalReviewResult:
+    """Review one open-model signal record and write a non-destructive JSONL copy."""
+    resolved_signal_id = str(signal_id or "")
+    if not resolved_signal_id:
+        raise ValueError("signal_id is required")
+    resolved_decision = _validate_decision(decision)
+
+    records = load_cases(input_path)
+    output = Path(output_path) if output_path is not None else _default_review_output_path(input_path)
+    found = False
+    review_status = REVIEW_STATUS_BY_DECISION[resolved_decision]
+
+    for index, record in enumerate(records):
+        if str(record.get("signal_id") or "") != resolved_signal_id:
+            continue
+        _validate_signal_record(record, record_index=index)
+        if resolved_decision == DECISION_PROMOTE:
+            _validate_promotable_signal(record)
+        found = True
+        record["signal_review"] = {
+            "schema_version": SCHEMA_VERSION,
+            "decision": resolved_decision,
+            "reviewer": str(reviewer or ""),
+            "reviewed_at": str(reviewed_at or utc_now_iso()),
+            "notes": str(notes or ""),
+        }
+        training_use = dict(_mapping(record.get("training_use")))
+        training_use["default_training_input"] = False
+        training_use["approved_for_auxiliary_training"] = (
+            resolved_decision == DECISION_PROMOTE
+        )
+        training_use["review_status"] = review_status
+        training_use["approved_signal_use"] = (
+            "auxiliary_training_feature"
+            if resolved_decision == DECISION_PROMOTE
+            else "none"
+        )
+        record["training_use"] = training_use
+        break
+
+    if not found:
+        raise ValueError(f"signal_id {resolved_signal_id!r} not found in {input_path}")
+
+    write_cases(output, records)
+    return OpenModelSignalReviewResult(
+        signal_id=resolved_signal_id,
+        output_path=str(output),
+        updated=True,
+        decision=resolved_decision,
+        review_status=review_status,
+    )
+
+
+def write_promoted_open_model_signal_pack(
+    *,
+    input_path: str | Path,
+    output_path: str | Path,
+    manifest_path: str | Path,
+    source_id: str,
+) -> PromotedOpenModelSignalPackResult:
+    """Write a promoted-only signal JSONL plus an explicit promotion manifest."""
+    resolved_source_id = str(source_id or "").strip()
+    if not resolved_source_id:
+        raise ValueError("source_id is required")
+
+    promoted = []
+    for index, record in enumerate(load_cases(input_path)):
+        _validate_signal_record(record, record_index=index)
+        if not _is_promoted_signal(record):
+            continue
+        promoted.append(_sanitize_promoted_signal_record(record))
+
+    output = Path(output_path)
+    manifest = Path(manifest_path)
+    write_cases(output, promoted)
+    counts_by_model = _counts_by_model(promoted)
+    _write_promotion_manifest(
+        manifest_path=manifest,
+        output_path=output,
+        source_id=resolved_source_id,
+        promoted_count=len(promoted),
+        counts_by_model=counts_by_model,
+    )
+    return PromotedOpenModelSignalPackResult(
+        output_path=str(output),
+        manifest_path=str(manifest),
+        source_id=resolved_source_id,
+        promoted_count=len(promoted),
+        counts_by_model=counts_by_model,
+    )
+
+
+def load_promoted_open_model_signals(
+    manifest_path: str | Path,
+) -> list[dict[str, Any]]:
+    """Load promoted open-model signals from a promotion manifest."""
+    manifest_file = Path(manifest_path)
+    manifest = json.loads(manifest_file.read_text(encoding="utf-8"))
+    if not isinstance(manifest, Mapping):
+        raise ValueError("open-model signal promotion manifest must be an object")
+    if manifest.get("case_type") != PROMOTION_MANIFEST_CASE_TYPE:
+        raise ValueError(
+            "open-model signal promotion manifest case_type must be "
+            f"{PROMOTION_MANIFEST_CASE_TYPE!r}"
+        )
+
+    sources = manifest.get("sources")
+    if not isinstance(sources, list):
+        raise ValueError("open-model signal promotion manifest sources must be a list")
+
+    records: list[dict[str, Any]] = []
+    errors: list[str] = []
+    for source_index, source in enumerate(sources):
+        if not isinstance(source, Mapping):
+            errors.append(f"sources[{source_index}] must be an object")
+            continue
+        path = str(source.get("path") or "")
+        if not path:
+            errors.append(f"sources[{source_index}]: path is required")
+            continue
+        if str(source.get("kind") or "") != OPEN_MODEL_SIGNAL_LOG_KIND:
+            errors.append(
+                f"sources[{source_index}]: unsupported kind "
+                f"{str(source.get('kind') or '')!r}"
+            )
+        if str(source.get("curation_status") or "") != REVIEWED_AUXILIARY_SIGNAL_STATUS:
+            errors.append(
+                f"sources[{source_index}]: unsupported curation_status "
+                f"{str(source.get('curation_status') or '')!r}"
+            )
+        source_path = Path(path)
+        if not source_path.is_absolute():
+            source_path = manifest_file.parent / source_path
+        for record_index, record in enumerate(load_cases(source_path)):
+            _validate_signal_record(record, record_index=record_index)
+            if not _is_promoted_signal(record):
+                errors.append(
+                    f"{source_path}:{record_index + 1}: promoted pack contains "
+                    "a non-promoted signal"
+                )
+                continue
+            records.append(_sanitize_promoted_signal_record(record))
+
+    if errors:
+        raise ValueError("; ".join(errors))
+    return records
+
+
+def attach_promoted_open_model_signals(
+    examples: Sequence[dict[str, Any]],
+    *,
+    manifest_path: str | Path,
+) -> None:
+    """Mutate dataset examples by attaching reviewed auxiliary signals by example_id."""
+    signals_by_example_id: dict[str, list[dict[str, Any]]] = {}
+    for signal in load_promoted_open_model_signals(manifest_path):
+        example_id = str(signal.get("example_id") or "")
+        if not example_id:
+            continue
+        signals_by_example_id.setdefault(example_id, []).append(signal)
+
+    for example in examples:
+        example_id = str(example.get("example_id") or "")
+        signals = signals_by_example_id.get(example_id)
+        if not signals:
+            continue
+        input_block = example.setdefault("input", {})
+        if not isinstance(input_block, dict):
+            raise ValueError(f"dataset example {example_id!r} input must be an object")
+        input_block["auxiliary_signals"] = sorted(
+            signals,
+            key=lambda item: str(item.get("signal_id") or ""),
+        )
+
+
+def _default_review_output_path(input_path: str | Path) -> Path:
+    path = Path(input_path)
+    if path.suffix == ".jsonl":
+        return path.with_name(f"{path.stem}.reviewed{path.suffix}")
+    return path.with_name(f"{path.name}.reviewed.jsonl")
+
+
+def _write_promotion_manifest(
+    *,
+    manifest_path: Path,
+    output_path: Path,
+    source_id: str,
+    promoted_count: int,
+    counts_by_model: Mapping[str, int],
+) -> None:
+    manifest_path.parent.mkdir(parents=True, exist_ok=True)
+    manifest = {
+        "schema_version": SCHEMA_VERSION,
+        "case_type": PROMOTION_MANIFEST_CASE_TYPE,
+        "sources": [
+            {
+                "source_id": source_id,
+                "kind": OPEN_MODEL_SIGNAL_LOG_KIND,
+                "path": _manifest_relative_path(output_path, manifest_path.parent),
+                "privacy_scope": PROJECT_PRIVACY_SCOPE,
+                "curation_status": REVIEWED_AUXILIARY_SIGNAL_STATUS,
+                "approved_signal_use": "auxiliary_training_feature",
+                "record_count": int(promoted_count),
+                "counts_by_model": dict(sorted(counts_by_model.items())),
+            }
+        ],
+        "record_count": int(promoted_count),
+        "counts_by_model": dict(sorted(counts_by_model.items())),
+        "training_use": {
+            "default_training_input": False,
+            "requires_explicit_dataset_flag": True,
+            "approved_signal_use": "auxiliary_training_feature",
+        },
+    }
+    manifest_path.write_text(
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _validate_decision(decision: str) -> str:
+    normalized = str(decision or "").strip().lower()
+    if normalized not in REVIEW_DECISIONS:
+        raise ValueError(
+            f"unsupported signal review decision {normalized!r}; "
+            f"expected one of {sorted(REVIEW_DECISIONS)}"
+        )
+    return normalized
+
+
+def _validate_signal_record(record: Mapping[str, Any], *, record_index: int) -> None:
+    if record.get("case_type") != SIGNAL_RECORD_CASE_TYPE:
+        raise ValueError(
+            f"record {record_index}: case_type must be {SIGNAL_RECORD_CASE_TYPE!r}"
+        )
+    if int(record.get("schema_version") or 0) != SIGNAL_SCHEMA_VERSION:
+        raise ValueError(
+            f"record {record_index}: schema_version must be {SIGNAL_SCHEMA_VERSION}"
+        )
+    if not str(record.get("signal_id") or ""):
+        raise ValueError(f"record {record_index}: signal_id is required")
+    if not str(record.get("example_id") or ""):
+        raise ValueError(f"record {record_index}: example_id is required")
+    if not _mapping(record.get("model")).get("id"):
+        raise ValueError(f"record {record_index}: model.id is required")
+    if not isinstance(record.get("signals"), Mapping):
+        raise ValueError(f"record {record_index}: signals object is required")
+
+
+def _validate_promotable_signal(record: Mapping[str, Any]) -> None:
+    signals = _mapping(record.get("signals"))
+    source = str(signals.get("signal_source") or "")
+    status = str(signals.get("status") or "")
+    if source == "dry_run" or status.startswith("dry_run"):
+        raise ValueError("cannot promote dry-run signal")
+    if status != "completed":
+        raise ValueError(f"cannot promote signal with status {status!r}")
+
+
+def _is_promoted_signal(record: Mapping[str, Any]) -> bool:
+    training_use = _mapping(record.get("training_use"))
+    review = _mapping(record.get("signal_review"))
+    return (
+        bool(training_use.get("approved_for_auxiliary_training"))
+        and str(training_use.get("review_status") or "") == "reviewed_promoted"
+        and str(review.get("decision") or "") == DECISION_PROMOTE
+    )
+
+
+def _sanitize_promoted_signal_record(record: Mapping[str, Any]) -> dict[str, Any]:
+    training_use = _mapping(record.get("training_use"))
+    return {
+        "schema_version": SIGNAL_SCHEMA_VERSION,
+        "case_type": SIGNAL_RECORD_CASE_TYPE,
+        "signal_id": str(record.get("signal_id") or ""),
+        "example_id": str(record.get("example_id") or ""),
+        "source_case": dict(_mapping(record.get("source_case"))),
+        "model": dict(_mapping(record.get("model"))),
+        "signals": dict(_mapping(record.get("signals"))),
+        "signal_review": dict(_mapping(record.get("signal_review"))),
+        "training_use": {
+            "default_training_input": False,
+            "approved_for_auxiliary_training": True,
+            "review_status": str(training_use.get("review_status") or ""),
+            "approved_signal_use": str(
+                training_use.get("approved_signal_use")
+                or "auxiliary_training_feature"
+            ),
+        },
+    }
+
+
+def _counts_by_model(records: Sequence[Mapping[str, Any]]) -> dict[str, int]:
+    counts: Counter[str] = Counter()
+    for record in records:
+        counts[str(_mapping(record.get("model")).get("id") or "unknown")] += 1
+    return dict(sorted(counts.items()))
+
+
+def _manifest_relative_path(output_path: Path, manifest_dir: Path) -> str:
+    rel = os.path.relpath(output_path, manifest_dir)
+    return Path(rel).as_posix()
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    if isinstance(value, Mapping):
+        return value
+    return {}

--- a/src/vulca/learning/tiny_action_model.py
+++ b/src/vulca/learning/tiny_action_model.py
@@ -227,6 +227,7 @@ def extract_tiny_action_features(example: Mapping[str, Any]) -> tuple[str, ...]:
     features.extend(_geometry_features(case_record))
     features.extend(_refinement_features(case_record))
     features.extend(_layer_generate_features(case_record))
+    features.extend(_auxiliary_signal_features(example))
     return tuple(features)
 
 
@@ -435,6 +436,51 @@ def _layer_generate_features(case_record: Mapping[str, Any]) -> tuple[str, ...]:
     return tuple(features)
 
 
+def _auxiliary_signal_features(example: Mapping[str, Any]) -> tuple[str, ...]:
+    input_block = _mapping(example.get("input"))
+    auxiliary_signals = input_block.get("auxiliary_signals")
+    if not isinstance(auxiliary_signals, Sequence) or isinstance(
+        auxiliary_signals, (str, bytes)
+    ):
+        return ()
+
+    features: list[str] = []
+    for signal_record in auxiliary_signals:
+        if not isinstance(signal_record, Mapping):
+            continue
+        training_use = _mapping(signal_record.get("training_use"))
+        if not bool(training_use.get("approved_for_auxiliary_training")):
+            continue
+        review_status = str(training_use.get("review_status") or "")
+        if review_status != "reviewed_promoted":
+            continue
+
+        model_id = str(_mapping(signal_record.get("model")).get("id") or "")
+        signals = _mapping(signal_record.get("signals"))
+        if model_id:
+            features.append(f"aux_signal.model:{model_id}")
+        status = str(signals.get("status") or "")
+        if status:
+            features.append(f"aux_signal.status:{status}")
+        features.append(f"aux_signal.review_status:{review_status}")
+
+        signal_source = str(signals.get("signal_source") or "")
+        if signal_source:
+            features.append(f"aux_signal.source:{signal_source}")
+        mask_count = _number(signals.get("mask_count"))
+        if mask_count is not None:
+            features.append(f"aux_signal.sam_mask_count:{_mask_count_bucket(mask_count)}")
+        total_area = _number(signals.get("total_mask_area_pct"))
+        if total_area is not None:
+            features.append(
+                f"aux_signal.sam_total_area_pct:{_aux_percent_bucket(total_area)}"
+            )
+        boundary_complexity = str(signals.get("boundary_complexity") or "")
+        if boundary_complexity:
+            features.append(f"aux_signal.boundary_complexity:{boundary_complexity}")
+    return tuple(features)
+
+
 def _target_action(example: Mapping[str, Any]) -> str:
     return str(_mapping(example.get("targets")).get("preferred_action") or "")
 
@@ -467,6 +513,8 @@ def _feature_weight(feature: str) -> float:
         return 3.0
     if feature.startswith(("quality.", "geometry.", "refinement.", "layer_count.", "output.")):
         return 2.0
+    if feature.startswith("aux_signal."):
+        return 1.5
     if feature.startswith("case_type:"):
         return 1.0
     return 1.0
@@ -567,6 +615,33 @@ def _count_bucket(value: float) -> str:
     if value <= 8:
         return "several"
     return "many"
+
+
+def _mask_count_bucket(value: float) -> str:
+    if value <= 0:
+        return "zero"
+    if value == 1:
+        return "one"
+    if value <= 4:
+        return "2-4"
+    if value <= 8:
+        return "5-8"
+    return "9+"
+
+
+def _aux_percent_bucket(value: float) -> str:
+    percent = value * 100 if 0 < value <= 1 else value
+    if percent <= 0:
+        return "0"
+    if percent < 5:
+        return "0-5"
+    if percent < 25:
+        return "5-25"
+    if percent < 50:
+        return "25-50"
+    if percent < 75:
+        return "50-75"
+    return "75-100"
 
 
 def _number(value: Any) -> float | None:

--- a/src/vulca/learning/tiny_dataset.py
+++ b/src/vulca/learning/tiny_dataset.py
@@ -103,6 +103,7 @@ def build_tiny_dataset_examples(
     manifest_path: str | Path = DEFAULT_SEED_MANIFEST,
     case_log_paths: Sequence[str | Path] = (),
     case_source_manifest_path: str | Path | None = None,
+    auxiliary_signal_manifest_path: str | Path | None = None,
     include_local_seeds: bool = True,
 ) -> list[dict[str, Any]]:
     """Build leak-resistant tiny dataset examples from seeds and case logs."""
@@ -155,6 +156,15 @@ def build_tiny_dataset_examples(
             )
 
     _assign_dataset_splits(examples, source_aware=len(case_sources) > 1)
+    if auxiliary_signal_manifest_path:
+        from vulca.learning.open_model_signal_review import (
+            attach_promoted_open_model_signals,
+        )
+
+        attach_promoted_open_model_signals(
+            examples,
+            manifest_path=auxiliary_signal_manifest_path,
+        )
     return examples
 
 
@@ -165,6 +175,7 @@ def write_tiny_dataset(
     manifest_path: str | Path = DEFAULT_SEED_MANIFEST,
     case_log_paths: Sequence[str | Path] = (),
     case_source_manifest_path: str | Path | None = None,
+    auxiliary_signal_manifest_path: str | Path | None = None,
     include_local_seeds: bool = True,
     index_path: str | Path | None = None,
 ) -> TinyDatasetWriteResult:
@@ -174,6 +185,7 @@ def write_tiny_dataset(
         manifest_path=manifest_path,
         case_log_paths=case_log_paths,
         case_source_manifest_path=case_source_manifest_path,
+        auxiliary_signal_manifest_path=auxiliary_signal_manifest_path,
         include_local_seeds=include_local_seeds,
     )
     output = Path(output_path)
@@ -192,6 +204,9 @@ def write_tiny_dataset(
                 "source_manifest": str(manifest_path),
                 "case_log_paths": [str(path) for path in case_log_paths],
                 "case_source_manifest_path": str(case_source_manifest_path or ""),
+                "auxiliary_signal_manifest_path": str(
+                    auxiliary_signal_manifest_path or ""
+                ),
                 "case_sources": _case_source_summaries(case_sources, examples),
                 "include_local_seeds": bool(include_local_seeds),
                 "example_count": len(examples),

--- a/src/vulca/learning/tiny_training_eval.py
+++ b/src/vulca/learning/tiny_training_eval.py
@@ -45,6 +45,7 @@ def run_tiny_training_eval_gate(
     manifest_path: str | Path | None = DEFAULT_SEED_MANIFEST,
     case_log_paths: Sequence[str | Path] = (),
     case_source_manifest_path: str | Path | None = DEFAULT_MANUAL_CURATED_CASE_SOURCE_MANIFEST,
+    auxiliary_signal_manifest_path: str | Path | None = None,
     include_local_seeds: bool = True,
     eval_split: str = "test",
     train_split: str = "train",
@@ -76,6 +77,7 @@ def run_tiny_training_eval_gate(
         manifest_path=resolved_manifest_path,
         case_log_paths=case_log_paths,
         case_source_manifest_path=resolved_case_source_manifest,
+        auxiliary_signal_manifest_path=auxiliary_signal_manifest_path,
         include_local_seeds=include_local_seeds,
     )
     tiny_agent_result = write_tiny_baseline_predictions(
@@ -123,6 +125,7 @@ def run_tiny_training_eval_gate(
             "source_manifest": str(resolved_manifest_path),
             "case_log_paths": [str(path) for path in case_log_paths],
             "case_source_manifest_path": str(resolved_case_source_manifest or ""),
+            "auxiliary_signal_manifest_path": str(auxiliary_signal_manifest_path or ""),
             "include_local_seeds": bool(include_local_seeds),
         },
         "artifacts": {

--- a/tests/test_open_model_signal_review.py
+++ b/tests/test_open_model_signal_review.py
@@ -1,0 +1,293 @@
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parent.parent
+CLI_ENV = dict(
+    os.environ,
+    PYTHONPATH=str(ROOT / "src") + os.pathsep + os.environ.get("PYTHONPATH", ""),
+)
+
+
+def _read_jsonl(path: Path) -> list[dict]:
+    return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines()]
+
+
+def _write_jsonl(path: Path, records: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "".join(json.dumps(record, sort_keys=True) + "\n" for record in records),
+        encoding="utf-8",
+    )
+
+
+def _first_decompose_example() -> dict:
+    from vulca.learning.tiny_dataset import build_tiny_dataset_examples
+
+    return next(
+        example
+        for example in build_tiny_dataset_examples(repo_root=ROOT)
+        if example["source_case"]["case_type"] == "decompose_case"
+    )
+
+
+def _completed_sam_signal_record(example: dict, *, signal_id: str = "open_signal_demo") -> dict:
+    return {
+        "schema_version": 1,
+        "case_type": "learning_open_model_signal_record",
+        "signal_id": signal_id,
+        "example_id": example["example_id"],
+        "source": {
+            "kind": "local_seed",
+            "split": "seed",
+            "privacy_scope": "project",
+        },
+        "source_case": dict(example["source_case"]),
+        "model": {
+            "id": "segment_anything_sam_vit",
+            "name": "Segment Anything SAM ViT",
+            "license": "Apache-2.0",
+            "license_risk": "low",
+            "model_role": "mask_proposal",
+            "output_training_policy": "weak_signal_requires_review",
+            "default_runtime_enabled": False,
+        },
+        "input_summary": {
+            "case_type": example["source_case"]["case_type"],
+            "case_id": example["source_case"]["case_id"],
+            "source_image_ref_kind": "repo_relative",
+        },
+        "signals": {
+            "status": "completed",
+            "signal_source": "local_runner",
+            "label_source": "assistant_labeled",
+            "review_status": "needs_human_review",
+            "mask_count": 3,
+            "total_mask_area_pct": 0.42,
+            "boundary_complexity": "medium",
+            "mask_coverage_candidates": [
+                {
+                    "area_pct": 0.21,
+                    "bbox": [4, 8, 40, 64],
+                    "predicted_iou": 0.91,
+                    "stability_score": 0.88,
+                }
+            ],
+        },
+        "training_use": {
+            "default_training_input": False,
+            "requires_manual_review_for_training_labels": True,
+            "review_status": "needs_human_review",
+            "output_training_policy": "weak_signal_requires_review",
+        },
+    }
+
+
+def test_open_model_signal_review_promotes_completed_local_signal(tmp_path):
+    from vulca.learning.open_model_signal_review import (
+        review_open_model_signal_log,
+        write_promoted_open_model_signal_pack,
+    )
+
+    signal_path = tmp_path / "signals.jsonl"
+    reviewed_path = tmp_path / "signals.reviewed.jsonl"
+    promoted_path = tmp_path / "signals.promoted.jsonl"
+    manifest_path = tmp_path / "signals.promotion_manifest.json"
+    record = _completed_sam_signal_record(_first_decompose_example())
+    _write_jsonl(signal_path, [record])
+
+    result = review_open_model_signal_log(
+        signal_path,
+        signal_id=record["signal_id"],
+        decision="promote",
+        output_path=reviewed_path,
+        reviewer="human-reviewer",
+        reviewed_at="2026-05-06T21:00:00Z",
+        notes="SAM mask proposals match the decompose failure.",
+    )
+    assert result.updated is True
+    assert result.review_status == "reviewed_promoted"
+
+    reviewed = _read_jsonl(reviewed_path)
+    assert reviewed[0]["signal_review"] == {
+        "schema_version": 1,
+        "decision": "promote",
+        "reviewer": "human-reviewer",
+        "reviewed_at": "2026-05-06T21:00:00Z",
+        "notes": "SAM mask proposals match the decompose failure.",
+    }
+    assert reviewed[0]["training_use"]["default_training_input"] is False
+    assert reviewed[0]["training_use"]["approved_for_auxiliary_training"] is True
+    assert reviewed[0]["training_use"]["review_status"] == "reviewed_promoted"
+
+    pack = write_promoted_open_model_signal_pack(
+        input_path=reviewed_path,
+        output_path=promoted_path,
+        manifest_path=manifest_path,
+        source_id="sam-reviewed-v1",
+    )
+    assert pack.promoted_count == 1
+    assert _read_jsonl(promoted_path)[0]["signal_id"] == record["signal_id"]
+
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert manifest["case_type"] == "learning_open_model_signal_promotion_manifest"
+    assert manifest["record_count"] == 1
+    assert manifest["sources"][0]["source_id"] == "sam-reviewed-v1"
+    assert manifest["sources"][0]["kind"] == "open_model_signal_log"
+    assert manifest["training_use"]["default_training_input"] is False
+    assert manifest["training_use"]["requires_explicit_dataset_flag"] is True
+
+
+def test_open_model_signal_review_rejects_dry_run_promotion(tmp_path):
+    from vulca.learning.open_model_signal_review import review_open_model_signal_log
+
+    signal_path = tmp_path / "signals.jsonl"
+    record = _completed_sam_signal_record(_first_decompose_example())
+    record["signals"] = {
+        "status": "dry_run_pending_model_execution",
+        "signal_source": "dry_run",
+    }
+    _write_jsonl(signal_path, [record])
+
+    with pytest.raises(ValueError, match="cannot promote dry-run signal"):
+        review_open_model_signal_log(
+            signal_path,
+            signal_id=record["signal_id"],
+            decision="promote",
+            reviewer="human-reviewer",
+        )
+
+
+def test_open_model_signal_review_rejects_skipped_signal_promotion(tmp_path):
+    from vulca.learning.open_model_signal_review import review_open_model_signal_log
+
+    signal_path = tmp_path / "signals.jsonl"
+    record = _completed_sam_signal_record(_first_decompose_example())
+    record["signals"]["status"] = "skipped"
+    _write_jsonl(signal_path, [record])
+
+    with pytest.raises(ValueError, match="cannot promote signal with status 'skipped'"):
+        review_open_model_signal_log(
+            signal_path,
+            signal_id=record["signal_id"],
+            decision="promote",
+            reviewer="human-reviewer",
+        )
+
+
+def test_tiny_dataset_attaches_only_explicitly_promoted_auxiliary_signals(tmp_path):
+    from vulca.learning.open_model_signal_review import (
+        review_open_model_signal_log,
+        write_promoted_open_model_signal_pack,
+    )
+    from vulca.learning.tiny_action_model import extract_tiny_action_features
+    from vulca.learning.tiny_dataset import build_tiny_dataset_examples
+
+    example = _first_decompose_example()
+    signal_path = tmp_path / "signals.jsonl"
+    reviewed_path = tmp_path / "signals.reviewed.jsonl"
+    promoted_path = tmp_path / "signals.promoted.jsonl"
+    manifest_path = tmp_path / "signals.promotion_manifest.json"
+    _write_jsonl(signal_path, [_completed_sam_signal_record(example)])
+    review_open_model_signal_log(
+        signal_path,
+        signal_id="open_signal_demo",
+        decision="promote",
+        output_path=reviewed_path,
+        reviewer="human-reviewer",
+        reviewed_at="2026-05-06T21:00:00Z",
+    )
+    write_promoted_open_model_signal_pack(
+        input_path=reviewed_path,
+        output_path=promoted_path,
+        manifest_path=manifest_path,
+        source_id="sam-reviewed-v1",
+    )
+
+    default_examples = build_tiny_dataset_examples(repo_root=ROOT)
+    default_target = next(
+        item for item in default_examples if item["example_id"] == example["example_id"]
+    )
+    assert "auxiliary_signals" not in default_target["input"]
+
+    examples = build_tiny_dataset_examples(
+        repo_root=ROOT,
+        auxiliary_signal_manifest_path=manifest_path,
+    )
+    target = next(item for item in examples if item["example_id"] == example["example_id"])
+    auxiliary_signals = target["input"]["auxiliary_signals"]
+    assert len(auxiliary_signals) == 1
+    assert auxiliary_signals[0]["signal_id"] == "open_signal_demo"
+    assert auxiliary_signals[0]["training_use"]["review_status"] == "reviewed_promoted"
+
+    features = extract_tiny_action_features(target)
+    assert "aux_signal.model:segment_anything_sam_vit" in features
+    assert "aux_signal.status:completed" in features
+    assert "aux_signal.review_status:reviewed_promoted" in features
+    assert "aux_signal.sam_mask_count:2-4" in features
+    assert "aux_signal.sam_total_area_pct:25-50" in features
+
+
+def test_open_model_signal_review_cli_writes_review_and_promotion_manifest(tmp_path):
+    signal_path = tmp_path / "signals.jsonl"
+    reviewed_path = tmp_path / "signals.reviewed.jsonl"
+    promoted_path = tmp_path / "signals.promoted.jsonl"
+    manifest_path = tmp_path / "signals.promotion_manifest.json"
+    record = _completed_sam_signal_record(_first_decompose_example())
+    _write_jsonl(signal_path, [record])
+
+    review_result = subprocess.run(
+        [
+            sys.executable,
+            str(ROOT / "scripts/open_model_signal_review.py"),
+            "review",
+            "--input",
+            str(signal_path),
+            "--output",
+            str(reviewed_path),
+            "--signal-id",
+            record["signal_id"],
+            "--decision",
+            "promote",
+            "--reviewer",
+            "human-reviewer",
+            "--reviewed-at",
+            "2026-05-06T21:00:00Z",
+        ],
+        cwd=ROOT,
+        env=CLI_ENV,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert review_result.returncode == 0, review_result.stderr
+    assert "Reviewed signal:" in review_result.stdout
+
+    promote_result = subprocess.run(
+        [
+            sys.executable,
+            str(ROOT / "scripts/open_model_signal_review.py"),
+            "promote",
+            "--input",
+            str(reviewed_path),
+            "--output",
+            str(promoted_path),
+            "--manifest",
+            str(manifest_path),
+            "--source-id",
+            "sam-reviewed-v1",
+        ],
+        cwd=ROOT,
+        env=CLI_ENV,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert promote_result.returncode == 0, promote_result.stderr
+    assert "Promoted signals: 1" in promote_result.stdout
+    assert json.loads(manifest_path.read_text(encoding="utf-8"))["record_count"] == 1


### PR DESCRIPTION
## Summary
- add human review + promoted-pack flow for open-model signal records
- allow tiny dataset/training gate to explicitly attach reviewed auxiliary signal manifests
- add low-weight auxiliary signal features to tiny_action_model_v1

## Safety
- open-model signals remain excluded from default training input
- dry-run and skipped signals cannot be promoted
- promotion requires an explicit manifest flag before dataset attachment

## Verification
- PYTHONPATH=src /opt/homebrew/bin/python3.11 -m pytest tests/test_open_model_signal_review.py tests/test_open_model_signal_adapter.py tests/test_tiny_dataset_export.py tests/test_tiny_action_model.py tests/test_tiny_training_eval_gate.py -q
- /opt/homebrew/bin/python3.11 -m py_compile src/vulca/learning/open_model_signal_review.py src/vulca/learning/tiny_dataset.py src/vulca/learning/tiny_action_model.py src/vulca/learning/tiny_training_eval.py scripts/open_model_signal_review.py scripts/tiny_training_eval_gate.py
- ruff check src/vulca/learning/open_model_signal_review.py src/vulca/learning/tiny_dataset.py src/vulca/learning/tiny_action_model.py src/vulca/learning/tiny_training_eval.py scripts/open_model_signal_review.py scripts/tiny_training_eval_gate.py tests/test_open_model_signal_review.py
- git diff --cached --check