### PR TITLE
feat(learning): add tiny feature ablation report

### DIFF
--- a/scripts/tiny_feature_ablation.py
+++ b/scripts/tiny_feature_ablation.py
@@ -1,0 +1,82 @@
+"""Run tiny_action_model feature ablation on an exported tiny dataset."""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Sequence
+
+
+ROOT = Path(__file__).resolve().parent.parent
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from vulca.learning.tiny_dataset import DATASET_SPLITS  # noqa: E402
+from vulca.learning.tiny_feature_ablation import (  # noqa: E402
+    DEFAULT_OUTPUT_PATH,
+    run_tiny_feature_ablation_report_for_dataset,
+)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Measure how tiny_action_model_v1 changes when strong input "
+            "feature groups are removed from a tiny dataset."
+        )
+    )
+    parser.add_argument("--dataset", required=True, help="Tiny dataset JSONL path.")
+    parser.add_argument(
+        "--output",
+        default=str(DEFAULT_OUTPUT_PATH),
+        help=f"Output JSON report path (default: {DEFAULT_OUTPUT_PATH}).",
+    )
+    parser.add_argument(
+        "--split",
+        default="test",
+        choices=DATASET_SPLITS,
+        help="Dataset split to evaluate.",
+    )
+    parser.add_argument(
+        "--train-split",
+        default="train",
+        choices=DATASET_SPLITS,
+        help="Dataset split used to fit train-derived baselines.",
+    )
+    parser.add_argument(
+        "--pretty",
+        action="store_true",
+        help="Print the full JSON report to stdout after writing it.",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        report = run_tiny_feature_ablation_report_for_dataset(
+            dataset_path=args.dataset,
+            output_path=args.output,
+            eval_split=args.split,
+            train_split=args.train_split,
+        )
+    except (ValueError, FileNotFoundError, json.JSONDecodeError) as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 2
+
+    if args.pretty:
+        print(json.dumps(report, indent=2, sort_keys=True))
+
+    print(f"Tiny feature ablation report: {args.output}")
+    print(f"Policy: {report['policy_name']}")
+    print(f"Examples: {report['example_count']}")
+    for variant in report["variant_reports"]:
+        policy_report = variant["policy_report"]
+        print(
+            f"{variant['variant_id']} action_accuracy: "
+            f"{policy_report['action_accuracy']}"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/vulca/learning/tiny_feature_ablation.py
+++ b/src/vulca/learning/tiny_feature_ablation.py
@@ -1,0 +1,299 @@
+"""Feature ablation reports for provider-free tiny action evaluation."""
+from __future__ import annotations
+
+import copy
+import json
+from collections import Counter
+from pathlib import Path
+from typing import Any, Callable, Mapping, Sequence
+
+from vulca.learning.tiny_action_model import (
+    FAILURE_HINT_ACTION_PRIORS,
+    POLICY_TINY_ACTION_MODEL,
+    build_tiny_action_model_predictions,
+)
+from vulca.learning.tiny_dataset import (
+    DATASET_SPLITS,
+    evaluate_tiny_prediction_records,
+    load_tiny_dataset_examples,
+)
+
+
+SCHEMA_VERSION = 1
+REPORT_CASE_TYPE = "learning_tiny_feature_ablation_report"
+DEFAULT_OUTPUT_PATH = Path("build/tiny_feature_ablation/tiny_feature_ablation.json")
+
+AblationMutator = Callable[[dict[str, Any]], None]
+
+_QUALITY_FAILURE_HINT_KEYS: frozenset[str] = frozenset(
+    set(FAILURE_HINT_ACTION_PRIORS)
+    | {
+        "alpha_quality",
+        "empty_layer",
+        "residual_leakage",
+        "semantic_mismatch",
+    }
+)
+
+
+def run_tiny_feature_ablation_report(
+    *,
+    examples: Sequence[Mapping[str, Any]],
+    output_path: str | Path | None = None,
+    eval_split: str = "test",
+    train_split: str = "train",
+) -> dict[str, Any]:
+    """Evaluate tiny_action_model_v1 under strong-feature ablations."""
+    _validate_split(eval_split, label="eval_split")
+    _validate_split(train_split, label="train_split")
+    source_examples = [copy.deepcopy(dict(example)) for example in examples]
+    variant_specs = _variant_specs()
+    variant_reports = [
+        _evaluate_variant(
+            source_examples,
+            variant_id=variant_id,
+            removed_feature_groups=removed_feature_groups,
+            mutators=mutators,
+            eval_split=eval_split,
+            train_split=train_split,
+        )
+        for variant_id, removed_feature_groups, mutators in variant_specs
+    ]
+    full_accuracy = _accuracy_by_variant(variant_reports).get("full")
+    for report in variant_reports:
+        accuracy = report["policy_report"]["action_accuracy"]
+        report["accuracy_delta_vs_full"] = _delta(accuracy, full_accuracy)
+
+    output = Path(output_path) if output_path is not None else DEFAULT_OUTPUT_PATH
+    result = {
+        "schema_version": SCHEMA_VERSION,
+        "case_type": REPORT_CASE_TYPE,
+        "policy_name": POLICY_TINY_ACTION_MODEL,
+        "eval_split": eval_split,
+        "train_split": train_split,
+        "example_count": len(source_examples),
+        "variant_reports": variant_reports,
+        "summary": _summary(variant_reports),
+    }
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(
+        json.dumps(result, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return result
+
+
+def run_tiny_feature_ablation_report_for_dataset(
+    *,
+    dataset_path: str | Path,
+    output_path: str | Path | None = None,
+    eval_split: str = "test",
+    train_split: str = "train",
+) -> dict[str, Any]:
+    """Load a tiny dataset JSONL and run the feature ablation report."""
+    return run_tiny_feature_ablation_report(
+        examples=load_tiny_dataset_examples(dataset_path),
+        output_path=output_path,
+        eval_split=eval_split,
+        train_split=train_split,
+    )
+
+
+def _evaluate_variant(
+    examples: Sequence[Mapping[str, Any]],
+    *,
+    variant_id: str,
+    removed_feature_groups: Sequence[str],
+    mutators: Sequence[AblationMutator],
+    eval_split: str,
+    train_split: str,
+) -> dict[str, Any]:
+    variant_examples = [copy.deepcopy(dict(example)) for example in examples]
+    for example in variant_examples:
+        for mutator in mutators:
+            mutator(example)
+
+    predictions = build_tiny_action_model_predictions(
+        variant_examples,
+        split=eval_split,
+        train_split=train_split,
+    )
+    policy_report = evaluate_tiny_prediction_records(
+        variant_examples,
+        predictions,
+        dataset_split=eval_split,
+        policy_name=POLICY_TINY_ACTION_MODEL,
+    )
+    return {
+        "variant_id": variant_id,
+        "removed_feature_groups": list(removed_feature_groups),
+        "policy_report": _compact_policy_report(policy_report),
+        "fallback_reason_counts": _fallback_reason_counts(predictions),
+        "auxiliary_feature_match_count": _auxiliary_feature_match_count(predictions),
+    }
+
+
+def _variant_specs() -> tuple[
+    tuple[str, tuple[str, ...], tuple[AblationMutator, ...]],
+    ...,
+]:
+    return (
+        ("full", (), ()),
+        (
+            "without_failure_hints",
+            ("quality.failure_hints",),
+            (_remove_failure_hints,),
+        ),
+        (
+            "without_action_hints",
+            ("decisions.action_hints",),
+            (_remove_action_hints,),
+        ),
+        (
+            "without_failure_and_action_hints",
+            ("quality.failure_hints", "decisions.action_hints"),
+            (_remove_failure_hints, _remove_action_hints),
+        ),
+        (
+            "without_auxiliary_signals",
+            ("input.auxiliary_signals",),
+            (_remove_auxiliary_signals,),
+        ),
+    )
+
+
+def _remove_failure_hints(example: dict[str, Any]) -> None:
+    quality = _case_record_child(example, "quality")
+    if not isinstance(quality, dict):
+        return
+    quality.pop("failures", None)
+    quality.pop("gate_passed", None)
+    for key in _QUALITY_FAILURE_HINT_KEYS:
+        quality.pop(key, None)
+
+
+def _remove_action_hints(example: dict[str, Any]) -> None:
+    decisions = _case_record_child(example, "decisions")
+    if not isinstance(decisions, dict):
+        return
+    fallback_decisions = decisions.get("fallback_decisions")
+    if not isinstance(fallback_decisions, list):
+        return
+    for item in fallback_decisions:
+        if isinstance(item, dict):
+            item.pop("suggested_action", None)
+
+
+def _remove_auxiliary_signals(example: dict[str, Any]) -> None:
+    input_block = example.get("input")
+    if isinstance(input_block, dict):
+        input_block.pop("auxiliary_signals", None)
+
+
+def _case_record_child(example: Mapping[str, Any], key: str) -> Any:
+    input_block = example.get("input")
+    if not isinstance(input_block, Mapping):
+        return None
+    case_record = input_block.get("case_record")
+    if not isinstance(case_record, Mapping):
+        return None
+    return case_record.get(key)
+
+
+def _compact_policy_report(report: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        "policy_name": str(report.get("policy_name") or ""),
+        "split": str(report.get("split") or ""),
+        "example_count": int(report.get("example_count") or 0),
+        "prediction_count": int(report.get("prediction_count") or 0),
+        "matched_count": int(report.get("matched_count") or 0),
+        "missing_count": int(report.get("missing_count") or 0),
+        "action_labeled_count": int(report.get("action_labeled_count") or 0),
+        "action_accuracy": report.get("action_accuracy"),
+        "mismatch_count": int(report.get("mismatch_count") or 0),
+        "mismatches": list(report.get("mismatches") or []),
+    }
+
+
+def _fallback_reason_counts(predictions: Sequence[Mapping[str, Any]]) -> dict[str, int]:
+    counts: Counter[str] = Counter()
+    for prediction in predictions:
+        explanation = prediction.get("explanation")
+        if not isinstance(explanation, Mapping):
+            counts["missing_explanation"] += 1
+            continue
+        reason = str(explanation.get("fallback_reason") or "scored_features")
+        counts[reason] += 1
+    return dict(sorted(counts.items()))
+
+
+def _auxiliary_feature_match_count(predictions: Sequence[Mapping[str, Any]]) -> int:
+    count = 0
+    for prediction in predictions:
+        explanation = prediction.get("explanation")
+        if not isinstance(explanation, Mapping):
+            continue
+        matched = explanation.get("matched_features")
+        if not isinstance(matched, Sequence) or isinstance(matched, (str, bytes)):
+            continue
+        if any(str(item).startswith("aux_signal.") for item in matched):
+            count += 1
+    return count
+
+
+def _summary(variant_reports: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+    by_variant = {
+        str(report.get("variant_id") or ""): report for report in variant_reports
+    }
+    full = _mapping(by_variant.get("full"))
+    full_policy = _mapping(full.get("policy_report"))
+    return {
+        "full_action_accuracy": full_policy.get("action_accuracy"),
+        "full_mismatch_count": int(full_policy.get("mismatch_count") or 0),
+        "largest_accuracy_drop": _largest_accuracy_drop(variant_reports),
+    }
+
+
+def _largest_accuracy_drop(
+    variant_reports: Sequence[Mapping[str, Any]],
+) -> dict[str, Any]:
+    rows = [
+        {
+            "variant_id": str(report.get("variant_id") or ""),
+            "accuracy_delta_vs_full": report.get("accuracy_delta_vs_full"),
+        }
+        for report in variant_reports
+        if report.get("variant_id") != "full"
+        and report.get("accuracy_delta_vs_full") is not None
+    ]
+    if not rows:
+        return {}
+    return sorted(rows, key=lambda item: float(item["accuracy_delta_vs_full"]))[0]
+
+
+def _accuracy_by_variant(
+    variant_reports: Sequence[Mapping[str, Any]],
+) -> dict[str, float | None]:
+    return {
+        str(report.get("variant_id") or ""): _mapping(
+            report.get("policy_report")
+        ).get("action_accuracy")
+        for report in variant_reports
+    }
+
+
+def _delta(value: Any, baseline: Any) -> float | None:
+    if value is None or baseline is None:
+        return None
+    return round(float(value) - float(baseline), 6)
+
+
+def _validate_split(value: str, *, label: str) -> None:
+    if value not in DATASET_SPLITS:
+        raise ValueError(f"unsupported {label} {value!r}; expected one of {DATASET_SPLITS}")
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    if isinstance(value, Mapping):
+        return value
+    return {}

--- a/tests/test_tiny_feature_ablation.py
+++ b/tests/test_tiny_feature_ablation.py
@@ -1,0 +1,183 @@
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+CLI_ENV = dict(
+    os.environ,
+    PYTHONPATH=str(ROOT / "src") + os.pathsep + os.environ.get("PYTHONPATH", ""),
+)
+
+
+def _example(
+    example_id: str,
+    *,
+    split: str,
+    case_id: str,
+    preferred_action: str,
+    case_record: dict,
+) -> dict:
+    case_record = {
+        "schema_version": 1,
+        "case_type": "layer_generate_case",
+        "case_id": case_id,
+        **case_record,
+    }
+    return {
+        "schema_version": 1,
+        "case_type": "learning_tiny_dataset_example",
+        "example_id": example_id,
+        "split": split,
+        "source_case": {
+            "case_type": "layer_generate_case",
+            "case_id": case_id,
+            "schema_version": 1,
+        },
+        "input": {"case_record": case_record},
+        "targets": {"preferred_action": preferred_action},
+    }
+
+
+def _write_jsonl(path: Path, records: list[dict]) -> None:
+    path.write_text(
+        "\n".join(json.dumps(record, sort_keys=True) for record in records) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _ablation_fixture() -> list[dict]:
+    return [
+        _example(
+            "train_accept_1",
+            split="train",
+            case_id="train_accept_1",
+            preferred_action="accept",
+            case_record={},
+        ),
+        _example(
+            "train_accept_2",
+            split="train",
+            case_id="train_accept_2",
+            preferred_action="accept",
+            case_record={},
+        ),
+        _example(
+            "train_style_drift",
+            split="train",
+            case_id="train_style_drift",
+            preferred_action="adjust_prompt",
+            case_record={
+                "quality": {
+                    "gate_passed": False,
+                    "failures": ["style_drift"],
+                }
+            },
+        ),
+        _example(
+            "train_provider_failure",
+            split="train",
+            case_id="train_provider_failure",
+            preferred_action="fallback_to_agent",
+            case_record={
+                "decisions": {
+                    "fallback_decisions": [
+                        {
+                            "reason": "provider rejected edit request",
+                            "suggested_action": "fallback_to_agent",
+                        }
+                    ]
+                }
+            },
+        ),
+        _example(
+            "test_style_drift",
+            split="test",
+            case_id="test_style_drift",
+            preferred_action="adjust_prompt",
+            case_record={
+                "quality": {
+                    "gate_passed": False,
+                    "failures": ["style_drift"],
+                }
+            },
+        ),
+        _example(
+            "test_provider_failure",
+            split="test",
+            case_id="test_provider_failure",
+            preferred_action="fallback_to_agent",
+            case_record={
+                "decisions": {
+                    "fallback_decisions": [
+                        {
+                            "reason": "provider rejected edit request",
+                            "suggested_action": "fallback_to_agent",
+                        }
+                    ]
+                }
+            },
+        ),
+    ]
+
+
+def test_tiny_feature_ablation_reports_dependency_on_strong_input_hints(tmp_path):
+    from vulca.learning.tiny_feature_ablation import run_tiny_feature_ablation_report
+
+    output = tmp_path / "ablation.json"
+    report = run_tiny_feature_ablation_report(
+        examples=_ablation_fixture(),
+        output_path=output,
+        eval_split="test",
+        train_split="train",
+    )
+
+    variants = {item["variant_id"]: item for item in report["variant_reports"]}
+    assert variants["full"]["policy_report"]["action_accuracy"] == 1.0
+    assert variants["without_failure_hints"]["policy_report"]["action_accuracy"] == 0.5
+    assert variants["without_action_hints"]["policy_report"]["action_accuracy"] == 0.5
+    assert (
+        variants["without_failure_and_action_hints"]["policy_report"][
+            "action_accuracy"
+        ]
+        == 0.0
+    )
+    assert variants["full"]["fallback_reason_counts"] == {
+        "failure_hint_prior": 1,
+        "visible_action_hint": 1,
+    }
+    assert variants["without_failure_and_action_hints"]["accuracy_delta_vs_full"] == -1.0
+    assert variants["without_failure_hints"]["removed_feature_groups"] == [
+        "quality.failure_hints"
+    ]
+    assert json.loads(output.read_text(encoding="utf-8")) == report
+
+
+def test_tiny_feature_ablation_cli_writes_report(tmp_path):
+    dataset = tmp_path / "dataset.jsonl"
+    output = tmp_path / "report.json"
+    _write_jsonl(dataset, _ablation_fixture())
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(ROOT / "scripts/tiny_feature_ablation.py"),
+            "--dataset",
+            str(dataset),
+            "--output",
+            str(output),
+        ],
+        cwd=ROOT,
+        env=CLI_ENV,
+        text=True,
+        capture_output=True,
+        timeout=20,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    report = json.loads(output.read_text(encoding="utf-8"))
+    assert report["case_type"] == "learning_tiny_feature_ablation_report"
+    assert "without_failure_and_action_hints action_accuracy: 0.0" in result.stdout


### PR DESCRIPTION
## Summary
- add a provider-free tiny_action_model feature ablation report
- expose a CLI for comparing full input vs removed quality failure hints, action hints, combined strong hints, and auxiliary signals
- add focused TDD coverage for dependency detection and CLI output

## Verification
- `PYTHONPATH=src /opt/homebrew/bin/python3.11 -m pytest tests/test_tiny_feature_ablation.py tests/test_tiny_action_model.py tests/test_tiny_training_eval_gate.py -q` -> 12 passed
- `/opt/homebrew/bin/python3.11 -m py_compile src/vulca/learning/tiny_feature_ablation.py scripts/tiny_feature_ablation.py tests/test_tiny_feature_ablation.py`
- `ruff check src/vulca/learning/tiny_feature_ablation.py scripts/tiny_feature_ablation.py tests/test_tiny_feature_ablation.py`
- `git diff --check`

## Local real-user trial
- real-user-only full accuracy: 1.0
- without quality failure hints: 0.4444444444444444
- without action hints: 0.7777777777777778
- without both: 0.1111111111111111
- with Florence auxiliary signals, removing aux still stayed 1.0, so current Florence captions did not create measurable lift on this tiny real-user set

## Notes
- No build artifacts or private paths are committed.
- This is an evaluation/reporting tool only; it does not change tiny_action_model behavior.