### PR TITLE
feat(learning): add real user asset coverage report

### DIFF
--- a/scripts/real_user_asset_coverage.py
+++ b/scripts/real_user_asset_coverage.py
@@ -1,0 +1,90 @@
+"""Write a safe source-asset coverage report for reviewed real user cases."""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Sequence
+
+
+ROOT = Path(__file__).resolve().parent.parent
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from vulca.learning.real_user_asset_coverage import (  # noqa: E402
+    DEFAULT_OUTPUT_PATH,
+    run_real_user_asset_coverage_report,
+)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Measure which reviewed real user cases have local source images "
+            "available for provider-free open-model signal extraction."
+        )
+    )
+    parser.add_argument(
+        "--repo-root",
+        default=str(ROOT),
+        help="Repository root (default: this script's repository).",
+    )
+    parser.add_argument(
+        "--case-source-manifest",
+        required=True,
+        help="Reviewed case source manifest JSON path.",
+    )
+    parser.add_argument(
+        "--private-asset-map",
+        action="append",
+        default=[],
+        help=(
+            "Private local asset map JSON path. Repeat to include multiple maps. "
+            "Mapped local paths are never copied into the report."
+        ),
+    )
+    parser.add_argument(
+        "--output",
+        default=str(DEFAULT_OUTPUT_PATH),
+        help=f"Coverage report JSON path (default: {DEFAULT_OUTPUT_PATH}).",
+    )
+    parser.add_argument(
+        "--pretty",
+        action="store_true",
+        help="Print the full JSON report to stdout after writing it.",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        report = run_real_user_asset_coverage_report(
+            repo_root=args.repo_root,
+            case_source_manifest_path=args.case_source_manifest,
+            private_asset_map_paths=args.private_asset_map,
+            output_path=args.output,
+        )
+    except (ValueError, FileNotFoundError, json.JSONDecodeError, OSError) as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 2
+
+    if args.pretty:
+        print(json.dumps(report, indent=2, sort_keys=True))
+
+    summary = report["summary"]
+    example_count = summary["example_count"]
+    print(f"Real-user asset coverage report: {args.output}")
+    print(f"Cases: {example_count}")
+    print(
+        "Open-model runnable: "
+        f"{summary['open_model_runnable_count']}/{example_count}"
+    )
+    print(f"Needs private asset map: {summary['needs_private_asset_map_count']}")
+    print(f"Source hint only: {summary['source_hint_only_count']}")
+    print(f"Missing source refs: {summary['missing_source_reference_count']}")
+    print(f"Invalid source images: {summary['invalid_image_count']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/vulca/learning/real_user_asset_coverage.py
+++ b/src/vulca/learning/real_user_asset_coverage.py
@@ -1,0 +1,266 @@
+"""Provider-free asset coverage reporting for reviewed real user cases."""
+from __future__ import annotations
+
+import hashlib
+import json
+from collections import Counter
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+from PIL import Image, UnidentifiedImageError
+
+from vulca.learning.florence_signal_runner import resolve_case_source_image_path
+from vulca.learning.private_asset_map import load_private_asset_maps
+from vulca.learning.tiny_dataset import build_tiny_dataset_examples
+
+
+SCHEMA_VERSION = 1
+REPORT_CASE_TYPE = "learning_real_user_asset_coverage_report"
+DEFAULT_OUTPUT_PATH = Path("build/real_user_asset_coverage/coverage_report.json")
+
+
+def run_real_user_asset_coverage_report(
+    *,
+    repo_root: str | Path,
+    case_source_manifest_path: str | Path,
+    private_asset_map_paths: Sequence[str | Path] = (),
+    output_path: str | Path | None = None,
+) -> dict[str, Any]:
+    """Write a safe coverage report for source images in real user cases."""
+    root = Path(repo_root)
+    private_asset_map = load_private_asset_maps(private_asset_map_paths)
+    examples = build_tiny_dataset_examples(
+        repo_root=root,
+        case_source_manifest_path=case_source_manifest_path,
+        include_local_seeds=False,
+    )
+    records = [
+        _coverage_record(
+            example,
+            repo_root=root,
+            private_asset_map=private_asset_map,
+        )
+        for example in examples
+    ]
+    summary = _summary(records)
+    report = {
+        "schema_version": SCHEMA_VERSION,
+        "case_type": REPORT_CASE_TYPE,
+        "inputs": {
+            "repo_root": _safe_repo_root(root),
+            "case_source_manifest_path": _safe_path(case_source_manifest_path),
+            "private_asset_map_count": len(private_asset_map_paths),
+        },
+        "summary": summary,
+        "counts_by_case_type": _counts_by(records, "case_type"),
+        "counts_by_asset_status": _counts_by(records, "asset_status"),
+        "records": records,
+        "recommended_next_actions": _recommended_next_actions(summary),
+    }
+
+    output = Path(output_path) if output_path is not None else root / DEFAULT_OUTPUT_PATH
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(
+        json.dumps(report, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return report
+
+
+def _coverage_record(
+    example: Mapping[str, Any],
+    *,
+    repo_root: Path,
+    private_asset_map: Mapping[str, str | Path],
+) -> dict[str, Any]:
+    source_case = _mapping(example.get("source_case"))
+    source = _mapping(example.get("source"))
+    case_record = _mapping(_mapping(example.get("input")).get("case_record"))
+    source_ref = _source_image_ref(case_record)
+    resolved = resolve_case_source_image_path(
+        case_record,
+        repo_root=repo_root,
+        private_asset_map=private_asset_map,
+    )
+    image_probe = _image_probe(resolved.path) if resolved.path is not None else {}
+    hint_stats = _path_hint_stats(case_record)
+    asset_status = _asset_status(
+        source_ref=source_ref,
+        ref_kind=resolved.ref_kind,
+        resolved_path=resolved.path,
+        image_probe=image_probe,
+        hint_stats=hint_stats,
+    )
+
+    record = {
+        "case_id": str(source_case.get("case_id") or ""),
+        "case_type": str(source_case.get("case_type") or ""),
+        "source": {
+            "source_id": str(source.get("source_id") or ""),
+            "kind": str(source.get("kind") or ""),
+            "privacy_scope": str(source.get("privacy_scope") or ""),
+            "record_index": int(source.get("index") or 0),
+        },
+        "asset_status": asset_status,
+        "open_model_runnable": asset_status == "available",
+        "source_image": {
+            "has_ref": bool(source_ref),
+            "ref_kind": resolved.ref_kind,
+            "available": asset_status == "available",
+        },
+        "path_hints": hint_stats,
+        "next_action": _next_action_for_status(asset_status),
+    }
+    if source_ref.startswith("private://"):
+        record["source_image"]["private_ref_digest"] = _digest(source_ref)
+    if image_probe:
+        record["image_probe"] = image_probe
+    return record
+
+
+def _asset_status(
+    *,
+    source_ref: str,
+    ref_kind: str,
+    resolved_path: Path | None,
+    image_probe: Mapping[str, Any],
+    hint_stats: Mapping[str, int],
+) -> str:
+    if resolved_path is not None:
+        if image_probe.get("valid_image") is True:
+            return "available"
+        return "invalid_image"
+    if ref_kind == "private_uri":
+        return "needs_private_asset_map"
+    if ref_kind == "remote_url":
+        return "remote_url_unsupported"
+    if ref_kind in {"repo_relative", "absolute_path"} and source_ref:
+        return "path_missing"
+    if int(hint_stats.get("source_path_hint_count") or 0) > 0:
+        return "source_hint_only"
+    return "missing_source_reference"
+
+
+def _image_probe(path: Path) -> dict[str, Any]:
+    try:
+        with Image.open(path) as image:
+            return {
+                "valid_image": True,
+                "width": int(image.width),
+                "height": int(image.height),
+                "format": str(image.format or "").lower(),
+            }
+    except (OSError, UnidentifiedImageError):
+        return {"valid_image": False}
+
+
+def _source_image_ref(case_record: Mapping[str, Any]) -> str:
+    direct = str(case_record.get("source_image") or "")
+    if direct:
+        return direct
+    for key in ("input", "inputs"):
+        nested = case_record.get(key)
+        if isinstance(nested, Mapping):
+            value = str(nested.get("source_image") or "")
+            if value:
+                return value
+    return ""
+
+
+def _path_hint_stats(case_record: Mapping[str, Any]) -> dict[str, int]:
+    stats = Counter()
+
+    def walk(value: Any, *, key: str = "") -> None:
+        if isinstance(value, Mapping):
+            for child_key, child in value.items():
+                walk(child, key=str(child_key))
+            return
+        if isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+            for child in value:
+                walk(child, key=key)
+            return
+        if not isinstance(value, str):
+            return
+        if key.endswith("source_path_hint") and value:
+            stats["source_path_hint_count"] += 1
+        if value.startswith("private://"):
+            stats["private_ref_count"] += 1
+        elif value.startswith("http://") or value.startswith("https://"):
+            stats["remote_ref_count"] += 1
+
+    walk(case_record)
+    return {
+        "source_path_hint_count": stats["source_path_hint_count"],
+        "private_ref_count": stats["private_ref_count"],
+        "remote_ref_count": stats["remote_ref_count"],
+    }
+
+
+def _summary(records: Sequence[Mapping[str, Any]]) -> dict[str, int]:
+    status_counts = Counter(str(record.get("asset_status") or "") for record in records)
+    available = status_counts["available"]
+    return {
+        "example_count": len(records),
+        "available_source_image_count": available,
+        "open_model_runnable_count": available,
+        "needs_private_asset_map_count": status_counts["needs_private_asset_map"],
+        "source_hint_only_count": status_counts["source_hint_only"],
+        "missing_source_reference_count": status_counts["missing_source_reference"],
+        "invalid_image_count": status_counts["invalid_image"],
+    }
+
+
+def _recommended_next_actions(summary: Mapping[str, int]) -> list[str]:
+    actions: list[str] = []
+    if int(summary.get("needs_private_asset_map_count") or 0) > 0:
+        actions.append("provide_private_asset_map_for_unmapped_private_refs")
+    if int(summary.get("source_hint_only_count") or 0) > 0:
+        actions.append("re_intake_brief_cases_with_source_image_or_artifact_path")
+    if int(summary.get("missing_source_reference_count") or 0) > 0:
+        actions.append("add_source_image_refs_for_visual_cases")
+    if not actions:
+        actions.append("ready_for_open_model_signal_run")
+    return actions
+
+
+def _next_action_for_status(asset_status: str) -> str:
+    return {
+        "available": "ready_for_open_model_signal_run",
+        "needs_private_asset_map": "provide_private_asset_map",
+        "source_hint_only": "re_intake_with_source_image",
+        "missing_source_reference": "add_source_image_ref",
+        "path_missing": "fix_or_map_source_path",
+        "invalid_image": "replace_invalid_image_asset",
+        "remote_url_unsupported": "download_or_cache_source_asset",
+    }.get(asset_status, "manual_review")
+
+
+def _counts_by(records: Sequence[Mapping[str, Any]], key: str) -> dict[str, int]:
+    counts = Counter(str(record.get(key) or "unknown") for record in records)
+    return dict(sorted(counts.items()))
+
+
+def _safe_path(path: str | Path) -> str:
+    value = Path(path)
+    parts = value.parts
+    if "docs" in parts:
+        docs_index = parts.index("docs")
+        return str(Path(*parts[docs_index:]))
+    if "build" in parts:
+        build_index = parts.index("build")
+        return str(Path(*parts[build_index:]))
+    return value.name
+
+
+def _safe_repo_root(path: str | Path) -> str:
+    return Path(path).name
+
+
+def _digest(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()[:12]
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    if isinstance(value, Mapping):
+        return value
+    return {}

--- a/tests/test_real_user_asset_coverage.py
+++ b/tests/test_real_user_asset_coverage.py
@@ -1,0 +1,194 @@
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from PIL import Image
+
+
+ROOT = Path(__file__).resolve().parent.parent
+CLI_ENV = dict(
+    os.environ,
+    PYTHONPATH=str(ROOT / "src") + os.pathsep + os.environ.get("PYTHONPATH", ""),
+)
+
+
+def _write_jsonl(path: Path, records: list[dict]) -> None:
+    path.write_text(
+        "\n".join(json.dumps(record, sort_keys=True) for record in records) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _write_image(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    Image.new("RGB", (4, 3), (255, 0, 0)).save(path)
+
+
+def _case(case_id: str, case_type: str, **extra) -> dict:
+    return {
+        "schema_version": 1,
+        "case_type": case_type,
+        "case_id": case_id,
+        "created_at": "2026-05-07T00:00:00Z",
+        "review": {
+            "human_accept": False,
+            "failure_type": "style_drift",
+            "preferred_action": "adjust_prompt",
+        },
+        **extra,
+    }
+
+
+def test_real_user_asset_coverage_classifies_safe_source_image_states(tmp_path):
+    from vulca.learning.private_asset_map import write_private_asset_map
+    from vulca.learning.real_user_asset_coverage import run_real_user_asset_coverage_report
+
+    repo_image = tmp_path / "repo_image.png"
+    mapped_image = tmp_path / "mapped_private.png"
+    _write_image(repo_image)
+    _write_image(mapped_image)
+
+    cases = tmp_path / "cases.jsonl"
+    _write_jsonl(
+        cases,
+        [
+            _case(
+                "repo_ready",
+                "redraw_case",
+                source_image=str(repo_image),
+            ),
+            _case(
+                "private_ready",
+                "decompose_case",
+                input={
+                    "source_image": "private://local_path/private123/source.png",
+                },
+            ),
+            _case(
+                "private_missing_map",
+                "decompose_case",
+                input={
+                    "source_image": "private://local_path/private456/source.png",
+                },
+            ),
+            _case(
+                "brief_hint_only",
+                "layer_generate_case",
+                source_summary={
+                    "source_path_hint": "private://local_path/brief789/case-brief",
+                },
+            ),
+            _case("no_source", "layer_generate_case"),
+        ],
+    )
+    manifest = tmp_path / "manifest.json"
+    manifest.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "case_type": "learning_tiny_case_source_manifest",
+                "sources": [
+                    {
+                        "source_id": "real_user_fixture",
+                        "kind": "user_case_log",
+                        "path": str(cases),
+                        "privacy_scope": "private",
+                        "curation_status": "reviewed",
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    private_map = tmp_path / "fixture.private.asset_map.json"
+    write_private_asset_map(
+        private_map,
+        source_id="fixture_private_map",
+        entries={
+            "private://local_path/private123/source.png": str(mapped_image),
+        },
+    )
+
+    report = run_real_user_asset_coverage_report(
+        repo_root=ROOT,
+        case_source_manifest_path=manifest,
+        private_asset_map_paths=(private_map,),
+        output_path=tmp_path / "report.json",
+    )
+
+    assert report["summary"] == {
+        "example_count": 5,
+        "available_source_image_count": 2,
+        "open_model_runnable_count": 2,
+        "needs_private_asset_map_count": 1,
+        "source_hint_only_count": 1,
+        "missing_source_reference_count": 1,
+        "invalid_image_count": 0,
+    }
+    by_case = {item["case_id"]: item for item in report["records"]}
+    assert by_case["repo_ready"]["asset_status"] == "available"
+    assert by_case["repo_ready"]["source_image"]["ref_kind"] == "absolute_path"
+    assert by_case["private_ready"]["asset_status"] == "available"
+    assert by_case["private_ready"]["source_image"]["ref_kind"] == "private_uri_mapped"
+    assert by_case["private_missing_map"]["asset_status"] == "needs_private_asset_map"
+    assert by_case["brief_hint_only"]["asset_status"] == "source_hint_only"
+    assert by_case["no_source"]["asset_status"] == "missing_source_reference"
+
+    encoded = json.dumps(report, sort_keys=True)
+    assert str(tmp_path) not in encoded
+    assert "private://local_path" not in encoded
+
+
+def test_real_user_asset_coverage_cli_writes_report(tmp_path):
+    image_path = tmp_path / "source.png"
+    _write_image(image_path)
+    cases = tmp_path / "cases.jsonl"
+    _write_jsonl(
+        cases,
+        [_case("repo_ready", "redraw_case", source_image=str(image_path))],
+    )
+    manifest = tmp_path / "manifest.json"
+    manifest.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "case_type": "learning_tiny_case_source_manifest",
+                "sources": [
+                    {
+                        "source_id": "real_user_fixture",
+                        "kind": "user_case_log",
+                        "path": str(cases),
+                        "privacy_scope": "private",
+                        "curation_status": "reviewed",
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    output = tmp_path / "coverage.json"
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(ROOT / "scripts/real_user_asset_coverage.py"),
+            "--case-source-manifest",
+            str(manifest),
+            "--output",
+            str(output),
+        ],
+        cwd=ROOT,
+        env=CLI_ENV,
+        text=True,
+        capture_output=True,
+        timeout=20,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert output.exists()
+    report = json.loads(output.read_text(encoding="utf-8"))
+    assert report["summary"]["open_model_runnable_count"] == 1
+    assert "Open-model runnable: 1/1" in result.stdout


### PR DESCRIPTION
## Summary
- add a provider-free real user asset coverage reporter for reviewed case source manifests
- add CLI `scripts/real_user_asset_coverage.py` with private asset map support and safe JSON output
- cover source-image availability states without leaking local paths or private refs

## Verification
- `PYTHONPATH=src /opt/homebrew/bin/python3.11 -m pytest tests/test_real_user_asset_coverage.py tests/test_florence_signal_runner.py tests/test_user_case_intake.py -q` -> 11 passed
- `/opt/homebrew/bin/python3.11 -m py_compile src/vulca/learning/real_user_asset_coverage.py scripts/real_user_asset_coverage.py tests/test_real_user_asset_coverage.py`
- `ruff check src/vulca/learning/real_user_asset_coverage.py scripts/real_user_asset_coverage.py tests/test_real_user_asset_coverage.py`
- `git diff --check`
- real user coverage smoke: 12 cases, 6/12 open-model runnable, 0 private-map gaps, 4 source-hint-only, 2 missing source refs

## Notes
- The generated build coverage report is intentionally local-only and not committed.
- This does not change redraw, decompose, layer_generate, or provider runtime behavior.