### PR TITLE
feat(learning): add real user source artifact coverage

### DIFF
--- a/scripts/real_user_source_artifact_coverage.py
+++ b/scripts/real_user_source_artifact_coverage.py
@@ -1,0 +1,91 @@
+"""Write a safe source-artifact coverage report for reviewed real user cases."""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Sequence
+
+
+ROOT = Path(__file__).resolve().parent.parent
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from vulca.learning.real_user_source_artifact_coverage import (  # noqa: E402
+    DEFAULT_OUTPUT_PATH,
+    run_real_user_source_artifact_coverage_report,
+)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Measure which reviewed real user cases have non-image source "
+            "artifacts available for source-context-dependent training."
+        )
+    )
+    parser.add_argument(
+        "--repo-root",
+        default=str(ROOT),
+        help="Repository root (default: this script's repository).",
+    )
+    parser.add_argument(
+        "--case-source-manifest",
+        required=True,
+        help="Reviewed case source manifest JSON path.",
+    )
+    parser.add_argument(
+        "--private-artifact-map",
+        action="append",
+        default=[],
+        help=(
+            "Private local source artifact map JSON path. Repeat to include "
+            "multiple maps. Local paths are never copied into the report."
+        ),
+    )
+    parser.add_argument(
+        "--output",
+        default=str(DEFAULT_OUTPUT_PATH),
+        help=f"Coverage report JSON path (default: {DEFAULT_OUTPUT_PATH}).",
+    )
+    parser.add_argument(
+        "--pretty",
+        action="store_true",
+        help="Print the full JSON report to stdout after writing it.",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        report = run_real_user_source_artifact_coverage_report(
+            repo_root=args.repo_root,
+            case_source_manifest_path=args.case_source_manifest,
+            private_artifact_map_paths=args.private_artifact_map,
+            output_path=args.output,
+        )
+    except (ValueError, FileNotFoundError, json.JSONDecodeError, OSError) as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 2
+
+    if args.pretty:
+        print(json.dumps(report, indent=2, sort_keys=True))
+
+    summary = report["summary"]
+    example_count = summary["example_count"]
+    print(f"Real-user source artifact coverage report: {args.output}")
+    print(f"Cases: {example_count}")
+    print(
+        "Source context available: "
+        f"{summary['source_context_available_count']}/{example_count}"
+    )
+    print(f"Source image present: {summary['source_image_present_count']}")
+    print(f"Available source artifacts: {summary['available_source_artifact_count']}")
+    print(f"Needs private artifact map: {summary['needs_private_artifact_map_count']}")
+    print(f"Missing artifact paths: {summary['missing_artifact_path_count']}")
+    print(f"Missing source artifacts: {summary['missing_source_artifact_count']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/vulca/learning/real_user_source_artifact_coverage.py
+++ b/src/vulca/learning/real_user_source_artifact_coverage.py
@@ -1,0 +1,333 @@
+"""Provider-free source artifact coverage for reviewed real user cases."""
+from __future__ import annotations
+
+import hashlib
+import json
+from collections import Counter
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+from vulca.learning.private_asset_map import load_private_asset_maps
+from vulca.learning.tiny_dataset import build_tiny_dataset_examples
+
+
+SCHEMA_VERSION = 1
+REPORT_CASE_TYPE = "learning_real_user_source_artifact_coverage_report"
+DEFAULT_OUTPUT_PATH = Path(
+    "build/real_user_source_artifact_coverage/source_artifact_coverage_report.json"
+)
+
+
+def run_real_user_source_artifact_coverage_report(
+    *,
+    repo_root: str | Path,
+    case_source_manifest_path: str | Path,
+    private_artifact_map_paths: Sequence[str | Path] = (),
+    output_path: str | Path | None = None,
+) -> dict[str, Any]:
+    """Write a safe report for non-image source artifacts in real user cases."""
+    root = Path(repo_root)
+    private_artifact_map = load_private_asset_maps(private_artifact_map_paths)
+    examples = build_tiny_dataset_examples(
+        repo_root=root,
+        case_source_manifest_path=case_source_manifest_path,
+        include_local_seeds=False,
+    )
+    records = [
+        _coverage_record(
+            example,
+            repo_root=root,
+            private_artifact_map=private_artifact_map,
+        )
+        for example in examples
+    ]
+    summary = _summary(records)
+    report = {
+        "schema_version": SCHEMA_VERSION,
+        "case_type": REPORT_CASE_TYPE,
+        "inputs": {
+            "repo_root": _safe_repo_root(root),
+            "case_source_manifest_path": _safe_path(case_source_manifest_path),
+            "private_artifact_map_count": len(private_artifact_map_paths),
+        },
+        "summary": summary,
+        "counts_by_case_type": _counts_by(records, "case_type"),
+        "counts_by_artifact_status": _counts_by(records, "artifact_status"),
+        "records": records,
+        "recommended_next_actions": _recommended_next_actions(summary),
+    }
+
+    output = Path(output_path) if output_path is not None else root / DEFAULT_OUTPUT_PATH
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(
+        json.dumps(report, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return report
+
+
+def _coverage_record(
+    example: Mapping[str, Any],
+    *,
+    repo_root: Path,
+    private_artifact_map: Mapping[str, str | Path],
+) -> dict[str, Any]:
+    source_case = _mapping(example.get("source_case"))
+    source = _mapping(example.get("source"))
+    case_record = _mapping(_mapping(example.get("input")).get("case_record"))
+    source_image_ref = _source_image_ref(case_record)
+    raw_refs = _artifact_refs(case_record)
+    artifacts = [
+        _resolve_artifact_ref(
+            ref,
+            repo_root=repo_root,
+            private_artifact_map=private_artifact_map,
+        )
+        for ref in raw_refs
+    ]
+    artifact_status = _artifact_status(
+        source_image_ref=source_image_ref,
+        artifact_records=artifacts,
+    )
+    return {
+        "case_id": str(source_case.get("case_id") or ""),
+        "case_type": str(source_case.get("case_type") or ""),
+        "source": {
+            "source_id": str(source.get("source_id") or ""),
+            "kind": str(source.get("kind") or ""),
+            "privacy_scope": str(source.get("privacy_scope") or ""),
+            "record_index": int(source.get("index") or 0),
+        },
+        "artifact_status": artifact_status,
+        "source_context_available": artifact_status in {
+            "available",
+            "source_image_present",
+        },
+        "source_image": {
+            "has_ref": bool(source_image_ref),
+            "private_ref_digest": _digest(source_image_ref)
+            if source_image_ref.startswith("private://")
+            else "",
+        },
+        "artifact_count": len(artifacts),
+        "artifacts": artifacts,
+        "next_action": _next_action_for_status(artifact_status),
+    }
+
+
+def _artifact_refs(case_record: Mapping[str, Any]) -> list[dict[str, str]]:
+    refs: list[dict[str, str]] = []
+    source_refs = case_record.get("source_refs")
+    if isinstance(source_refs, Mapping):
+        for key, value in source_refs.items():
+            refs.extend(_refs_from_value(value, label=f"source_refs.{key}"))
+
+    source_summary = case_record.get("source_summary")
+    if isinstance(source_summary, Mapping):
+        value = source_summary.get("source_path_hint")
+        refs.extend(_refs_from_value(value, label="source_summary.source_path_hint"))
+
+    inputs = case_record.get("inputs")
+    if not isinstance(inputs, Mapping):
+        inputs = case_record.get("input")
+    if isinstance(inputs, Mapping):
+        prompt_stack = inputs.get("prompt_stack")
+        if isinstance(prompt_stack, Mapping):
+            for key, value in prompt_stack.items():
+                if _is_prompt_artifact_key(str(key)):
+                    refs.extend(_refs_from_value(value, label=f"inputs.prompt_stack.{key}"))
+    return refs
+
+
+def _refs_from_value(value: Any, *, label: str) -> list[dict[str, str]]:
+    if isinstance(value, str):
+        if value:
+            return [{"label": label, "ref": value}]
+        return []
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+        refs: list[dict[str, str]] = []
+        for index, item in enumerate(value):
+            if isinstance(item, str) and item:
+                refs.append({"label": f"{label}[{index}]", "ref": item})
+        return refs
+    return []
+
+
+def _is_prompt_artifact_key(key: str) -> bool:
+    return key.endswith("_path") or key.endswith("_paths") or key.endswith("_refs")
+
+
+def _resolve_artifact_ref(
+    item: Mapping[str, str],
+    *,
+    repo_root: Path,
+    private_artifact_map: Mapping[str, str | Path],
+) -> dict[str, Any]:
+    raw_ref = str(item.get("ref") or "")
+    label = str(item.get("label") or "")
+    base = {
+        "label": label,
+        "ref_kind": _ref_kind(raw_ref),
+        "available": False,
+    }
+    if raw_ref.startswith("private://"):
+        resolved = private_artifact_map.get(raw_ref)
+        record = {
+            **base,
+            "private_ref_digest": _digest(raw_ref),
+        }
+        if resolved is None:
+            record["status"] = "needs_private_artifact_map"
+            return record
+        path = Path(resolved)
+        record.update(_path_status(path, include_path_digest=True))
+        return record
+
+    if raw_ref.startswith("http://") or raw_ref.startswith("https://"):
+        return {**base, "status": "remote_url_unsupported"}
+
+    path = Path(raw_ref)
+    if not path.is_absolute():
+        path = repo_root / path
+    return {
+        **base,
+        **_path_status(path, include_path_digest=path.is_absolute()),
+        "safe_path": _safe_path(raw_ref),
+    }
+
+
+def _path_status(path: Path, *, include_path_digest: bool = False) -> dict[str, Any]:
+    exists = path.exists()
+    record: dict[str, Any] = {
+        "available": exists,
+        "status": "available" if exists else "missing_artifact_path",
+        "artifact_kind": _artifact_kind(path) if exists else "",
+        "basename": path.name,
+    }
+    if include_path_digest:
+        record["path_digest"] = _digest(str(path.resolve()))
+    return record
+
+
+def _artifact_status(
+    *,
+    source_image_ref: str,
+    artifact_records: Sequence[Mapping[str, Any]],
+) -> str:
+    if source_image_ref:
+        return "source_image_present"
+    if not artifact_records:
+        return "missing_source_artifact"
+
+    statuses = {str(record.get("status") or "") for record in artifact_records}
+    if statuses == {"available"}:
+        return "available"
+    if "needs_private_artifact_map" in statuses:
+        return "needs_private_artifact_map"
+    if "missing_artifact_path" in statuses:
+        return "missing_artifact_path"
+    if "remote_url_unsupported" in statuses:
+        return "remote_url_unsupported"
+    return "manual_review"
+
+
+def _summary(records: Sequence[Mapping[str, Any]]) -> dict[str, int]:
+    status_counts = Counter(str(record.get("artifact_status") or "") for record in records)
+    context_available = sum(
+        1 for record in records if bool(record.get("source_context_available"))
+    )
+    return {
+        "example_count": len(records),
+        "source_image_present_count": status_counts["source_image_present"],
+        "available_source_artifact_count": status_counts["available"],
+        "needs_private_artifact_map_count": status_counts["needs_private_artifact_map"],
+        "missing_artifact_path_count": status_counts["missing_artifact_path"],
+        "missing_source_artifact_count": status_counts["missing_source_artifact"],
+        "source_context_available_count": context_available,
+    }
+
+
+def _recommended_next_actions(summary: Mapping[str, int]) -> list[str]:
+    actions: list[str] = []
+    if int(summary.get("needs_private_artifact_map_count") or 0) > 0:
+        actions.append("provide_private_source_artifact_map_for_hint_only_cases")
+    if int(summary.get("missing_artifact_path_count") or 0) > 0:
+        actions.append("fix_or_remove_missing_source_artifact_paths")
+    if int(summary.get("missing_source_artifact_count") or 0) > 0:
+        actions.append("re_intake_cases_with_source_artifact_refs")
+    if not actions:
+        actions.append("ready_for_source_context_dependent_training")
+    return actions
+
+
+def _next_action_for_status(artifact_status: str) -> str:
+    return {
+        "available": "ready_for_source_context_dependent_training",
+        "source_image_present": "handled_by_source_image_coverage",
+        "needs_private_artifact_map": "provide_private_source_artifact_map",
+        "missing_artifact_path": "fix_or_remove_source_artifact_path",
+        "missing_source_artifact": "re_intake_with_source_artifact",
+        "remote_url_unsupported": "download_or_cache_source_artifact",
+    }.get(artifact_status, "manual_review")
+
+
+def _source_image_ref(case_record: Mapping[str, Any]) -> str:
+    direct = str(case_record.get("source_image") or "")
+    if direct:
+        return direct
+    for key in ("input", "inputs"):
+        nested = case_record.get(key)
+        if isinstance(nested, Mapping):
+            value = str(nested.get("source_image") or "")
+            if value:
+                return value
+    return ""
+
+
+def _ref_kind(ref: str) -> str:
+    if ref.startswith("private://"):
+        return "private_uri"
+    if ref.startswith("http://") or ref.startswith("https://"):
+        return "remote_url"
+    if Path(ref).is_absolute():
+        return "absolute_path"
+    return "repo_relative"
+
+
+def _artifact_kind(path: Path) -> str:
+    if path.is_dir():
+        return "directory"
+    if path.is_file():
+        return "file"
+    return ""
+
+
+def _counts_by(records: Sequence[Mapping[str, Any]], key: str) -> dict[str, int]:
+    counts = Counter(str(record.get(key) or "unknown") for record in records)
+    return dict(sorted(counts.items()))
+
+
+def _safe_path(path: str | Path) -> str:
+    value = Path(path)
+    parts = value.parts
+    if "docs" in parts:
+        docs_index = parts.index("docs")
+        return str(Path(*parts[docs_index:]))
+    if "build" in parts:
+        build_index = parts.index("build")
+        return str(Path(*parts[build_index:]))
+    return value.name
+
+
+def _safe_repo_root(path: str | Path) -> str:
+    return Path(path).name
+
+
+def _digest(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()[:12]
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    if isinstance(value, Mapping):
+        return value
+    return {}

--- a/tests/test_real_user_source_artifact_coverage.py
+++ b/tests/test_real_user_source_artifact_coverage.py
@@ -1,0 +1,193 @@
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+CLI_ENV = dict(
+    os.environ,
+    PYTHONPATH=str(ROOT / "src") + os.pathsep + os.environ.get("PYTHONPATH", ""),
+)
+
+
+def _write_jsonl(path: Path, records: list[dict]) -> None:
+    path.write_text(
+        "\n".join(json.dumps(record, sort_keys=True) for record in records) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _case(case_id: str, case_type: str = "layer_generate_case", **extra) -> dict:
+    return {
+        "schema_version": 1,
+        "case_type": case_type,
+        "case_id": case_id,
+        "created_at": "2026-05-07T00:00:00Z",
+        "review": {
+            "reviewed_at": "2026-05-07T00:00:00Z",
+            "human_accept": False,
+            "failure_type": "prompt_ambiguity",
+            "preferred_action": "manual_review",
+        },
+        **extra,
+    }
+
+
+def _write_manifest(tmp_path: Path, records: list[dict]) -> Path:
+    cases = tmp_path / "real_user_cases.private.user_cases.jsonl"
+    _write_jsonl(cases, records)
+    manifest = tmp_path / "real_user_case_source_manifest.json"
+    manifest.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "case_type": "learning_tiny_case_source_manifest",
+                "sources": [
+                    {
+                        "source_id": "real_user_fixture",
+                        "kind": "user_case_log",
+                        "path": cases.name,
+                        "privacy_scope": "private",
+                        "curation_status": "reviewed",
+                    }
+                ],
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return manifest
+
+
+def test_source_artifact_coverage_classifies_brief_artifact_states(tmp_path):
+    from vulca.learning.private_asset_map import write_private_asset_map
+    from vulca.learning.real_user_source_artifact_coverage import (
+        run_real_user_source_artifact_coverage_report,
+    )
+
+    (tmp_path / "docs/brief.md").parent.mkdir(parents=True)
+    (tmp_path / "docs/brief.md").write_text("brief", encoding="utf-8")
+    (tmp_path / "docs/structured.json").write_text("{}", encoding="utf-8")
+    private_dir = tmp_path / "private-source-artifacts/case-a"
+    private_dir.mkdir(parents=True)
+    (private_dir / "proposal.md").write_text("private brief", encoding="utf-8")
+
+    records = [
+        _case(
+            "source_image_case",
+            source_image="private://local_path/a/source.png",
+        ),
+        _case(
+            "repo_brief_ready",
+            source_refs={
+                "source_brief_path": "docs/brief.md",
+                "structured_brief_path": "docs/structured.json",
+            },
+            inputs={
+                "prompt_stack": {
+                    "plan_prompt_path": "docs/brief.md",
+                    "layer_prompt_refs": ["docs/structured.json"],
+                }
+            },
+        ),
+        _case(
+            "private_hint_ready",
+            source_summary={
+                "source_path_hint": "private://local_path/private123/case-a",
+            },
+        ),
+        _case(
+            "private_hint_unmapped",
+            source_summary={
+                "source_path_hint": "private://local_path/private456/case-b",
+            },
+        ),
+        _case(
+            "repo_path_missing",
+            source_refs={"source_brief_path": "docs/missing.md"},
+        ),
+        _case("no_source_artifact"),
+    ]
+    manifest = _write_manifest(tmp_path, records)
+    private_map = tmp_path / "source_artifacts.private.asset_map.json"
+    write_private_asset_map(
+        private_map,
+        source_id="source_artifacts_fixture",
+        entries={
+            "private://local_path/private123/case-a": str(private_dir),
+        },
+    )
+
+    report = run_real_user_source_artifact_coverage_report(
+        repo_root=tmp_path,
+        case_source_manifest_path=manifest,
+        private_artifact_map_paths=(private_map,),
+        output_path=tmp_path / "report.json",
+    )
+
+    assert report["case_type"] == "learning_real_user_source_artifact_coverage_report"
+    assert report["summary"] == {
+        "example_count": 6,
+        "source_image_present_count": 1,
+        "available_source_artifact_count": 2,
+        "needs_private_artifact_map_count": 1,
+        "missing_artifact_path_count": 1,
+        "missing_source_artifact_count": 1,
+        "source_context_available_count": 3,
+    }
+    by_case = {item["case_id"]: item for item in report["records"]}
+    assert by_case["source_image_case"]["artifact_status"] == "source_image_present"
+    assert by_case["repo_brief_ready"]["artifact_status"] == "available"
+    assert by_case["repo_brief_ready"]["artifact_count"] == 4
+    assert by_case["private_hint_ready"]["artifact_status"] == "available"
+    assert by_case["private_hint_unmapped"]["artifact_status"] == (
+        "needs_private_artifact_map"
+    )
+    assert by_case["repo_path_missing"]["artifact_status"] == "missing_artifact_path"
+    assert by_case["no_source_artifact"]["artifact_status"] == "missing_source_artifact"
+
+    encoded = json.dumps(report, sort_keys=True)
+    assert str(tmp_path) not in encoded
+    assert "private://local_path" not in encoded
+
+
+def test_source_artifact_coverage_cli_writes_report(tmp_path):
+    (tmp_path / "docs/brief.md").parent.mkdir(parents=True)
+    (tmp_path / "docs/brief.md").write_text("brief", encoding="utf-8")
+    manifest = _write_manifest(
+        tmp_path,
+        [
+            _case(
+                "repo_brief_ready",
+                source_refs={"source_brief_path": "docs/brief.md"},
+            )
+        ],
+    )
+    output = tmp_path / "source_artifact_coverage.json"
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(ROOT / "scripts/real_user_source_artifact_coverage.py"),
+            "--repo-root",
+            str(tmp_path),
+            "--case-source-manifest",
+            str(manifest),
+            "--output",
+            str(output),
+        ],
+        cwd=ROOT,
+        env=CLI_ENV,
+        text=True,
+        capture_output=True,
+        timeout=20,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    report = json.loads(output.read_text(encoding="utf-8"))
+    assert report["summary"]["available_source_artifact_count"] == 1
+    assert "Source context available: 1/1" in result.stdout


### PR DESCRIPTION
## Summary
- add provider-free source artifact coverage for reviewed real-user cases
- classify source-image cases separately from repo/private source artifacts
- support private artifact maps for hint-only brief/source artifact cases without leaking local paths

## Verification
- PYTHONPATH=src /opt/homebrew/bin/python3.11 -m pytest tests/test_real_user_source_artifact_coverage.py tests/test_real_user_asset_coverage.py tests/test_real_user_asset_reintake.py tests/test_real_user_asset_map_recovery.py -q
- PYTHONPATH=src /opt/homebrew/bin/python3.11 -m py_compile src/vulca/learning/real_user_source_artifact_coverage.py scripts/real_user_source_artifact_coverage.py tests/test_real_user_source_artifact_coverage.py
- ruff check src/vulca/learning/real_user_source_artifact_coverage.py scripts/real_user_source_artifact_coverage.py tests/test_real_user_source_artifact_coverage.py
- git diff --check

## Real smoke
- v1 source artifact coverage: source context available 3/5; source image present 2; available source artifacts 1; needs private artifact map 2
- v2 source artifact coverage: source context available 5/7; source image present 4; available source artifacts 1; needs private artifact map 2
- safe report grep for /Users, .worktrees, private://local_path: no matches

This separates Seattle brief/source-artifact readiness from the remaining P2B private source_path_hint cases.