### PR TITLE
feat(learning): add private asset map resolver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ env/
 .env
 .env.*
 !.env.example
+*.private.asset_map.json
 
 # Editor / OS
 .vscode/

--- a/scripts/open_model_signal_adapter.py
+++ b/scripts/open_model_signal_adapter.py
@@ -120,6 +120,15 @@ def main(argv: Sequence[str] | None = None) -> int:
         help="SAM automatic mask generator points_per_side for local pilot runs.",
     )
     parser.add_argument(
+        "--private-asset-map",
+        action="append",
+        default=[],
+        help=(
+            "Local-only private:// asset map JSON for resolving reviewed user "
+            "case images. Repeat for multiple maps."
+        ),
+    )
+    parser.add_argument(
         "--no-local-seeds",
         action="store_true",
         help="Only use records from the case source manifest.",
@@ -149,6 +158,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             sam_model_type=args.sam_model_type,
             sam_device=args.sam_device,
             sam_points_per_side=args.sam_points_per_side,
+            private_asset_map_paths=tuple(args.private_asset_map),
         )
     except (FileNotFoundError, RuntimeError, ValueError, json.JSONDecodeError) as exc:
         print(f"Error: {exc}", file=sys.stderr)

--- a/src/vulca/cli.py
+++ b/src/vulca/cli.py
@@ -363,6 +363,16 @@ def main(argv: list[str] | None = None) -> None:
         default="",
         help="Output case source manifest path (default: OUTPUT_DIR/SOURCE.case_source_manifest.json)",
     )
+    cases_intake_user.add_argument(
+        "--write-private-asset-map",
+        action="store_true",
+        help="Write a local-only private:// ref to absolute path sidecar map",
+    )
+    cases_intake_user.add_argument(
+        "--asset-map-output",
+        default="",
+        help="Output private asset map path (default: OUTPUT_DIR/SOURCE.private.asset_map.json)",
+    )
     cases_seed = cases_sub.add_parser("seed", help="Build local seed case JSONL logs")
     cases_seed.add_argument(
         "--output",
@@ -1783,6 +1793,8 @@ def _cmd_cases(args: argparse.Namespace) -> None:
                 output_dir=args.output_dir or None,
                 output_path=args.output_log or None,
                 manifest_path=args.manifest_output or None,
+                asset_map_path=args.asset_map_output or None,
+                write_private_asset_map=bool(args.write_private_asset_map),
             )
         except (ValueError, FileNotFoundError, _json.JSONDecodeError) as exc:
             print(f"Error: {exc}", file=sys.stderr)
@@ -1792,6 +1804,8 @@ def _cmd_cases(args: argparse.Namespace) -> None:
         print(f"  Records: {result.record_count}")
         print(f"  Source id: {result.source_id}")
         print(f"  Case source manifest: {result.manifest_path}")
+        if result.asset_map_path:
+            print(f"  Private asset map: {result.asset_map_path}")
         return
 
     if args.cases_command == "export-dataset":

--- a/src/vulca/learning/florence_signal_runner.py
+++ b/src/vulca/learning/florence_signal_runner.py
@@ -7,9 +7,14 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Mapping, Protocol
+from typing import Any, Mapping, Protocol, Sequence
 
 from PIL import Image
+
+from vulca.learning.private_asset_map import (
+    load_private_asset_maps,
+    resolve_private_asset_ref,
+)
 
 
 DEFAULT_FLORENCE_MODEL_ID = "microsoft/Florence-2-base"
@@ -39,6 +44,7 @@ def build_florence2_signal_runner(
     model_id: str = DEFAULT_FLORENCE_MODEL_ID,
     device: str = "auto",
     allow_weight_download: bool = False,
+    private_asset_map_paths: Sequence[str | Path] = (),
 ) -> Any:
     """Build a local Florence-2 signal runner.
 
@@ -46,6 +52,7 @@ def build_florence2_signal_runner(
     local cached weights unless the caller explicitly opts into downloads.
     """
     root = Path(repo_root)
+    private_asset_map = load_private_asset_maps(private_asset_map_paths)
     resolved_backend = backend or Florence2LocalBackend(
         model_id=model_id,
         device=device,
@@ -54,7 +61,11 @@ def build_florence2_signal_runner(
 
     def run(example: Mapping[str, Any], model_spec: Mapping[str, Any]) -> dict[str, Any]:
         case_record = _case_record_from_example(example)
-        source = resolve_case_source_image_path(case_record, repo_root=root)
+        source = resolve_case_source_image_path(
+            case_record,
+            repo_root=root,
+            private_asset_map=private_asset_map,
+        )
         if source.path is None:
             return {
                 "status": "skipped",
@@ -100,13 +111,25 @@ def resolve_case_source_image_path(
     case_record: Mapping[str, Any],
     *,
     repo_root: str | Path,
+    private_asset_map: Mapping[str, str | Path] | None = None,
 ) -> ResolvedSourceImage:
     """Resolve a case source image to a local path without leaking private refs."""
     ref = _source_image_ref(case_record)
     if not ref:
         return ResolvedSourceImage(path=None, ref_kind="missing")
     ref_kind = _ref_kind(ref)
-    if ref_kind in {"private_uri", "remote_url"}:
+    if ref_kind == "private_uri":
+        private_path = resolve_private_asset_ref(
+            ref,
+            private_asset_map=private_asset_map,
+        )
+        if private_path is not None and private_path.exists():
+            return ResolvedSourceImage(
+                path=private_path,
+                ref_kind="private_uri_mapped",
+            )
+        return ResolvedSourceImage(path=None, ref_kind=ref_kind)
+    if ref_kind == "remote_url":
         return ResolvedSourceImage(path=None, ref_kind=ref_kind)
 
     candidate = Path(ref)

--- a/src/vulca/learning/open_model_signals.py
+++ b/src/vulca/learning/open_model_signals.py
@@ -58,6 +58,7 @@ def run_open_model_signal_adapter(
     sam_model_type: str = "vit_b",
     sam_device: str = "auto",
     sam_points_per_side: int = 16,
+    private_asset_map_paths: Sequence[str | Path] = (),
 ) -> dict[str, Any]:
     """Write dry-run or injected open-model signal records and a summary report."""
     if max_examples is not None and max_examples < 0:
@@ -97,6 +98,7 @@ def run_open_model_signal_adapter(
         sam_model_type=sam_model_type,
         sam_device=sam_device,
         sam_points_per_side=sam_points_per_side,
+        private_asset_map_paths=private_asset_map_paths,
     )
     records = build_open_model_signal_records(
         examples,
@@ -118,6 +120,7 @@ def run_open_model_signal_adapter(
         enable_local_runners=enable_local_runners,
         max_examples=max_examples,
         weight_download_enabled=allow_weight_download,
+        private_asset_map_count=len(private_asset_map_paths),
     )
     resolved_report_path.parent.mkdir(parents=True, exist_ok=True)
     resolved_report_path.write_text(
@@ -224,6 +227,7 @@ def build_open_model_signal_report(
     enable_local_runners: Sequence[str] = (),
     max_examples: int | None = None,
     weight_download_enabled: bool = False,
+    private_asset_map_count: int = 0,
 ) -> dict[str, Any]:
     """Summarize signal-record coverage and safety policy."""
     counts_by_model: Counter[str] = Counter()
@@ -250,6 +254,7 @@ def build_open_model_signal_report(
             "model_ids": [str(item.get("id") or "") for item in model_specs],
             "enable_local_runners": [str(item) for item in enable_local_runners],
             "max_examples": max_examples,
+            "private_asset_map_count": int(private_asset_map_count),
         },
         "artifacts": {
             "output_path": _safe_artifact_path(repo_root, output_path),
@@ -372,6 +377,7 @@ def _build_runner_map(
     sam_model_type: str,
     sam_device: str,
     sam_points_per_side: int,
+    private_asset_map_paths: Sequence[str | Path],
 ) -> dict[str, SignalRunner]:
     runner_map = dict(runners or {})
     model_id_set = {str(item) for item in model_ids}
@@ -397,6 +403,7 @@ def _build_runner_map(
                     "allow_weight_download": allow_weight_download,
                     "model_id": florence_model_id,
                     "device": florence_device,
+                    "private_asset_map_paths": tuple(private_asset_map_paths),
                 }
             elif model_id == "segment_anything_sam_vit":
                 from vulca.learning.sam_signal_runner import (
@@ -410,6 +417,7 @@ def _build_runner_map(
                     "model_type": sam_model_type,
                     "device": sam_device,
                     "points_per_side": sam_points_per_side,
+                    "private_asset_map_paths": tuple(private_asset_map_paths),
                 }
             else:
                 raise ValueError(f"no local runner is available for model {model_id!r}")
@@ -424,6 +432,7 @@ def _build_runner_map(
                 sam_model_type=sam_model_type,
                 sam_device=sam_device,
                 sam_points_per_side=sam_points_per_side,
+                private_asset_map_paths=private_asset_map_paths,
             )
         runner_map[model_id] = factory(**factory_kwargs)
     return runner_map
@@ -440,6 +449,7 @@ def _local_runner_factory_kwargs(
     sam_model_type: str,
     sam_device: str,
     sam_points_per_side: int,
+    private_asset_map_paths: Sequence[str | Path],
 ) -> dict[str, Any]:
     if model_id == "florence_2":
         return {
@@ -447,6 +457,7 @@ def _local_runner_factory_kwargs(
             "allow_weight_download": allow_weight_download,
             "model_id": florence_model_id,
             "device": florence_device,
+            "private_asset_map_paths": tuple(private_asset_map_paths),
         }
     if model_id == "segment_anything_sam_vit":
         return {
@@ -455,8 +466,12 @@ def _local_runner_factory_kwargs(
             "model_type": sam_model_type,
             "device": sam_device,
             "points_per_side": sam_points_per_side,
+            "private_asset_map_paths": tuple(private_asset_map_paths),
         }
-    return {"repo_root": repo_root}
+    return {
+        "repo_root": repo_root,
+        "private_asset_map_paths": tuple(private_asset_map_paths),
+    }
 
 
 def _safe_model_summary(model_spec: Mapping[str, Any]) -> dict[str, Any]:

--- a/src/vulca/learning/private_asset_map.py
+++ b/src/vulca/learning/private_asset_map.py
@@ -1,0 +1,94 @@
+"""Private local asset map helpers for reviewed user cases.
+
+The map intentionally lives outside training records. It may contain absolute
+local paths, so callers should keep it local-only and never promote it into
+shared benchmark artifacts.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Mapping, Sequence
+
+
+PRIVATE_ASSET_MAP_SCHEMA_VERSION = 1
+PRIVATE_ASSET_MAP_CASE_TYPE = "learning_private_asset_map"
+PRIVATE_LOCAL_PRIVACY_SCOPE = "private_local"
+
+
+def write_private_asset_map(
+    path: str | Path,
+    *,
+    source_id: str,
+    entries: Mapping[str, str],
+) -> None:
+    """Write a deterministic private-ref to local-path sidecar map."""
+    output_path = Path(path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "schema_version": PRIVATE_ASSET_MAP_SCHEMA_VERSION,
+        "case_type": PRIVATE_ASSET_MAP_CASE_TYPE,
+        "source_id": str(source_id),
+        "privacy_scope": PRIVATE_LOCAL_PRIVACY_SCOPE,
+        "entries": [
+            {
+                "private_ref": str(private_ref),
+                "local_path": str(local_path),
+            }
+            for private_ref, local_path in sorted(entries.items())
+        ],
+    }
+    output_path.write_text(
+        json.dumps(payload, indent=2, sort_keys=False) + "\n",
+        encoding="utf-8",
+    )
+
+
+def load_private_asset_maps(
+    paths: Sequence[str | Path] | None,
+) -> dict[str, Path]:
+    """Load one or more private asset maps into an in-memory resolver."""
+    resolver: dict[str, Path] = {}
+    for raw_path in paths or ():
+        path = Path(raw_path)
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        if not isinstance(payload, Mapping):
+            raise ValueError("private asset map must be a JSON object")
+        if payload.get("case_type") != PRIVATE_ASSET_MAP_CASE_TYPE:
+            raise ValueError(
+                f"private asset map case_type must be {PRIVATE_ASSET_MAP_CASE_TYPE!r}"
+            )
+        entries = payload.get("entries")
+        if not isinstance(entries, list):
+            raise ValueError("private asset map entries must be a list")
+        for index, entry in enumerate(entries):
+            if not isinstance(entry, Mapping):
+                raise ValueError(f"private asset map entry {index}: expected object")
+            private_ref = str(entry.get("private_ref") or "")
+            local_path = str(entry.get("local_path") or "")
+            if not private_ref.startswith("private://"):
+                raise ValueError(
+                    f"private asset map entry {index}: private_ref is required"
+                )
+            if not local_path:
+                raise ValueError(
+                    f"private asset map entry {index}: local_path is required"
+                )
+            resolver[private_ref] = Path(local_path)
+    return resolver
+
+
+def resolve_private_asset_ref(
+    ref: str,
+    *,
+    private_asset_map: Mapping[str, str | Path] | None,
+) -> Path | None:
+    """Return the mapped local path for a private ref, if one exists."""
+    if not ref.startswith("private://"):
+        return None
+    if not private_asset_map:
+        return None
+    mapped = private_asset_map.get(ref)
+    if mapped is None:
+        return None
+    return Path(mapped)

--- a/src/vulca/learning/sam_signal_runner.py
+++ b/src/vulca/learning/sam_signal_runner.py
@@ -6,11 +6,12 @@ does not convert masks into accepted decompose or redraw labels.
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any, Mapping, Protocol
+from typing import Any, Mapping, Protocol, Sequence
 
 from PIL import Image
 
 from vulca.learning.florence_signal_runner import resolve_case_source_image_path
+from vulca.learning.private_asset_map import load_private_asset_maps
 
 
 DEFAULT_SAM_MODEL_TYPE = "vit_b"
@@ -36,6 +37,7 @@ def build_sam_vit_signal_runner(
     model_type: str = DEFAULT_SAM_MODEL_TYPE,
     device: str = "auto",
     points_per_side: int = DEFAULT_SAM_POINTS_PER_SIDE,
+    private_asset_map_paths: Sequence[str | Path] = (),
     **_: Any,
 ) -> Any:
     """Build a local SAM signal runner.
@@ -44,6 +46,7 @@ def build_sam_vit_signal_runner(
     when no test/experiment backend is injected.
     """
     root = Path(repo_root)
+    private_asset_map = load_private_asset_maps(private_asset_map_paths)
     resolved_backend = backend or SamVitLocalBackend(
         checkpoint_path=checkpoint_path,
         model_type=model_type,
@@ -53,7 +56,11 @@ def build_sam_vit_signal_runner(
 
     def run(example: Mapping[str, Any], model_spec: Mapping[str, Any]) -> dict[str, Any]:
         case_record = _case_record_from_example(example)
-        source = resolve_case_source_image_path(case_record, repo_root=root)
+        source = resolve_case_source_image_path(
+            case_record,
+            repo_root=root,
+            private_asset_map=private_asset_map,
+        )
         if source.path is None:
             return {
                 "status": "skipped",

--- a/src/vulca/learning/user_case_intake.py
+++ b/src/vulca/learning/user_case_intake.py
@@ -10,6 +10,7 @@ from pathlib import Path, PureWindowsPath
 from typing import Any, Mapping
 
 from vulca.learning.case_review import load_cases, write_cases
+from vulca.learning.private_asset_map import write_private_asset_map as write_asset_map
 
 
 USER_CASE_INTAKE_SCHEMA_VERSION = 1
@@ -42,6 +43,7 @@ class UserCaseIntakeResult:
     source_id: str
     output_path: str
     manifest_path: str
+    asset_map_path: str
     record_count: int
 
 
@@ -52,6 +54,8 @@ def write_user_case_intake(
     output_dir: str | Path | None = None,
     output_path: str | Path | None = None,
     manifest_path: str | Path | None = None,
+    asset_map_path: str | Path | None = None,
+    write_private_asset_map: bool = False,
 ) -> UserCaseIntakeResult:
     """Normalize reviewed user case JSONL into a private user_case_log source."""
     resolved_source_id = str(source_id).strip()
@@ -71,12 +75,20 @@ def write_user_case_intake(
         if manifest_path is not None
         else base_dir / f"{path_token}.case_source_manifest.json"
     )
+    asset_map = (
+        Path(asset_map_path)
+        if asset_map_path is not None
+        else base_dir / f"{path_token}.private.asset_map.json"
+    )
+    should_write_asset_map = bool(write_private_asset_map or asset_map_path)
 
+    private_asset_entries: dict[str, str] = {}
     normalized_records = [
         normalize_user_case_record(
             record,
             source_id=resolved_source_id,
             record_index=index,
+            private_asset_entries=private_asset_entries,
         )
         for index, record in enumerate(input_records)
     ]
@@ -87,10 +99,17 @@ def write_user_case_intake(
         output_path=output,
         source_id=resolved_source_id,
     )
+    if should_write_asset_map:
+        write_asset_map(
+            asset_map,
+            source_id=resolved_source_id,
+            entries=private_asset_entries,
+        )
     return UserCaseIntakeResult(
         source_id=resolved_source_id,
         output_path=str(output),
         manifest_path=str(manifest),
+        asset_map_path=str(asset_map) if should_write_asset_map else "",
         record_count=len(normalized_records),
     )
 
@@ -100,10 +119,15 @@ def normalize_user_case_record(
     *,
     source_id: str,
     record_index: int,
+    private_asset_entries: dict[str, str] | None = None,
 ) -> dict[str, Any]:
     """Return a sanitized reviewed case record with private intake metadata."""
     _validate_reviewed_case(record, record_index=record_index)
-    normalized = _sanitize_value(dict(record), key="")
+    normalized = _sanitize_value(
+        dict(record),
+        key="",
+        private_asset_entries=private_asset_entries,
+    )
     if not isinstance(normalized, dict):
         raise ValueError(f"record {record_index}: expected JSON object")
     normalized["user_case_intake"] = {
@@ -164,38 +188,84 @@ def _write_case_source_manifest(
     )
 
 
-def _sanitize_value(value: Any, *, key: str) -> Any:
+def _sanitize_value(
+    value: Any,
+    *,
+    key: str,
+    private_asset_entries: dict[str, str] | None = None,
+) -> Any:
     if _SENSITIVE_KEY_RE.search(key):
         return "<redacted>"
     if isinstance(value, dict):
         return {
-            str(child_key): _sanitize_value(child_value, key=str(child_key))
+            str(child_key): _sanitize_value(
+                child_value,
+                key=str(child_key),
+                private_asset_entries=private_asset_entries,
+            )
             for child_key, child_value in value.items()
         }
     if isinstance(value, list):
-        return [_sanitize_value(child, key=key) for child in value]
+        return [
+            _sanitize_value(
+                child,
+                key=key,
+                private_asset_entries=private_asset_entries,
+            )
+            for child in value
+        ]
     if isinstance(value, str):
-        return _sanitize_text(value)
+        return _sanitize_text(value, private_asset_entries=private_asset_entries)
     return value
 
 
-def _sanitize_text(value: str) -> str:
-    sanitized = _POSIX_LOCAL_PATH_RE.sub(_canonical_posix_path, value)
-    sanitized = _WINDOWS_LOCAL_PATH_RE.sub(_canonical_windows_path, sanitized)
+def _sanitize_text(
+    value: str,
+    *,
+    private_asset_entries: dict[str, str] | None = None,
+) -> str:
+    sanitized = _POSIX_LOCAL_PATH_RE.sub(
+        lambda match: _canonical_posix_path(
+            match,
+            private_asset_entries=private_asset_entries,
+        ),
+        value,
+    )
+    sanitized = _WINDOWS_LOCAL_PATH_RE.sub(
+        lambda match: _canonical_windows_path(
+            match,
+            private_asset_entries=private_asset_entries,
+        ),
+        sanitized,
+    )
     sanitized = _EMAIL_RE.sub("<email:redacted>", sanitized)
     sanitized = _PHONE_RE.sub("<phone:redacted>", sanitized)
     sanitized = _SECRET_RE.sub("<secret:redacted>", sanitized)
     return sanitized
 
 
-def _canonical_posix_path(match: re.Match[str]) -> str:
+def _canonical_posix_path(
+    match: re.Match[str],
+    *,
+    private_asset_entries: dict[str, str] | None = None,
+) -> str:
     raw, trailing = _strip_trailing_punctuation(match.group(0))
-    return f"{_canonical_path_token(raw, Path(raw).name)}{trailing}"
+    token = _canonical_path_token(raw, Path(raw).name)
+    if private_asset_entries is not None:
+        private_asset_entries[token] = raw
+    return f"{token}{trailing}"
 
 
-def _canonical_windows_path(match: re.Match[str]) -> str:
+def _canonical_windows_path(
+    match: re.Match[str],
+    *,
+    private_asset_entries: dict[str, str] | None = None,
+) -> str:
     raw, trailing = _strip_trailing_punctuation(match.group(0))
-    return f"{_canonical_path_token(raw, PureWindowsPath(raw).name)}{trailing}"
+    token = _canonical_path_token(raw, PureWindowsPath(raw).name)
+    if private_asset_entries is not None:
+        private_asset_entries[token] = raw
+    return f"{token}{trailing}"
 
 
 def _canonical_path_token(raw_path: str, name: str) -> str:

--- a/tests/test_florence_signal_runner.py
+++ b/tests/test_florence_signal_runner.py
@@ -31,6 +31,17 @@ def _example_with_source(source_image: str) -> dict:
     }
 
 
+def _write_jsonl(path: Path, records: list[dict]) -> None:
+    path.write_text(
+        "\n".join(json.dumps(record, sort_keys=True) for record in records) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _read_jsonl(path: Path) -> list[dict]:
+    return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines()]
+
+
 class FakeFlorenceBackend:
     def __init__(self):
         self.calls = []
@@ -112,6 +123,63 @@ def test_florence_runner_skips_private_or_missing_source_without_leaking_path(tm
     }
     assert "private://local_path" not in encoded
     assert "/Users/" not in encoded
+
+
+def test_florence_runner_resolves_private_asset_map_without_leaking_ref(tmp_path):
+    from vulca.learning.florence_signal_runner import build_florence2_signal_runner
+    from vulca.learning.user_case_intake import write_user_case_intake
+
+    image_path = tmp_path / "private-source.png"
+    Image.new("RGB", (9, 7), (255, 0, 0)).save(image_path)
+    input_path = tmp_path / "reviewed_user_cases.jsonl"
+    _write_jsonl(
+        input_path,
+        [
+            {
+                "schema_version": 1,
+                "case_type": "redraw_case",
+                "case_id": "private_mapped_case",
+                "created_at": "2026-05-06T00:00:00Z",
+                "source_image": str(image_path),
+                "review": {
+                    "human_accept": False,
+                    "failure_type": "style_drift",
+                    "preferred_action": "adjust_instruction",
+                    "reviewed_at": "2026-05-06T01:00:00Z",
+                },
+            }
+        ],
+    )
+    intake = write_user_case_intake(
+        input_path=input_path,
+        output_dir=tmp_path / "intake",
+        source_id="private_map_test",
+        write_private_asset_map=True,
+    )
+    sanitized = _read_jsonl(Path(intake.output_path))[0]
+    backend = FakeFlorenceBackend()
+    runner = build_florence2_signal_runner(
+        repo_root=tmp_path,
+        backend=backend,
+        private_asset_map_paths=(intake.asset_map_path,),
+    )
+
+    signals = runner(
+        _example_with_source(sanitized["source_image"]),
+        {"id": "florence_2", "model_role": "vision_caption_grounding_ocr"},
+    )
+
+    encoded = json.dumps(signals, sort_keys=True)
+    assert signals["status"] == "completed"
+    assert signals["source_image"] == {
+        "available": True,
+        "ref_kind": "private_uri_mapped",
+        "width": 9,
+        "height": 7,
+    }
+    assert backend.calls[0]["image_path"] == str(image_path)
+    assert "private://local_path" not in encoded
+    assert str(tmp_path) not in encoded
 
 
 def test_open_model_adapter_enables_florence_local_runner_with_factory(tmp_path):

--- a/tests/test_open_model_signal_adapter.py
+++ b/tests/test_open_model_signal_adapter.py
@@ -141,6 +141,44 @@ def test_open_model_signal_adapter_uses_injected_runner_outputs():
     assert records[0]["training_use"]["review_status"] == "needs_human_review"
 
 
+def test_open_model_signal_adapter_passes_private_asset_maps_to_local_runner_factory(
+    tmp_path,
+):
+    from vulca.learning.open_model_signals import run_open_model_signal_adapter
+
+    captured = {}
+    asset_map_path = tmp_path / "session.private.asset_map.json"
+
+    def fake_factory(**kwargs):
+        captured.update(kwargs)
+
+        def run(_example, _model):
+            return {
+                "status": "completed",
+                "signal_source": "local_runner",
+                "review_status": "needs_human_review",
+            }
+
+        return run
+
+    report = run_open_model_signal_adapter(
+        repo_root=ROOT,
+        output_path=tmp_path / "signals.jsonl",
+        report_path=tmp_path / "report.json",
+        model_catalog_path=CATALOG,
+        case_source_manifest_path=COMBINED_MANIFEST,
+        model_ids=("florence_2",),
+        include_local_seeds=False,
+        enable_local_runners=("florence_2",),
+        local_runner_factories={"florence_2": fake_factory},
+        private_asset_map_paths=(asset_map_path,),
+        max_examples=1,
+    )
+
+    assert report["runtime"]["uses_local_runner"] is True
+    assert captured["private_asset_map_paths"] == (asset_map_path,)
+
+
 def test_open_model_signal_adapter_cli_writes_report(tmp_path):
     output_path = tmp_path / "signals.jsonl"
     report_path = tmp_path / "report.json"
@@ -171,3 +209,21 @@ def test_open_model_signal_adapter_cli_writes_report(tmp_path):
     assert report["case_type"] == "learning_open_model_signal_report"
     assert report["record_count"] == len(_read_jsonl(output_path))
     assert "Open model signal records:" in result.stdout
+
+
+def test_open_model_signal_adapter_cli_exposes_private_asset_map_flag():
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(ROOT / "scripts/open_model_signal_adapter.py"),
+            "--help",
+        ],
+        cwd=ROOT,
+        env=CLI_ENV,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert "--private-asset-map" in result.stdout

--- a/tests/test_user_case_intake.py
+++ b/tests/test_user_case_intake.py
@@ -125,6 +125,45 @@ def test_user_case_intake_writes_private_manifest_and_sanitized_log(tmp_path):
     assert example["source_case"]["case_id"] == "redraw_user_001"
 
 
+def test_user_case_intake_can_write_private_asset_map_sidecar(tmp_path):
+    from vulca.learning.user_case_intake import write_user_case_intake
+
+    input_path = tmp_path / "reviewed_user_cases.jsonl"
+    _write_jsonl(input_path, [_reviewed_redraw_case()])
+
+    result = write_user_case_intake(
+        input_path=input_path,
+        output_dir=tmp_path / "intake",
+        source_id="user_session_2026_05",
+        write_private_asset_map=True,
+    )
+
+    assert result.asset_map_path
+    asset_map_path = Path(result.asset_map_path)
+    assert asset_map_path.name == "user_session_2026_05.private.asset_map.json"
+    asset_map = json.loads(asset_map_path.read_text(encoding="utf-8"))
+    records = _read_jsonl(Path(result.output_path))
+    source_ref = records[0]["source_image"]
+    layer_ref = records[0]["artifacts"]["source_layer_path"]
+
+    assert asset_map["case_type"] == "learning_private_asset_map"
+    assert asset_map["source_id"] == "user_session_2026_05"
+    assert asset_map["privacy_scope"] == "private_local"
+    assert {
+        "private_ref": source_ref,
+        "local_path": "/Users/alice/private-client/source.png",
+    } in asset_map["entries"]
+    assert {
+        "private_ref": layer_ref,
+        "local_path": "/Users/alice/private-client/layers/sign.png",
+    } in asset_map["entries"]
+    assert "/Users/alice" not in json.dumps(records[0], sort_keys=True)
+    assert "/Users/alice/private-client/source.png" in json.dumps(
+        asset_map,
+        sort_keys=True,
+    )
+
+
 def test_user_case_intake_rejects_unreviewed_cases(tmp_path):
     from vulca.learning.user_case_intake import write_user_case_intake
 
@@ -158,6 +197,7 @@ def test_cases_intake_user_cli_writes_manifest_and_private_log(tmp_path):
             "cli_user_session",
             "--output-dir",
             str(output_dir),
+            "--write-private-asset-map",
         ],
         capture_output=True,
         text=True,
@@ -177,3 +217,6 @@ def test_cases_intake_user_cli_writes_manifest_and_private_log(tmp_path):
     assert manifest["sources"][0]["kind"] == "user_case_log"
     assert manifest["sources"][0]["privacy_scope"] == "private"
     assert manifest["sources"][0]["curation_status"] == "reviewed"
+    asset_map_path = output_dir / "cli_user_session.private.asset_map.json"
+    assert asset_map_path.exists()
+    assert "Private asset map:" in result.stdout


### PR DESCRIPTION
## Summary
- add local-only private asset map sidecar writing for reviewed user case intake
- let Florence/SAM local signal runners resolve private:// refs from explicit asset maps without leaking paths into signal records
- expose CLI flags for user intake asset maps and open-model signal adapter asset map inputs

## Verification
- PYTHONPATH=src /opt/homebrew/bin/python3.11 -m pytest tests/test_user_case_intake.py tests/test_florence_signal_runner.py tests/test_sam_signal_runner.py tests/test_open_model_signal_adapter.py tests/test_tiny_dataset_export.py -q
- PYTHONPATH=src /opt/homebrew/bin/python3.11 -m pytest tests/test_real_user_cases_v1.py tests/test_real_user_cases_v2.py tests/test_combined_learning_sources_v1.py tests/test_tiny_training_eval_gate.py -q
- PYTHONPATH=src /opt/homebrew/bin/python3.11 -m py_compile src/vulca/learning/private_asset_map.py src/vulca/learning/user_case_intake.py src/vulca/learning/florence_signal_runner.py src/vulca/learning/sam_signal_runner.py src/vulca/learning/open_model_signals.py scripts/open_model_signal_adapter.py
- /opt/homebrew/bin/python3.11 -m ruff check src/vulca/learning/private_asset_map.py src/vulca/learning/user_case_intake.py src/vulca/learning/florence_signal_runner.py src/vulca/learning/sam_signal_runner.py src/vulca/learning/open_model_signals.py src/vulca/cli.py scripts/open_model_signal_adapter.py tests/test_user_case_intake.py tests/test_florence_signal_runner.py tests/test_open_model_signal_adapter.py
- git diff --check
- open-model dry-run safety grep for /Users/, private://local_path, learning_targets, and review