### PR TITLE
feat(learning): recover real user private asset maps

### DIFF
--- a/scripts/real_user_asset_map_recovery.py
+++ b/scripts/real_user_asset_map_recovery.py
@@ -1,0 +1,139 @@
+"""Recover a local-only private asset map for real user source images."""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Sequence
+
+
+ROOT = Path(__file__).resolve().parent.parent
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from vulca.learning.real_user_asset_map_recovery import (  # noqa: E402
+    DEFAULT_OUTPUT_DIR,
+    recover_real_user_private_asset_map,
+)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Search local asset directories for private real-user source image "
+            "basenames and write a local-only private asset map."
+        )
+    )
+    parser.add_argument(
+        "--repo-root",
+        default=str(ROOT),
+        help="Repository root (default: this script's repository).",
+    )
+    parser.add_argument(
+        "--case-source-manifest",
+        required=True,
+        help="Reviewed real-user case source manifest JSON path.",
+    )
+    parser.add_argument(
+        "--search-root",
+        action="append",
+        default=[],
+        help="Local directory to search for source assets. Repeat as needed.",
+    )
+    parser.add_argument(
+        "--filename-alias",
+        action="append",
+        default=[],
+        metavar="PRIVATE_BASENAME=LOCAL_BASENAME",
+        help=(
+            "Explicit filename alias for recovered assets, for example "
+            "nighthawks_reference.png=nighthawks.jpg. Repeat as needed."
+        ),
+    )
+    parser.add_argument(
+        "--output-dir",
+        default=str(DEFAULT_OUTPUT_DIR),
+        help=f"Output directory for report and private map (default: {DEFAULT_OUTPUT_DIR}).",
+    )
+    parser.add_argument(
+        "--report",
+        default="",
+        help=(
+            "Safe JSON report path "
+            "(default: OUTPUT_DIR/real_user_private_asset_recovery_report.json)."
+        ),
+    )
+    parser.add_argument(
+        "--asset-map",
+        default="",
+        help=(
+            "Local private asset map path "
+            "(default: OUTPUT_DIR/real_user_recovered.private.asset_map.json)."
+        ),
+    )
+    parser.add_argument(
+        "--source-id",
+        default="real_user_cases_local_recovered",
+        help="source_id to write into the private asset map.",
+    )
+    parser.add_argument(
+        "--pretty",
+        action="store_true",
+        help="Print the full safe JSON report to stdout after writing it.",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        report = recover_real_user_private_asset_map(
+            repo_root=args.repo_root,
+            case_source_manifest_path=args.case_source_manifest,
+            search_roots=args.search_root,
+            filename_aliases=_parse_filename_aliases(args.filename_alias),
+            output_dir=args.output_dir,
+            report_path=args.report or None,
+            asset_map_path=args.asset_map or None,
+            source_id=args.source_id,
+        )
+    except (ValueError, FileNotFoundError, json.JSONDecodeError, OSError) as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 2
+
+    if args.pretty:
+        print(json.dumps(report, indent=2, sort_keys=True))
+
+    summary = report["summary"]
+    artifacts = report["artifacts"]
+    print(f"Recovery report: {artifacts['report_path']}")
+    print(f"Private asset map: {artifacts['private_asset_map_path']}")
+    print(
+        "Recovered private source refs: "
+        f"{summary['recovered_count']}/{summary['private_source_ref_count']}"
+    )
+    print(f"Ambiguous private source refs: {summary['ambiguous_count']}")
+    print(f"Unresolved private source refs: {summary['unresolved_count']}")
+    print(f"Status: {report['status']}")
+    return 0
+
+
+def _parse_filename_aliases(values: Sequence[str]) -> dict[str, str]:
+    aliases: dict[str, str] = {}
+    for value in values:
+        if "=" not in value:
+            raise ValueError(
+                f"filename alias must use PRIVATE_BASENAME=LOCAL_BASENAME: {value!r}"
+            )
+        source_name, local_name = value.split("=", 1)
+        source_name = source_name.strip()
+        local_name = local_name.strip()
+        if not source_name or not local_name:
+            raise ValueError(
+                f"filename alias must use PRIVATE_BASENAME=LOCAL_BASENAME: {value!r}"
+            )
+        aliases[source_name] = local_name
+    return aliases
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/vulca/learning/real_user_asset_map_recovery.py
+++ b/src/vulca/learning/real_user_asset_map_recovery.py
@@ -1,0 +1,288 @@
+"""Recover local-only private asset maps for real user source images."""
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+from PIL import Image, UnidentifiedImageError
+
+from vulca.learning.private_asset_map import write_private_asset_map
+from vulca.learning.tiny_dataset import build_tiny_dataset_examples
+
+
+SCHEMA_VERSION = 1
+REPORT_CASE_TYPE = "learning_real_user_private_asset_recovery_report"
+DEFAULT_OUTPUT_DIR = Path("build/real_user_asset_map_recovery")
+DEFAULT_REPORT_NAME = "real_user_private_asset_recovery_report.json"
+DEFAULT_ASSET_MAP_NAME = "real_user_recovered.private.asset_map.json"
+DEFAULT_SOURCE_ID = "real_user_cases_local_recovered"
+
+
+def recover_real_user_private_asset_map(
+    *,
+    repo_root: str | Path,
+    case_source_manifest_path: str | Path,
+    search_roots: Sequence[str | Path],
+    filename_aliases: Mapping[str, str] | None = None,
+    output_dir: str | Path = DEFAULT_OUTPUT_DIR,
+    report_path: str | Path | None = None,
+    asset_map_path: str | Path | None = None,
+    source_id: str = DEFAULT_SOURCE_ID,
+) -> dict[str, Any]:
+    """Write a local private asset map by matching private source basenames."""
+    roots = [Path(root) for root in search_roots]
+    if not roots:
+        raise ValueError("at least one search root is required")
+    aliases = {
+        str(source_name): str(local_name)
+        for source_name, local_name in (filename_aliases or {}).items()
+        if str(source_name) and str(local_name)
+    }
+
+    output = Path(output_dir)
+    output.mkdir(parents=True, exist_ok=True)
+    resolved_report_path = (
+        Path(report_path) if report_path else output / DEFAULT_REPORT_NAME
+    )
+    resolved_asset_map_path = (
+        Path(asset_map_path) if asset_map_path else output / DEFAULT_ASSET_MAP_NAME
+    )
+
+    private_source_refs = _private_source_refs(
+        repo_root=repo_root,
+        case_source_manifest_path=case_source_manifest_path,
+    )
+    recovered: list[dict[str, Any]] = []
+    ambiguous: list[dict[str, Any]] = []
+    unresolved: list[dict[str, Any]] = []
+    entries: dict[str, str] = {}
+
+    for item in private_source_refs:
+        basename = str(item["basename"])
+        candidates = _find_valid_image_candidates(
+            _candidate_basenames(basename, aliases),
+            roots,
+        )
+        if len(candidates) == 1:
+            candidate, matched_basename = candidates[0]
+            private_ref = str(item["private_ref"])
+            entries[private_ref] = str(candidate)
+            recovered.append(
+                _safe_record(
+                    item,
+                    candidate_count=1,
+                    matched_basename=matched_basename,
+                    selected_path_digest=_digest_path(candidate),
+                    image_probe=_image_probe(candidate),
+                )
+            )
+            continue
+        if candidates:
+            ambiguous.append(
+                _safe_record(
+                    item,
+                    candidate_count=len(candidates),
+                    candidate_path_digests=[
+                        _digest_path(candidate) for candidate, _ in candidates
+                    ],
+                )
+            )
+            continue
+        unresolved.append(_safe_record(item, candidate_count=0))
+
+    write_private_asset_map(
+        resolved_asset_map_path,
+        source_id=source_id,
+        entries=entries,
+    )
+    report = {
+        "schema_version": SCHEMA_VERSION,
+        "case_type": REPORT_CASE_TYPE,
+        "status": "ready_to_rerun_coverage" if entries else "needs_user_assets",
+        "inputs": {
+            "case_source_manifest_path": _safe_path(case_source_manifest_path),
+            "search_root_count": len(roots),
+            "filename_alias_count": len(aliases),
+        },
+        "artifacts": {
+            "report_path": _artifact_name(resolved_report_path, output),
+            "private_asset_map_path": _artifact_name(resolved_asset_map_path, output),
+        },
+        "summary": {
+            "private_source_ref_count": len(private_source_refs),
+            "recovered_count": len(recovered),
+            "ambiguous_count": len(ambiguous),
+            "unresolved_count": len(unresolved),
+        },
+        "recovered": recovered,
+        "ambiguous": ambiguous,
+        "unresolved": unresolved,
+        "safe_handling": {
+            "private_asset_map_contains_local_paths": True,
+            "do_not_commit_private_asset_map": True,
+            "report_omits_local_paths": True,
+        },
+    }
+    resolved_report_path.parent.mkdir(parents=True, exist_ok=True)
+    resolved_report_path.write_text(
+        json.dumps(report, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return report
+
+
+def _private_source_refs(
+    *,
+    repo_root: str | Path,
+    case_source_manifest_path: str | Path,
+) -> list[dict[str, Any]]:
+    examples = build_tiny_dataset_examples(
+        repo_root=repo_root,
+        case_source_manifest_path=case_source_manifest_path,
+        include_local_seeds=False,
+    )
+    items: list[dict[str, Any]] = []
+    for example in examples:
+        case_record = _mapping(_mapping(example.get("input")).get("case_record"))
+        private_ref = _source_image_ref(case_record)
+        if not private_ref.startswith("private://"):
+            continue
+        basename = private_ref.rstrip("/").rsplit("/", 1)[-1]
+        if not basename:
+            continue
+        source_case = _mapping(example.get("source_case"))
+        source = _mapping(example.get("source"))
+        items.append(
+            {
+                "case_id": str(source_case.get("case_id") or ""),
+                "case_type": str(source_case.get("case_type") or ""),
+                "basename": basename,
+                "private_ref": private_ref,
+                "private_ref_digest": _digest_text(private_ref),
+                "source": {
+                    "source_id": str(source.get("source_id") or ""),
+                    "kind": str(source.get("kind") or ""),
+                    "privacy_scope": str(source.get("privacy_scope") or ""),
+                    "record_index": int(source.get("index") or 0),
+                },
+            }
+        )
+    return items
+
+
+def _candidate_basenames(
+    basename: str,
+    filename_aliases: Mapping[str, str],
+) -> tuple[str, ...]:
+    alias = filename_aliases.get(basename)
+    if alias and alias != basename:
+        return (basename, alias)
+    return (basename,)
+
+
+def _find_valid_image_candidates(
+    basenames: Sequence[str],
+    roots: Sequence[Path],
+) -> list[tuple[Path, str]]:
+    candidates: dict[str, tuple[Path, str]] = {}
+    for root in roots:
+        if not root.exists():
+            continue
+        for basename in basenames:
+            for path in root.rglob(basename):
+                if not path.is_file() or ".git" in path.parts:
+                    continue
+                if _image_probe(path).get("valid_image") is not True:
+                    continue
+                resolved = path.resolve()
+                candidates[str(resolved)] = (resolved, basename)
+    return [candidates[key] for key in sorted(candidates)]
+
+
+def _source_image_ref(case_record: Mapping[str, Any]) -> str:
+    direct = str(case_record.get("source_image") or "")
+    if direct:
+        return direct
+    for key in ("input", "inputs"):
+        nested = case_record.get(key)
+        if isinstance(nested, Mapping):
+            value = str(nested.get("source_image") or "")
+            if value:
+                return value
+    return ""
+
+
+def _safe_record(
+    item: Mapping[str, Any],
+    *,
+    candidate_count: int,
+    matched_basename: str = "",
+    selected_path_digest: str = "",
+    candidate_path_digests: Sequence[str] = (),
+    image_probe: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    record = {
+        "case_id": str(item.get("case_id") or ""),
+        "case_type": str(item.get("case_type") or ""),
+        "source": dict(_mapping(item.get("source"))),
+        "basename": str(item.get("basename") or ""),
+        "private_ref_digest": str(item.get("private_ref_digest") or ""),
+        "candidate_count": candidate_count,
+    }
+    if selected_path_digest:
+        record["selected_path_digest"] = selected_path_digest
+    if matched_basename:
+        record["matched_basename"] = matched_basename
+    if candidate_path_digests:
+        record["candidate_path_digests"] = list(candidate_path_digests)
+    if image_probe:
+        record["image_probe"] = dict(image_probe)
+    return record
+
+
+def _image_probe(path: Path) -> dict[str, Any]:
+    try:
+        with Image.open(path) as image:
+            return {
+                "valid_image": True,
+                "width": int(image.width),
+                "height": int(image.height),
+                "format": str(image.format or "").lower(),
+            }
+    except (OSError, UnidentifiedImageError):
+        return {"valid_image": False}
+
+
+def _safe_path(path: str | Path) -> str:
+    value = Path(path)
+    parts = value.parts
+    if "docs" in parts:
+        index = parts.index("docs")
+        return str(Path(*parts[index:]))
+    if "build" in parts:
+        index = parts.index("build")
+        return str(Path(*parts[index:]))
+    return value.name
+
+
+def _artifact_name(path: Path, output_dir: Path) -> str:
+    try:
+        return str(path.relative_to(output_dir))
+    except ValueError:
+        return path.name
+
+
+def _digest_text(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()[:12]
+
+
+def _digest_path(path: Path) -> str:
+    return _digest_text(str(path.resolve()))
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    if isinstance(value, Mapping):
+        return value
+    return {}

--- a/tests/test_real_user_asset_map_recovery.py
+++ b/tests/test_real_user_asset_map_recovery.py
@@ -1,0 +1,208 @@
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from PIL import Image
+
+
+ROOT = Path(__file__).resolve().parent.parent
+CLI_ENV = dict(
+    os.environ,
+    PYTHONPATH=str(ROOT / "src") + os.pathsep + os.environ.get("PYTHONPATH", ""),
+)
+
+
+def _write_image(path: Path, *, size: tuple[int, int] = (8, 6)) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    Image.new("RGB", size, color=(25, 80, 140)).save(path)
+
+
+def _write_case_source(tmp_path: Path) -> Path:
+    case_log = tmp_path / "real_user_cases.private.user_cases.jsonl"
+    records = [
+        {
+            "schema_version": 1,
+            "case_type": "redraw_case",
+            "case_id": "recoverable_source",
+            "source_image": "private://local_path/a/source.png",
+            "review": {
+                "reviewed_at": "2026-05-07T00:00:00Z",
+                "human_accept": False,
+                "failure_type": "missing_detail",
+                "preferred_action": "adjust_instruction",
+            },
+        },
+        {
+            "schema_version": 1,
+            "case_type": "layer_generate_case",
+            "case_id": "missing_source",
+            "source_image": "private://local_path/b/missing.png",
+            "review": {
+                "reviewed_at": "2026-05-07T00:00:00Z",
+                "human_accept": False,
+                "failure_type": "provider_failure",
+                "preferred_action": "fallback_to_agent",
+            },
+        },
+    ]
+    case_log.write_text(
+        "\n".join(json.dumps(record, sort_keys=True) for record in records) + "\n",
+        encoding="utf-8",
+    )
+    manifest = tmp_path / "real_user_case_source_manifest.json"
+    manifest.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "case_type": "learning_tiny_case_source_manifest",
+                "sources": [
+                    {
+                        "source_id": "real_user_cases_fixture",
+                        "kind": "user_case_log",
+                        "path": case_log.name,
+                        "privacy_scope": "private",
+                        "curation_status": "reviewed",
+                    }
+                ],
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return manifest
+
+
+def test_recover_private_asset_map_writes_local_map_and_safe_report(tmp_path):
+    from vulca.learning.real_user_asset_map_recovery import (
+        recover_real_user_private_asset_map,
+    )
+
+    manifest = _write_case_source(tmp_path)
+    search_root = tmp_path / "assets"
+    _write_image(search_root / "source.png")
+
+    report = recover_real_user_private_asset_map(
+        repo_root=tmp_path,
+        case_source_manifest_path=manifest,
+        search_roots=[search_root],
+        output_dir=tmp_path / "recovery",
+    )
+
+    assert report["case_type"] == "learning_real_user_private_asset_recovery_report"
+    assert report["summary"] == {
+        "private_source_ref_count": 2,
+        "recovered_count": 1,
+        "ambiguous_count": 0,
+        "unresolved_count": 1,
+    }
+    assert report["recovered"][0]["case_id"] == "recoverable_source"
+    assert report["unresolved"][0]["case_id"] == "missing_source"
+
+    report_path = tmp_path / "recovery" / "real_user_private_asset_recovery_report.json"
+    asset_map_path = tmp_path / "recovery" / "real_user_recovered.private.asset_map.json"
+    encoded_report = report_path.read_text(encoding="utf-8")
+    assert str(tmp_path) not in encoded_report
+    assert "private://local_path/a/source.png" not in encoded_report
+    assert "source.png" in encoded_report
+
+    asset_map = json.loads(asset_map_path.read_text(encoding="utf-8"))
+    assert asset_map["case_type"] == "learning_private_asset_map"
+    assert asset_map["entries"] == [
+        {
+            "private_ref": "private://local_path/a/source.png",
+            "local_path": str(search_root / "source.png"),
+        }
+    ]
+
+
+def test_recover_private_asset_map_does_not_auto_select_ambiguous_names(tmp_path):
+    from vulca.learning.real_user_asset_map_recovery import (
+        recover_real_user_private_asset_map,
+    )
+
+    manifest = _write_case_source(tmp_path)
+    _write_image(tmp_path / "assets_a" / "source.png")
+    _write_image(tmp_path / "assets_b" / "source.png")
+
+    report = recover_real_user_private_asset_map(
+        repo_root=tmp_path,
+        case_source_manifest_path=manifest,
+        search_roots=[tmp_path / "assets_a", tmp_path / "assets_b"],
+        output_dir=tmp_path / "recovery",
+    )
+
+    assert report["summary"]["recovered_count"] == 0
+    assert report["summary"]["ambiguous_count"] == 1
+    assert report["ambiguous"][0]["case_id"] == "recoverable_source"
+
+    asset_map = json.loads(
+        (tmp_path / "recovery" / "real_user_recovered.private.asset_map.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert asset_map["entries"] == []
+
+
+def test_recover_private_asset_map_supports_explicit_filename_alias(tmp_path):
+    from vulca.learning.real_user_asset_map_recovery import (
+        recover_real_user_private_asset_map,
+    )
+
+    manifest = _write_case_source(tmp_path)
+    search_root = tmp_path / "assets"
+    _write_image(search_root / "source_asset.png")
+
+    report = recover_real_user_private_asset_map(
+        repo_root=tmp_path,
+        case_source_manifest_path=manifest,
+        search_roots=[search_root],
+        output_dir=tmp_path / "recovery",
+        filename_aliases={"source.png": "source_asset.png"},
+    )
+
+    assert report["summary"]["recovered_count"] == 1
+    assert report["recovered"][0]["basename"] == "source.png"
+    assert report["recovered"][0]["matched_basename"] == "source_asset.png"
+
+    asset_map = json.loads(
+        (tmp_path / "recovery" / "real_user_recovered.private.asset_map.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert asset_map["entries"][0]["local_path"] == str(search_root / "source_asset.png")
+
+
+def test_real_user_asset_map_recovery_cli_writes_outputs(tmp_path):
+    manifest = _write_case_source(tmp_path)
+    search_root = tmp_path / "assets"
+    output_dir = tmp_path / "recovery"
+    _write_image(search_root / "source.png")
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(ROOT / "scripts/real_user_asset_map_recovery.py"),
+            "--repo-root",
+            str(tmp_path),
+            "--case-source-manifest",
+            str(manifest),
+            "--search-root",
+            str(search_root),
+            "--output-dir",
+            str(output_dir),
+        ],
+        cwd=ROOT,
+        env=CLI_ENV,
+        text=True,
+        capture_output=True,
+        timeout=20,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "Recovered private source refs: 1/2" in result.stdout
+    assert (output_dir / "real_user_private_asset_recovery_report.json").exists()
+    assert (output_dir / "real_user_recovered.private.asset_map.json").exists()


### PR DESCRIPTION
## Summary
- add a local-only real-user private asset map recovery module and CLI
- recover source_image private refs by unique local filename match, with explicit filename aliases for confirmed renames
- write a safe recovery report that omits local paths/private refs while writing the local private asset map separately

## Verification
- PYTHONPATH=src /opt/homebrew/bin/python3.11 -m pytest tests/test_real_user_asset_map_recovery.py tests/test_real_user_asset_coverage.py tests/test_real_user_asset_reintake.py tests/test_user_case_intake.py -q
- PYTHONPATH=src /opt/homebrew/bin/python3.11 -m py_compile src/vulca/learning/real_user_asset_map_recovery.py scripts/real_user_asset_map_recovery.py tests/test_real_user_asset_map_recovery.py
- ruff check src/vulca/learning/real_user_asset_map_recovery.py scripts/real_user_asset_map_recovery.py tests/test_real_user_asset_map_recovery.py
- git diff --check

## Real smoke
- v1 recovery with explicit roots: 2/2 private source refs recovered
- v2 recovery with explicit roots and nighthawks_reference.png=nighthawks.jpg alias: 4/4 private source refs recovered
- coverage after generated maps: v1 ready 2/5, v2 ready 4/7, total ready 6/12
- remaining tasks: 4 source_hint_only, 2 missing_source_reference
- safe report grep for /Users, .worktrees, private://local_path: no matches

Private asset map outputs remain under build/ and are not committed.