### PR TITLE
feat(learning): gate tiny eval with feature ablation

### DIFF
--- a/scripts/tiny_training_eval_gate.py
+++ b/scripts/tiny_training_eval_gate.py
@@ -22,6 +22,7 @@ from vulca.learning.tiny_training_eval import (  # noqa: E402
     format_gate_violation,
     parse_policy_float_thresholds,
     parse_policy_int_thresholds,
+    parse_variant_float_thresholds,
     run_tiny_training_eval_gate,
 )
 
@@ -119,6 +120,16 @@ def main(argv: Sequence[str] | None = None) -> int:
         ),
     )
     parser.add_argument(
+        "--min-ablation-action-accuracy",
+        action="append",
+        default=[],
+        metavar="VARIANT=VALUE",
+        help=(
+            "Fail if a tiny_action_model_v1 ablation variant action_accuracy "
+            "is below VALUE. Example: without_failure_and_action_hints=0.5."
+        ),
+    )
+    parser.add_argument(
         "--allow-missing-predictions",
         action="store_true",
         help="Do not fail when prediction JSONL files omit examples from the eval split.",
@@ -132,6 +143,9 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     try:
         min_thresholds = parse_policy_float_thresholds(args.min_action_accuracy)
+        min_ablation_thresholds = parse_variant_float_thresholds(
+            args.min_ablation_action_accuracy
+        )
         max_thresholds = parse_policy_int_thresholds(args.max_mismatches)
         report = run_tiny_training_eval_gate(
             repo_root=args.repo_root,
@@ -147,6 +161,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             eval_split=args.split,
             train_split=args.train_split,
             min_action_accuracy=min_thresholds,
+            min_ablation_action_accuracy=min_ablation_thresholds,
             max_mismatches=max_thresholds,
             require_no_missing_predictions=not args.allow_missing_predictions,
         )
@@ -170,6 +185,10 @@ def main(argv: Sequence[str] | None = None) -> int:
     for policy in sorted(report["comparison"]["policy_reports"]):
         policy_report = report["comparison"]["policy_reports"][policy]
         print(f"{policy} action_accuracy: {policy_report['action_accuracy']}")
+    print("tiny_action_model_v1 ablation:")
+    for variant in report["ablation"]["variant_reports"]:
+        policy_report = variant["policy_report"]
+        print(f"  {variant['variant_id']} action_accuracy: {policy_report['action_accuracy']}")
 
     if not report["gate"]["passed"]:
         print("Tiny training/eval gate failed:", file=sys.stderr)

--- a/scripts/training_effectiveness_report.py
+++ b/scripts/training_effectiveness_report.py
@@ -120,6 +120,16 @@ def main(argv: Sequence[str] | None = None) -> int:
         "Accuracy delta vs baseline: "
         f"{effectiveness['accuracy_delta_vs_baseline']}"
     )
+    hardest_drop = effectiveness.get("ablation_summary", {}).get(
+        "largest_accuracy_drop",
+        {},
+    )
+    if hardest_drop:
+        print(
+            "Ablation hardest drop: "
+            f"{hardest_drop.get('variant_id')} "
+            f"{hardest_drop.get('accuracy_delta_vs_full')}"
+        )
     print(f"Tiny gate passed: {effectiveness['gate_passed']}")
     print(f"Data gaps: {len(report['data_gaps'])}")
     for gap in report["data_gaps"][:10]:

--- a/src/vulca/learning/aggregated_case_source_eval.py
+++ b/src/vulca/learning/aggregated_case_source_eval.py
@@ -112,6 +112,9 @@ def run_aggregated_case_source_eval(
                 "tiny_action_model_v1_prediction_path"
             ],
             "comparison_report_path": tiny_report["artifacts"]["comparison_report_path"],
+            "tiny_feature_ablation_report_path": tiny_report["artifacts"][
+                "tiny_feature_ablation_report_path"
+            ],
         },
         "dataset_summary": _build_dataset_summary(examples),
         "source_summary": _build_source_summary(examples),
@@ -122,6 +125,7 @@ def run_aggregated_case_source_eval(
             policy_comparison=policy_comparison,
         ),
         "tiny_training_eval": {
+            "ablation": tiny_report.get("ablation", {}),
             "gate": tiny_report["gate"],
             "predictions": tiny_report["predictions"],
         },

--- a/src/vulca/learning/tiny_training_eval.py
+++ b/src/vulca/learning/tiny_training_eval.py
@@ -21,6 +21,7 @@ from vulca.learning.tiny_dataset import (
     load_tiny_dataset_examples,
     write_tiny_dataset,
 )
+from vulca.learning.tiny_feature_ablation import run_tiny_feature_ablation_report_for_dataset
 
 
 SCHEMA_VERSION = 1
@@ -50,6 +51,7 @@ def run_tiny_training_eval_gate(
     eval_split: str = "test",
     train_split: str = "train",
     min_action_accuracy: Mapping[str, float] | None = None,
+    min_ablation_action_accuracy: Mapping[str, float] | None = None,
     max_mismatches: Mapping[str, int] | None = None,
     require_no_missing_predictions: bool = True,
 ) -> dict[str, Any]:
@@ -64,6 +66,7 @@ def run_tiny_training_eval_gate(
     tiny_agent_path = output / "tiny_agent_v0.predictions.jsonl"
     tiny_action_model_path = output / "tiny_action_model_v1.predictions.jsonl"
     comparison_report_path = output / "tiny_dataset_comparison.json"
+    ablation_report_path = output / "tiny_feature_ablation.json"
     resolved_report_path = Path(report_path) if report_path else output / "tiny_training_eval_report.json"
     resolved_manifest_path = manifest_path or DEFAULT_SEED_MANIFEST
 
@@ -103,6 +106,12 @@ def run_tiny_training_eval_gate(
         json.dumps(comparison_report, indent=2, sort_keys=True) + "\n",
         encoding="utf-8",
     )
+    ablation_report = run_tiny_feature_ablation_report_for_dataset(
+        dataset_path=dataset_path,
+        output_path=ablation_report_path,
+        eval_split=eval_split,
+        train_split=train_split,
+    )
 
     min_thresholds = dict(DEFAULT_MIN_ACTION_ACCURACY)
     min_thresholds.update(min_action_accuracy or {})
@@ -110,7 +119,9 @@ def run_tiny_training_eval_gate(
     max_thresholds.update(max_mismatches or {})
     gate = build_tiny_training_eval_gate_result(
         comparison_report,
+        ablation_report=ablation_report,
         min_action_accuracy=min_thresholds,
+        min_ablation_action_accuracy=min_ablation_action_accuracy or {},
         max_mismatches=max_thresholds,
         require_no_missing_predictions=require_no_missing_predictions,
     )
@@ -134,6 +145,7 @@ def run_tiny_training_eval_gate(
             "tiny_agent_v0_prediction_path": str(tiny_agent_path),
             "tiny_action_model_v1_prediction_path": str(tiny_action_model_path),
             "comparison_report_path": str(comparison_report_path),
+            "tiny_feature_ablation_report_path": str(ablation_report_path),
             "report_path": str(resolved_report_path),
         },
         "dataset": asdict(dataset_result),
@@ -142,6 +154,7 @@ def run_tiny_training_eval_gate(
             POLICY_TINY_ACTION_MODEL: asdict(tiny_action_model_result),
         },
         "comparison": comparison_report,
+        "ablation": ablation_report,
         "gate": gate,
     }
     resolved_report_path.parent.mkdir(parents=True, exist_ok=True)
@@ -155,11 +168,14 @@ def run_tiny_training_eval_gate(
 def build_tiny_training_eval_gate_result(
     comparison_report: Mapping[str, Any],
     *,
+    ablation_report: Mapping[str, Any] | None = None,
     min_action_accuracy: Mapping[str, float],
+    min_ablation_action_accuracy: Mapping[str, float] | None = None,
     max_mismatches: Mapping[str, int],
     require_no_missing_predictions: bool = True,
 ) -> dict[str, Any]:
     policy_reports = _mapping(comparison_report.get("policy_reports"))
+    ablation_by_variant = _ablation_variants_by_id(ablation_report or {})
     violations: list[dict[str, Any]] = []
 
     for policy, threshold in sorted(min_action_accuracy.items()):
@@ -170,6 +186,20 @@ def build_tiny_training_eval_gate_result(
                 {
                     "policy": str(policy),
                     "metric": "action_accuracy",
+                    "actual": actual,
+                    "expected": f">= {_format_number(float(threshold))}",
+                }
+            )
+
+    for variant, threshold in sorted((min_ablation_action_accuracy or {}).items()):
+        metrics = _mapping(_mapping(ablation_by_variant.get(variant)).get("policy_report"))
+        actual = metrics.get("action_accuracy")
+        if actual is None or float(actual) < float(threshold):
+            violations.append(
+                {
+                    "policy": POLICY_TINY_ACTION_MODEL,
+                    "variant": str(variant),
+                    "metric": "ablation_action_accuracy",
                     "actual": actual,
                     "expected": f">= {_format_number(float(threshold))}",
                 }
@@ -210,6 +240,10 @@ def build_tiny_training_eval_gate_result(
             "min_action_accuracy": {
                 policy: float(value)
                 for policy, value in sorted(min_action_accuracy.items())
+            },
+            "min_ablation_action_accuracy": {
+                variant: float(value)
+                for variant, value in sorted((min_ablation_action_accuracy or {}).items())
             },
             "max_mismatches": {
                 policy: int(value) for policy, value in sorted(max_mismatches.items())
@@ -265,7 +299,24 @@ def format_gate_violation(violation: Mapping[str, Any]) -> str:
         return f"{policy} mismatch_count {actual} > {threshold}"
     if metric == "missing_count":
         return f"{policy} missing_count {actual} > 0"
+    if metric == "ablation_action_accuracy":
+        variant = str(violation.get("variant") or "")
+        threshold = expected.replace(">= ", "")
+        return f"{policy} {variant} action_accuracy {actual} < {threshold}"
     return f"{policy} {metric} {actual} violates {expected}"
+
+
+def parse_variant_float_thresholds(values: Sequence[str]) -> dict[str, float]:
+    thresholds: dict[str, float] = {}
+    for raw in values:
+        variant, value = _split_policy_threshold(raw)
+        try:
+            thresholds[variant] = float(value)
+        except ValueError as exc:
+            raise ValueError(
+                f"invalid threshold value {value!r} for variant {variant!r}"
+            ) from exc
+    return thresholds
 
 
 def _split_policy_threshold(raw: str) -> tuple[str, str]:
@@ -302,6 +353,19 @@ def _format_number(value: float) -> str:
     if value.is_integer():
         return f"{value:.1f}"
     return str(value)
+
+
+def _ablation_variants_by_id(
+    ablation_report: Mapping[str, Any],
+) -> dict[str, Mapping[str, Any]]:
+    variants = ablation_report.get("variant_reports")
+    if not isinstance(variants, Sequence) or isinstance(variants, (str, bytes)):
+        return {}
+    return {
+        str(_mapping(item).get("variant_id") or ""): _mapping(item)
+        for item in variants
+        if isinstance(item, Mapping)
+    }
 
 
 def _mapping(value: Any) -> Mapping[str, Any]:

--- a/src/vulca/learning/training_effectiveness.py
+++ b/src/vulca/learning/training_effectiveness.py
@@ -97,6 +97,9 @@ def run_training_effectiveness_report(
             "comparison_report_path": aggregated_report["artifacts"][
                 "comparison_report_path"
             ],
+            "tiny_feature_ablation_report_path": aggregated_report["artifacts"][
+                "tiny_feature_ablation_report_path"
+            ],
         },
         "dataset": {
             "example_count": int(dataset_summary.get("example_count") or 0),
@@ -144,6 +147,9 @@ def _build_effectiveness_summary(aggregated_report: Mapping[str, Any]) -> dict[s
         accuracy_delta = action_accuracy - baseline_accuracy
 
     gate = _mapping(_mapping(aggregated_report.get("tiny_training_eval")).get("gate"))
+    ablation = _mapping(
+        _mapping(aggregated_report.get("tiny_training_eval")).get("ablation")
+    )
     return {
         "gate_passed": bool(gate.get("passed")),
         "evaluated_policy": DEFAULT_EVALUATED_POLICY,
@@ -153,6 +159,8 @@ def _build_effectiveness_summary(aggregated_report: Mapping[str, Any]) -> dict[s
         "accuracy_delta_vs_baseline": accuracy_delta,
         "mismatch_count": int(evaluated.get("mismatch_count") or 0),
         "missing_count": int(evaluated.get("missing_count") or 0),
+        "ablation_summary": dict(_mapping(ablation.get("summary"))),
+        "ablation_variants": _compact_ablation_variants(ablation),
         "gate": dict(gate),
         "policy_ranking": _policy_ranking(policy_reports),
     }
@@ -179,6 +187,40 @@ def _policy_ranking(policy_reports: Mapping[str, Any]) -> list[dict[str, Any]]:
             item["policy_name"],
         ),
     )
+
+
+def _compact_ablation_variants(
+    ablation_report: Mapping[str, Any],
+) -> list[dict[str, Any]]:
+    variants = ablation_report.get("variant_reports")
+    if not isinstance(variants, Sequence) or isinstance(variants, (str, bytes)):
+        return []
+    rows: list[dict[str, Any]] = []
+    for variant_value in variants:
+        variant = _mapping(variant_value)
+        policy_report = _mapping(variant.get("policy_report"))
+        rows.append(
+            {
+                "variant_id": str(variant.get("variant_id") or ""),
+                "removed_feature_groups": list(
+                    variant.get("removed_feature_groups") or []
+                ),
+                "action_accuracy": _float_or_none(
+                    policy_report.get("action_accuracy")
+                ),
+                "mismatch_count": int(policy_report.get("mismatch_count") or 0),
+                "accuracy_delta_vs_full": _float_or_none(
+                    variant.get("accuracy_delta_vs_full")
+                ),
+                "fallback_reason_counts": dict(
+                    _mapping(variant.get("fallback_reason_counts"))
+                ),
+                "auxiliary_feature_match_count": int(
+                    variant.get("auxiliary_feature_match_count") or 0
+                ),
+            }
+        )
+    return rows
 
 
 def _build_coverage_summary(aggregated_report: Mapping[str, Any]) -> dict[str, Any]:

--- a/tests/test_tiny_training_eval_gate.py
+++ b/tests/test_tiny_training_eval_gate.py
@@ -45,6 +45,7 @@ def test_tiny_training_eval_gate_command_writes_dataset_predictions_and_report(t
     assert (output_dir / "tiny_agent_v0.predictions.jsonl").exists()
     assert (output_dir / "tiny_action_model_v1.predictions.jsonl").exists()
     assert (output_dir / "tiny_dataset_comparison.json").exists()
+    assert (output_dir / "tiny_feature_ablation.json").exists()
     assert report_path.exists()
 
     report = json.loads(report_path.read_text(encoding="utf-8"))
@@ -54,8 +55,21 @@ def test_tiny_training_eval_gate_command_writes_dataset_predictions_and_report(t
     assert report["artifacts"]["comparison_report_path"] == str(
         output_dir / "tiny_dataset_comparison.json"
     )
+    assert report["artifacts"]["tiny_feature_ablation_report_path"] == str(
+        output_dir / "tiny_feature_ablation.json"
+    )
     assert report["dataset"]["example_count"] == 20
     assert report["dataset"]["counts_by_split"]["test"] == 5
+    assert report["ablation"]["case_type"] == "learning_tiny_feature_ablation_report"
+    assert {
+        item["variant_id"] for item in report["ablation"]["variant_reports"]
+    } >= {
+        "full",
+        "without_failure_hints",
+        "without_action_hints",
+        "without_failure_and_action_hints",
+        "without_auxiliary_signals",
+    }
 
 
 def test_tiny_training_eval_gate_report_includes_required_policies(tmp_path):
@@ -89,6 +103,34 @@ def test_tiny_training_eval_gate_fails_below_action_accuracy_threshold(tmp_path)
             "policy": "tiny_action_model_v1",
             "metric": "action_accuracy",
             "actual": 1.0,
+            "expected": ">= 1.01",
+        }
+    ]
+
+
+def test_tiny_training_eval_gate_fails_below_ablation_threshold(tmp_path):
+    result, _, report_path = _run_gate(
+        tmp_path,
+        "--min-ablation-action-accuracy",
+        "without_failure_and_action_hints=1.01",
+    )
+
+    assert result.returncode == 1
+    assert "Tiny training/eval gate failed" in result.stderr
+    assert (
+        "tiny_action_model_v1 without_failure_and_action_hints "
+        "action_accuracy" in result.stderr
+    )
+    report = json.loads(report_path.read_text(encoding="utf-8"))
+    assert report["gate"]["passed"] is False
+    assert report["gate"]["violations"] == [
+        {
+            "policy": "tiny_action_model_v1",
+            "variant": "without_failure_and_action_hints",
+            "metric": "ablation_action_accuracy",
+            "actual": report["ablation"]["variant_reports"][3]["policy_report"][
+                "action_accuracy"
+            ],
             "expected": ">= 1.01",
         }
     ]

--- a/tests/test_training_effectiveness_report.py
+++ b/tests/test_training_effectiveness_report.py
@@ -67,6 +67,17 @@ def test_training_effectiveness_report_uses_combined_real_manual_and_seed_data(t
     assert report["effectiveness"]["action_accuracy"] == 1.0
     assert report["effectiveness"]["mismatch_count"] == 0
     assert report["effectiveness"]["accuracy_delta_vs_baseline"] > 0
+    assert report["effectiveness"]["ablation_summary"]["full_action_accuracy"] == 1.0
+    assert (
+        report["effectiveness"]["ablation_summary"]["largest_accuracy_drop"][
+            "variant_id"
+        ]
+        == "without_failure_and_action_hints"
+    )
+    assert (
+        "tiny_feature_ablation_report_path"
+        in report["artifacts"]
+    )
     ranked = {
         item["policy_name"]: item for item in report["effectiveness"]["policy_ranking"]
     }
@@ -105,6 +116,7 @@ def test_training_effectiveness_report_script_writes_report_and_prints_summary(t
     assert "Dataset examples: 50" in result.stdout
     assert "Eval examples: 21" in result.stdout
     assert "tiny_action_model_v1 action_accuracy: 1.0" in result.stdout
+    assert "Ablation hardest drop:" in result.stdout
     assert "tiny_agent_v0 action_accuracy:" in result.stdout
     assert "Data gaps: 0" in result.stdout
     assert "source.kind local_seed: eval 0/12" not in result.stdout


### PR DESCRIPTION
## Summary
- always generate a tiny feature ablation report as part of `tiny_training_eval_gate`
- add optional `--min-ablation-action-accuracy VARIANT=VALUE` thresholds so hard-score checks can fail the gate explicitly
- surface ablation artifacts and summaries through aggregated eval and training effectiveness reports
- print ablation variant accuracies in the gate CLI and hardest ablation drop in the training effectiveness CLI

## Verification
- `PYTHONPATH=src /opt/homebrew/bin/python3.11 -m pytest tests/test_tiny_training_eval_gate.py tests/test_tiny_feature_ablation.py tests/test_training_effectiveness_report.py tests/test_aggregated_case_source_eval.py -q` -> 12 passed
- `/opt/homebrew/bin/python3.11 -m py_compile src/vulca/learning/tiny_training_eval.py src/vulca/learning/training_effectiveness.py src/vulca/learning/aggregated_case_source_eval.py scripts/tiny_training_eval_gate.py scripts/training_effectiveness_report.py tests/test_tiny_training_eval_gate.py tests/test_training_effectiveness_report.py`
- `ruff check src/vulca/learning/tiny_training_eval.py src/vulca/learning/training_effectiveness.py src/vulca/learning/aggregated_case_source_eval.py scripts/tiny_training_eval_gate.py scripts/training_effectiveness_report.py tests/test_tiny_training_eval_gate.py tests/test_training_effectiveness_report.py`
- `git diff --check`

## Real-user smoke
- full action_accuracy: 1.0
- without_failure_hints: 0.4444444444444444
- without_action_hints: 0.7777777777777778
- without_failure_and_action_hints: 0.1111111111111111
- without_auxiliary_signals: 1.0

## Notes
- The new hard ablation threshold is opt-in; default CI gets observability without forcing an immediate fail on known weak hard scores.
- No build artifacts or private paths are committed.