### PR TITLE
feat(learning): consume auxiliary signal text features

### DIFF
--- a/src/vulca/learning/tiny_action_model.py
+++ b/src/vulca/learning/tiny_action_model.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import json
+import re
 from collections import Counter
 from dataclasses import dataclass
 from pathlib import Path
@@ -37,6 +38,23 @@ FAILURE_HINT_ACTION_PRIORS: Mapping[str, str] = {
     "under_split": "fallback_to_agent",
     "wrong_subject": "adjust_instruction",
 }
+_AUX_TEXT_TOKEN_RE = re.compile(r"[A-Za-z][A-Za-z0-9]{2,31}")
+_AUX_TEXT_STOPWORDS: frozenset[str] = frozenset(
+    {
+        "and",
+        "are",
+        "for",
+        "from",
+        "into",
+        "next",
+        "of",
+        "on",
+        "the",
+        "this",
+        "with",
+    }
+)
+_AUX_TEXT_MAX_TOKENS = 12
 
 
 @dataclass(frozen=True)
@@ -467,6 +485,25 @@ def _auxiliary_signal_features(example: Mapping[str, Any]) -> tuple[str, ...]:
         signal_source = str(signals.get("signal_source") or "")
         if signal_source:
             features.append(f"aux_signal.source:{signal_source}")
+        features.extend(
+            _aux_text_features(
+                signals.get("caption_candidates"),
+                prefix="caption_token",
+            )
+        )
+        features.extend(
+            _aux_text_features(
+                signals.get("dense_region_descriptions"),
+                prefix="dense_token",
+            )
+        )
+        features.extend(
+            _aux_text_features(
+                signals.get("ocr_text"),
+                prefix="ocr_token",
+                max_tokens=8,
+            )
+        )
         mask_count = _number(signals.get("mask_count"))
         if mask_count is not None:
             features.append(f"aux_signal.sam_mask_count:{_mask_count_bucket(mask_count)}")
@@ -479,6 +516,46 @@ def _auxiliary_signal_features(example: Mapping[str, Any]) -> tuple[str, ...]:
         if boundary_complexity:
             features.append(f"aux_signal.boundary_complexity:{boundary_complexity}")
     return tuple(features)
+
+
+def _aux_text_features(
+    value: Any,
+    *,
+    prefix: str,
+    max_tokens: int = _AUX_TEXT_MAX_TOKENS,
+) -> tuple[str, ...]:
+    tokens: list[str] = []
+    for text in _flatten_aux_text(value):
+        for match in _AUX_TEXT_TOKEN_RE.finditer(text.lower()):
+            token = match.group(0)
+            if token in _AUX_TEXT_STOPWORDS:
+                continue
+            tokens.append(token)
+            if len(tokens) >= max_tokens:
+                return _aux_token_features(prefix, tokens)
+    return _aux_token_features(prefix, tokens)
+
+
+def _aux_token_features(prefix: str, tokens: Sequence[str]) -> tuple[str, ...]:
+    return tuple(f"aux_signal.{prefix}:{item}" for item in dict.fromkeys(tokens))
+
+
+def _flatten_aux_text(value: Any) -> tuple[str, ...]:
+    if value is None:
+        return ()
+    if isinstance(value, str):
+        return (value,)
+    if isinstance(value, Mapping):
+        texts: list[str] = []
+        for child in value.values():
+            texts.extend(_flatten_aux_text(child))
+        return tuple(texts)
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+        texts = []
+        for item in value:
+            texts.extend(_flatten_aux_text(item))
+        return tuple(texts)
+    return (str(value),)
 
 
 def _target_action(example: Mapping[str, Any]) -> str:

--- a/tests/test_tiny_action_model.py
+++ b/tests/test_tiny_action_model.py
@@ -271,3 +271,83 @@ def test_tiny_action_model_uses_curated_failure_priors_without_split_coupling():
         assert prediction["recommended_action"] == expected_action
         assert prediction["failure_hint"] == failure_hint
         assert prediction["explanation"]["fallback_reason"] == "failure_hint_prior"
+
+
+def test_tiny_action_model_learns_promoted_florence_caption_tokens():
+    from vulca.learning.tiny_action_model import (
+        TinyActionClassifier,
+        extract_tiny_action_features,
+    )
+
+    def example(example_id, split, target_action, caption, ocr):
+        return {
+            "example_id": example_id,
+            "split": split,
+            "source_case": {
+                "case_id": example_id,
+                "case_type": "layer_generate_case",
+            },
+            "input": {
+                "case_record": {
+                    "case_type": "layer_generate_case",
+                    "quality": {
+                        "gate_passed": False,
+                    },
+                },
+                "auxiliary_signals": [
+                    {
+                        "signal_id": f"signal_{example_id}",
+                        "model": {
+                            "id": "florence_2",
+                        },
+                        "signals": {
+                            "status": "completed",
+                            "signal_source": "local_runner",
+                            "caption_candidates": [caption],
+                            "ocr_text": [ocr],
+                        },
+                        "training_use": {
+                            "approved_for_auxiliary_training": True,
+                            "review_status": "reviewed_promoted",
+                        },
+                    }
+                ],
+            },
+            "targets": {
+                "preferred_action": target_action,
+            },
+        }
+
+    train = example(
+        "train_provider_failure_car",
+        "train",
+        "fallback_to_agent",
+        "A red car is parked on the side of the road.",
+        "JAMES CO.UK",
+    )
+    distractor = example(
+        "train_prompt_case_bar",
+        "train",
+        "adjust_prompt",
+        "A group of people sitting at a bar.",
+        "PHILLIES",
+    )
+    test = example(
+        "test_provider_failure_car",
+        "test",
+        "fallback_to_agent",
+        "A red car is parked on the side of the road.",
+        "JAMES CO.UK",
+    )
+
+    features = extract_tiny_action_features(test)
+    assert "aux_signal.caption_token:red" in features
+    assert "aux_signal.caption_token:car" in features
+    assert "aux_signal.ocr_token:james" in features
+    prediction = TinyActionClassifier.fit([train, distractor]).predict(test)
+
+    assert prediction["recommended_action"] == "fallback_to_agent"
+    assert "aux_signal.caption_token:car" in prediction["explanation"][
+        "matched_features"
+    ]
+    assert prediction["explanation"]["fallback_reason"] == ""


### PR DESCRIPTION
## Summary
- extract capped caption/dense-region/OCR token features from reviewed promoted auxiliary signals
- let tiny_action_model_v1 learn action votes from Florence text signals instead of only generic aux model/status features
- add a regression test with a distractor train sample proving caption tokens can determine the predicted action

## Verification
- PYTHONPATH=src /opt/homebrew/bin/python3.11 -m pytest tests/test_tiny_action_model.py tests/test_tiny_training_eval_gate.py tests/test_open_model_signal_review.py tests/test_open_model_signal_review_table.py -q
- /opt/homebrew/bin/python3.11 -m ruff check src/vulca/learning/tiny_action_model.py tests/test_tiny_action_model.py
- PYTHONPATH=src /opt/homebrew/bin/python3.11 -m py_compile src/vulca/learning/tiny_action_model.py
- git diff --check
- real-user Florence aux smoke using local ignored #82 artifacts: gate passed; prediction explanation matched caption_token/ocr_token on the red-car case