### PR TITLE
feat(learning): add open model signal review table

### DIFF
--- a/docs/superpowers/plans/2026-05-06-open-model-signal-review-table-v1.md
+++ b/docs/superpowers/plans/2026-05-06-open-model-signal-review-table-v1.md
@@ -1,0 +1,48 @@
+# Open-Model Signal Review Table V1
+
+## Goal
+
+Turn completed open-model signal records into a human review worklist before
+promotion. The table is an operator surface for deciding promote/reject/hold,
+not an automatic training input.
+
+## Scope
+
+- Add `vulca.learning.open_model_signal_review_table`.
+- Add `scripts/open_model_signal_review_table.py`.
+- Export JSONL, CSV, Markdown, and a JSON report.
+- Default to `completed` signals only. Skipped and dry-run signals stay out of
+  the review table unless a caller explicitly includes those statuses.
+- Include promote/reject/hold commands that call
+  `scripts/open_model_signal_review.py review`.
+
+## Safety Policy
+
+- The table does not promote records by itself.
+- The table only prepares human review decisions.
+- Training still requires the separate promotion manifest from
+  `open_model_signal_review.py promote`.
+- Output rows only summarize safe signal fields: ids, model metadata, case
+  metadata, caption/OCR previews, and mask summary metrics.
+
+## Verification
+
+Run:
+
+```bash
+PYTHONPATH=src /opt/homebrew/bin/python3.11 -m pytest \
+  tests/test_open_model_signal_review_table.py \
+  tests/test_open_model_signal_review.py \
+  tests/test_open_model_signal_adapter.py -q
+
+/opt/homebrew/bin/python3.11 -m py_compile \
+  src/vulca/learning/open_model_signal_review_table.py \
+  scripts/open_model_signal_review_table.py
+
+ruff check \
+  src/vulca/learning/open_model_signal_review_table.py \
+  scripts/open_model_signal_review_table.py \
+  tests/test_open_model_signal_review_table.py
+
+git diff --check
+```

--- a/scripts/open_model_signal_review_table.py
+++ b/scripts/open_model_signal_review_table.py
@@ -1,0 +1,99 @@
+"""Write a review table for completed open-model signal records."""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Sequence
+
+
+ROOT = Path(__file__).resolve().parent.parent
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from vulca.learning.open_model_signal_review_table import (  # noqa: E402
+    DEFAULT_OUTPUT_DIR,
+    DEFAULT_REVIEWABLE_STATUSES,
+    run_open_model_signal_review_table,
+)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Export JSONL/CSV/Markdown rows for human review of completed "
+            "open-model signal records."
+        )
+    )
+    parser.add_argument("--input", required=True, help="Open-model signal JSONL path.")
+    parser.add_argument(
+        "--output-dir",
+        default=str(DEFAULT_OUTPUT_DIR),
+        help="Directory for review table artifacts.",
+    )
+    parser.add_argument(
+        "--report",
+        default="",
+        help="Stable JSON report path (default: OUTPUT_DIR/open_model_signal_review_table_report.json).",
+    )
+    parser.add_argument(
+        "--reviewed-output",
+        default="",
+        help="Reviewed signal JSONL path used in generated review commands.",
+    )
+    parser.add_argument(
+        "--include-status",
+        action="append",
+        default=[],
+        help=(
+            "Signal status to include; repeat for multiple statuses. "
+            f"Default: {DEFAULT_REVIEWABLE_STATUSES}."
+        ),
+    )
+    parser.add_argument(
+        "--max-preview-chars",
+        type=int,
+        default=120,
+        help="Maximum caption/OCR preview length per row.",
+    )
+    parser.add_argument(
+        "--pretty",
+        action="store_true",
+        help="Print the full JSON report to stdout after writing it.",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        report = run_open_model_signal_review_table(
+            input_path=args.input,
+            output_dir=args.output_dir,
+            report_path=args.report or None,
+            reviewed_output_path=args.reviewed_output or None,
+            reviewable_statuses=tuple(args.include_status)
+            or DEFAULT_REVIEWABLE_STATUSES,
+            max_preview_chars=args.max_preview_chars,
+        )
+    except (ValueError, FileNotFoundError, json.JSONDecodeError) as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 2
+
+    if args.pretty:
+        print(json.dumps(report, indent=2, sort_keys=True))
+
+    artifacts = report["artifacts"]
+    summary = report["summary"]
+    print(f"Open-model signal review table: {artifacts['report_path']}")
+    print(f"JSONL: {artifacts['review_table_jsonl_path']}")
+    print(f"CSV: {artifacts['review_table_csv_path']}")
+    print(f"Markdown: {artifacts['review_table_markdown_path']}")
+    print(f"Input records: {summary['input_record_count']}")
+    print(f"Reviewable rows: {summary['row_count']}")
+    print(f"Status counts: {summary['status_counts']}")
+    print(f"Review table status: {report['status']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/vulca/learning/open_model_signal_review_table.py
+++ b/src/vulca/learning/open_model_signal_review_table.py
@@ -1,0 +1,367 @@
+"""Review table export for completed open-model signal records."""
+from __future__ import annotations
+
+import csv
+import json
+import shlex
+from collections import Counter
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+from vulca.learning.case_review import load_cases
+from vulca.learning.open_model_signals import SIGNAL_RECORD_CASE_TYPE
+
+
+SCHEMA_VERSION = 1
+REPORT_CASE_TYPE = "learning_open_model_signal_review_table"
+ROW_CASE_TYPE = "learning_open_model_signal_review_row"
+DEFAULT_OUTPUT_DIR = Path("build/open_model_signal_review_table")
+DEFAULT_REPORT_NAME = "open_model_signal_review_table_report.json"
+DEFAULT_JSONL_NAME = "open_model_signal_review_table.jsonl"
+DEFAULT_CSV_NAME = "open_model_signal_review_table.csv"
+DEFAULT_MARKDOWN_NAME = "open_model_signal_review_table.md"
+DEFAULT_REVIEWABLE_STATUSES: tuple[str, ...] = ("completed",)
+CSV_COLUMNS: tuple[str, ...] = (
+    "signal_id",
+    "example_id",
+    "model_id",
+    "model_role",
+    "source_case_type",
+    "case_id",
+    "signal_status",
+    "signal_source",
+    "source_image_ref_kind",
+    "source_image_width",
+    "source_image_height",
+    "caption_preview",
+    "ocr_preview",
+    "mask_count",
+    "total_mask_area_pct",
+    "boundary_complexity",
+    "suggested_review_decision",
+    "review_priority",
+    "review_reason",
+    "review_command_promote",
+    "review_command_reject",
+    "review_command_hold",
+)
+MARKDOWN_COLUMNS: tuple[str, ...] = (
+    "signal_id",
+    "model_id",
+    "source_case_type",
+    "case_id",
+    "caption_preview",
+    "ocr_preview",
+    "mask_count",
+    "suggested_review_decision",
+)
+
+
+def run_open_model_signal_review_table(
+    *,
+    input_path: str | Path,
+    output_dir: str | Path = DEFAULT_OUTPUT_DIR,
+    report_path: str | Path | None = None,
+    reviewed_output_path: str | Path | None = None,
+    reviewable_statuses: Sequence[str] = DEFAULT_REVIEWABLE_STATUSES,
+    max_preview_chars: int = 120,
+) -> dict[str, Any]:
+    """Write JSONL/CSV/Markdown rows for human reviewable signal records."""
+    source_path = Path(input_path)
+    output = Path(output_dir)
+    output.mkdir(parents=True, exist_ok=True)
+    resolved_report_path = Path(report_path) if report_path else output / DEFAULT_REPORT_NAME
+    resolved_reviewed_output = (
+        Path(reviewed_output_path)
+        if reviewed_output_path is not None
+        else _default_reviewed_output_path(source_path)
+    )
+    reviewable = {str(item) for item in reviewable_statuses}
+    records = load_cases(source_path)
+    status_counts = _status_counts(records)
+
+    rows = [
+        _build_row(
+            record,
+            input_path=source_path,
+            reviewed_output_path=resolved_reviewed_output,
+            max_preview_chars=max_preview_chars,
+        )
+        for record in records
+        if _signal_status(record) in reviewable
+    ]
+    rows = sorted(
+        rows,
+        key=lambda item: (
+            -int(item["review_priority"]),
+            str(item["source_case_type"]),
+            str(item["case_id"]),
+            str(item["signal_id"]),
+        ),
+    )
+
+    jsonl_path = output / DEFAULT_JSONL_NAME
+    csv_path = output / DEFAULT_CSV_NAME
+    markdown_path = output / DEFAULT_MARKDOWN_NAME
+    _write_jsonl(jsonl_path, rows)
+    _write_csv(csv_path, rows)
+    _write_markdown(markdown_path, rows)
+
+    included_status_counts = Counter(str(row["signal_status"]) for row in rows)
+    excluded_status_counts = Counter(status_counts)
+    for status, count in included_status_counts.items():
+        excluded_status_counts[status] -= count
+        if excluded_status_counts[status] <= 0:
+            del excluded_status_counts[status]
+
+    report = {
+        "schema_version": SCHEMA_VERSION,
+        "case_type": REPORT_CASE_TYPE,
+        "status": "ready_for_human_review",
+        "inputs": {
+            "input_path": str(source_path),
+            "reviewable_statuses": sorted(reviewable),
+            "max_preview_chars": int(max_preview_chars),
+            "reviewed_output_path": str(resolved_reviewed_output),
+        },
+        "artifacts": {
+            "report_path": str(resolved_report_path),
+            "review_table_jsonl_path": str(jsonl_path),
+            "review_table_csv_path": str(csv_path),
+            "review_table_markdown_path": str(markdown_path),
+        },
+        "summary": {
+            "input_record_count": len(records),
+            "row_count": len(rows),
+            "status_counts": dict(sorted(status_counts.items())),
+            "excluded_status_counts": dict(sorted(excluded_status_counts.items())),
+            "counts_by_model": _counts_by_key(rows, "model_id"),
+            "counts_by_source_case_type": _counts_by_key(rows, "source_case_type"),
+        },
+    }
+    resolved_report_path.parent.mkdir(parents=True, exist_ok=True)
+    resolved_report_path.write_text(
+        json.dumps(report, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return report
+
+
+def _build_row(
+    record: Mapping[str, Any],
+    *,
+    input_path: Path,
+    reviewed_output_path: Path,
+    max_preview_chars: int,
+) -> dict[str, Any]:
+    if record.get("case_type") != SIGNAL_RECORD_CASE_TYPE:
+        raise ValueError(
+            f"signal record case_type must be {SIGNAL_RECORD_CASE_TYPE!r}"
+        )
+    signals = _mapping(record.get("signals"))
+    model = _mapping(record.get("model"))
+    source_case = _mapping(record.get("source_case"))
+    source_image = _mapping(signals.get("source_image"))
+    signal_id = str(record.get("signal_id") or "")
+    signal_status = str(signals.get("status") or "")
+    model_id = str(model.get("id") or "")
+    caption_preview = _preview_text(
+        signals.get("caption_candidates"),
+        max_chars=max_preview_chars,
+    )
+    ocr_preview = _preview_text(signals.get("ocr_text"), max_chars=max_preview_chars)
+    mask_count = signals.get("mask_count")
+    total_area = signals.get("total_mask_area_pct")
+    boundary_complexity = str(signals.get("boundary_complexity") or "")
+
+    review_priority, review_reason = _review_priority(
+        model_id=model_id,
+        caption_preview=caption_preview,
+        ocr_preview=ocr_preview,
+        mask_count=mask_count,
+        signal_status=signal_status,
+    )
+    base = {
+        "schema_version": SCHEMA_VERSION,
+        "row_case_type": ROW_CASE_TYPE,
+        "signal_id": signal_id,
+        "example_id": str(record.get("example_id") or ""),
+        "model_id": model_id,
+        "model_role": str(model.get("model_role") or ""),
+        "source_case_type": str(source_case.get("case_type") or ""),
+        "case_id": str(source_case.get("case_id") or ""),
+        "signal_status": signal_status,
+        "signal_source": str(signals.get("signal_source") or ""),
+        "source_image_ref_kind": str(source_image.get("ref_kind") or ""),
+        "source_image_width": source_image.get("width"),
+        "source_image_height": source_image.get("height"),
+        "caption_preview": caption_preview,
+        "ocr_preview": ocr_preview,
+        "mask_count": mask_count,
+        "total_mask_area_pct": total_area,
+        "boundary_complexity": boundary_complexity,
+        "suggested_review_decision": "hold",
+        "review_priority": review_priority,
+        "review_reason": review_reason,
+    }
+    base.update(
+        {
+            "review_command_promote": _review_command(
+                input_path=input_path,
+                reviewed_output_path=reviewed_output_path,
+                signal_id=signal_id,
+                decision="promote",
+            ),
+            "review_command_reject": _review_command(
+                input_path=input_path,
+                reviewed_output_path=reviewed_output_path,
+                signal_id=signal_id,
+                decision="reject",
+            ),
+            "review_command_hold": _review_command(
+                input_path=input_path,
+                reviewed_output_path=reviewed_output_path,
+                signal_id=signal_id,
+                decision="hold",
+            ),
+        }
+    )
+    return base
+
+
+def _review_command(
+    *,
+    input_path: Path,
+    reviewed_output_path: Path,
+    signal_id: str,
+    decision: str,
+) -> str:
+    parts = [
+        "python",
+        "scripts/open_model_signal_review.py",
+        "review",
+        "--input",
+        str(input_path),
+        "--output",
+        str(reviewed_output_path),
+        "--signal-id",
+        signal_id,
+        "--decision",
+        decision,
+        "--reviewer",
+        "human",
+    ]
+    return " ".join(shlex.quote(part) for part in parts)
+
+
+def _review_priority(
+    *,
+    model_id: str,
+    caption_preview: str,
+    ocr_preview: str,
+    mask_count: Any,
+    signal_status: str,
+) -> tuple[int, str]:
+    score = 40
+    reasons = [f"signal_status:{signal_status}"]
+    if model_id == "segment_anything_sam_vit":
+        score += 30
+        reasons.append("mask_signal")
+    if mask_count not in (None, ""):
+        score += 10
+        reasons.append("has_mask_count")
+    if caption_preview:
+        score += 10
+        reasons.append("has_caption")
+    if ocr_preview:
+        score += 5
+        reasons.append("has_ocr")
+    return min(score, 100), "; ".join(reasons)
+
+
+def _status_counts(records: Sequence[Mapping[str, Any]]) -> Counter[str]:
+    return Counter(_signal_status(record) for record in records)
+
+
+def _signal_status(record: Mapping[str, Any]) -> str:
+    return str(_mapping(record.get("signals")).get("status") or "unknown")
+
+
+def _counts_by_key(rows: Sequence[Mapping[str, Any]], key: str) -> dict[str, int]:
+    counts: Counter[str] = Counter()
+    for row in rows:
+        counts[str(row.get(key) or "unknown")] += 1
+    return dict(sorted(counts.items()))
+
+
+def _preview_text(value: Any, *, max_chars: int) -> str:
+    text = " | ".join(_flatten_text(value))
+    text = " ".join(text.split())
+    if len(text) <= max_chars:
+        return text
+    return f"{text[: max(0, max_chars - 1)].rstrip()}..."
+
+
+def _flatten_text(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return [value] if value else []
+    if isinstance(value, Mapping):
+        texts: list[str] = []
+        for child in value.values():
+            texts.extend(_flatten_text(child))
+        return texts
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+        texts = []
+        for item in value:
+            texts.extend(_flatten_text(item))
+        return texts
+    return [str(value)]
+
+
+def _write_jsonl(path: Path, rows: Sequence[Mapping[str, Any]]) -> None:
+    with path.open("w", encoding="utf-8") as handle:
+        for row in rows:
+            handle.write(json.dumps(dict(row), sort_keys=True, separators=(",", ":")))
+            handle.write("\n")
+
+
+def _write_csv(path: Path, rows: Sequence[Mapping[str, Any]]) -> None:
+    with path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=CSV_COLUMNS, extrasaction="ignore")
+        writer.writeheader()
+        for row in rows:
+            writer.writerow(dict(row))
+
+
+def _write_markdown(path: Path, rows: Sequence[Mapping[str, Any]]) -> None:
+    lines = [
+        "# Open-Model Signal Review Table",
+        "",
+        "| " + " | ".join(MARKDOWN_COLUMNS) + " |",
+        "| " + " | ".join("---" for _ in MARKDOWN_COLUMNS) + " |",
+    ]
+    for row in rows:
+        lines.append(
+            "| "
+            + " | ".join(_markdown_cell(row.get(column)) for column in MARKDOWN_COLUMNS)
+            + " |"
+        )
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _markdown_cell(value: Any) -> str:
+    return str(value if value is not None else "").replace("|", "\\|")
+
+
+def _default_reviewed_output_path(input_path: Path) -> Path:
+    if input_path.suffix == ".jsonl":
+        return input_path.with_name(f"{input_path.stem}.reviewed{input_path.suffix}")
+    return input_path.with_name(f"{input_path.name}.reviewed.jsonl")
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    if isinstance(value, Mapping):
+        return value
+    return {}

--- a/tests/test_open_model_signal_review_table.py
+++ b/tests/test_open_model_signal_review_table.py
@@ -1,0 +1,227 @@
+import csv
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+CLI_ENV = dict(
+    os.environ,
+    PYTHONPATH=str(ROOT / "src") + os.pathsep + os.environ.get("PYTHONPATH", ""),
+)
+SCRIPT = ROOT / "scripts" / "open_model_signal_review_table.py"
+
+
+def _read_jsonl(path: Path) -> list[dict]:
+    return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines()]
+
+
+def _write_jsonl(path: Path, records: list[dict]) -> None:
+    path.write_text(
+        "".join(json.dumps(record, sort_keys=True) + "\n" for record in records),
+        encoding="utf-8",
+    )
+
+
+def _signal_record(
+    signal_id: str,
+    *,
+    model_id: str = "florence_2",
+    case_type: str = "redraw_case",
+    case_id: str = "redraw_case_1",
+    status: str = "completed",
+    signals: dict | None = None,
+) -> dict:
+    signal_block = {
+        "status": status,
+        "signal_source": "local_runner",
+        "label_source": "assistant_labeled",
+        "review_status": "needs_human_review",
+        "caption_candidates": ["A red car parked by the road."],
+        "ocr_text": ["JAMES CO.UK"],
+        "source_image": {
+            "available": status == "completed",
+            "ref_kind": "repo_relative",
+            "width": 4032,
+            "height": 3024,
+        },
+    }
+    if signals is not None:
+        signal_block.update(signals)
+    return {
+        "schema_version": 1,
+        "case_type": "learning_open_model_signal_record",
+        "signal_id": signal_id,
+        "example_id": f"tiny_{signal_id}",
+        "source": {"kind": "local_seed", "split": "seed"},
+        "source_case": {
+            "case_type": case_type,
+            "case_id": case_id,
+            "schema_version": 1,
+        },
+        "model": {
+            "id": model_id,
+            "name": model_id,
+            "model_role": "mask_proposal"
+            if model_id == "segment_anything_sam_vit"
+            else "vision_caption_grounding_ocr",
+            "output_training_policy": "weak_signal_requires_review",
+            "default_runtime_enabled": False,
+        },
+        "input_summary": {
+            "case_type": case_type,
+            "case_id": case_id,
+            "source_image_ref_kind": "repo_relative",
+        },
+        "signals": signal_block,
+        "training_use": {
+            "default_training_input": False,
+            "requires_manual_review_for_training_labels": True,
+            "review_status": "needs_human_review",
+        },
+    }
+
+
+def test_open_model_signal_review_table_exports_completed_rows_only(tmp_path):
+    from vulca.learning.open_model_signal_review_table import (
+        run_open_model_signal_review_table,
+    )
+
+    input_path = tmp_path / "signals.jsonl"
+    _write_jsonl(
+        input_path,
+        [
+            _signal_record("open_signal_completed_a"),
+            _signal_record("open_signal_skipped", status="skipped"),
+            _signal_record(
+                "open_signal_dry",
+                status="dry_run_pending_model_execution",
+                signals={"signal_source": "dry_run"},
+            ),
+            _signal_record(
+                "open_signal_completed_sam",
+                model_id="segment_anything_sam_vit",
+                case_type="decompose_case",
+                case_id="decompose_case_1",
+                signals={
+                    "mask_count": 3,
+                    "total_mask_area_pct": 0.42,
+                    "boundary_complexity": "medium",
+                    "mask_coverage_candidates": [
+                        {"area_pct": 0.21, "bbox": [4, 8, 40, 64]},
+                    ],
+                },
+            ),
+        ],
+    )
+
+    report = run_open_model_signal_review_table(
+        input_path=input_path,
+        output_dir=tmp_path / "review_table",
+        report_path=tmp_path / "review_table_report.json",
+        reviewed_output_path=tmp_path / "signals.reviewed.jsonl",
+    )
+
+    assert report["case_type"] == "learning_open_model_signal_review_table"
+    assert report["status"] == "ready_for_human_review"
+    assert report["summary"]["input_record_count"] == 4
+    assert report["summary"]["row_count"] == 2
+    assert report["summary"]["status_counts"] == {
+        "completed": 2,
+        "dry_run_pending_model_execution": 1,
+        "skipped": 1,
+    }
+    assert report["summary"]["excluded_status_counts"] == {
+        "dry_run_pending_model_execution": 1,
+        "skipped": 1,
+    }
+
+    rows = _read_jsonl(Path(report["artifacts"]["review_table_jsonl_path"]))
+    assert [row["signal_id"] for row in rows] == [
+        "open_signal_completed_sam",
+        "open_signal_completed_a",
+    ]
+    assert all(row["signal_status"] == "completed" for row in rows)
+    assert {row["suggested_review_decision"] for row in rows} == {"hold"}
+    assert rows[0]["model_id"] == "segment_anything_sam_vit"
+    assert rows[0]["mask_count"] == 3
+    assert rows[0]["total_mask_area_pct"] == 0.42
+    assert rows[0]["boundary_complexity"] == "medium"
+    assert rows[1]["caption_preview"] == "A red car parked by the road."
+    assert rows[1]["ocr_preview"] == "JAMES CO.UK"
+    assert "open_model_signal_review.py review" in rows[0]["review_command_promote"]
+    assert "--decision promote" in rows[0]["review_command_promote"]
+    assert "--decision reject" in rows[0]["review_command_reject"]
+    assert "--decision hold" in rows[0]["review_command_hold"]
+
+
+def test_open_model_signal_review_table_writes_csv_and_markdown(tmp_path):
+    from vulca.learning.open_model_signal_review_table import (
+        run_open_model_signal_review_table,
+    )
+
+    input_path = tmp_path / "signals.jsonl"
+    _write_jsonl(
+        input_path,
+        [
+            _signal_record("open_signal_completed_a"),
+            _signal_record("open_signal_skipped", status="skipped"),
+        ],
+    )
+
+    report = run_open_model_signal_review_table(
+        input_path=input_path,
+        output_dir=tmp_path / "review_table",
+    )
+
+    csv_path = Path(report["artifacts"]["review_table_csv_path"])
+    with csv_path.open(newline="", encoding="utf-8") as handle:
+        rows = list(csv.DictReader(handle))
+
+    assert len(rows) == 1
+    assert rows[0]["signal_id"] == "open_signal_completed_a"
+    assert rows[0]["caption_preview"] == "A red car parked by the road."
+    assert rows[0]["review_command_promote"]
+
+    markdown = Path(report["artifacts"]["review_table_markdown_path"]).read_text(
+        encoding="utf-8"
+    )
+    assert "| signal_id | model_id | source_case_type |" in markdown
+    assert "open_signal_completed_a" in markdown
+    assert "open_signal_skipped" not in markdown
+
+
+def test_open_model_signal_review_table_cli_writes_artifacts(tmp_path):
+    input_path = tmp_path / "signals.jsonl"
+    output_dir = tmp_path / "review_table"
+    report_path = tmp_path / "review_table_report.json"
+    _write_jsonl(input_path, [_signal_record("open_signal_completed_a")])
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--input",
+            str(input_path),
+            "--output-dir",
+            str(output_dir),
+            "--report",
+            str(report_path),
+        ],
+        cwd=ROOT,
+        env=CLI_ENV,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    report = json.loads(report_path.read_text(encoding="utf-8"))
+    assert report["summary"]["row_count"] == 1
+    assert Path(report["artifacts"]["review_table_jsonl_path"]).exists()
+    assert Path(report["artifacts"]["review_table_csv_path"]).exists()
+    assert Path(report["artifacts"]["review_table_markdown_path"]).exists()
+    assert "Open-model signal review table:" in result.stdout
+    assert "Reviewable rows: 1" in result.stdout


### PR DESCRIPTION
## Summary
- add JSONL/CSV/Markdown review table export for completed open-model signal records
- include promote/reject/hold commands for the existing signal review gate
- default table rows to completed signals only so skipped/dry-run records are not mixed into human promotion work

## Pilot smoke
- copied the local Florence-2 pilot signals into build/ and generated a review table
- 12 input records -> 7 completed review rows, 5 skipped excluded

## Verification
- PYTHONPATH=src /opt/homebrew/bin/python3.11 -m pytest tests/test_open_model_signal_review_table.py tests/test_open_model_signal_review.py tests/test_open_model_signal_adapter.py -q
- /opt/homebrew/bin/python3.11 -m py_compile src/vulca/learning/open_model_signal_review_table.py scripts/open_model_signal_review_table.py
- ruff check src/vulca/learning/open_model_signal_review_table.py scripts/open_model_signal_review_table.py tests/test_open_model_signal_review_table.py
- git diff --check
- git diff --cached --check