### PR TITLE
feat(learning): recover real user source artifact maps

### DIFF
--- a/scripts/real_user_source_artifact_map_recovery.py
+++ b/scripts/real_user_source_artifact_map_recovery.py
@@ -1,0 +1,140 @@
+"""Recover a local-only private map for real user source artifacts."""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Sequence
+
+
+ROOT = Path(__file__).resolve().parent.parent
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from vulca.learning.real_user_source_artifact_map_recovery import (  # noqa: E402
+    DEFAULT_OUTPUT_DIR,
+    recover_real_user_private_source_artifact_map,
+)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Search local artifact directories for private real-user source "
+            "artifact basenames and write a local-only private asset map."
+        )
+    )
+    parser.add_argument(
+        "--repo-root",
+        default=str(ROOT),
+        help="Repository root (default: this script's repository).",
+    )
+    parser.add_argument(
+        "--case-source-manifest",
+        required=True,
+        help="Reviewed real-user case source manifest JSON path.",
+    )
+    parser.add_argument(
+        "--search-root",
+        action="append",
+        default=[],
+        help="Local directory to search for source artifacts. Repeat as needed.",
+    )
+    parser.add_argument(
+        "--filename-alias",
+        action="append",
+        default=[],
+        metavar="PRIVATE_BASENAME=LOCAL_BASENAME",
+        help=(
+            "Explicit filename or directory alias, for example "
+            "case-A-spring-festival=local-case-a. Repeat as needed."
+        ),
+    )
+    parser.add_argument(
+        "--output-dir",
+        default=str(DEFAULT_OUTPUT_DIR),
+        help=f"Output directory for report and private map (default: {DEFAULT_OUTPUT_DIR}).",
+    )
+    parser.add_argument(
+        "--report",
+        default="",
+        help=(
+            "Safe JSON report path "
+            "(default: OUTPUT_DIR/real_user_source_artifact_recovery_report.json)."
+        ),
+    )
+    parser.add_argument(
+        "--asset-map",
+        default="",
+        help=(
+            "Local private artifact map path "
+            "(default: OUTPUT_DIR/real_user_source_artifacts.private.asset_map.json)."
+        ),
+    )
+    parser.add_argument(
+        "--source-id",
+        default="real_user_source_artifacts_local_recovered",
+        help="source_id to write into the private asset map.",
+    )
+    parser.add_argument(
+        "--pretty",
+        action="store_true",
+        help="Print the full safe JSON report to stdout after writing it.",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        report = recover_real_user_private_source_artifact_map(
+            repo_root=args.repo_root,
+            case_source_manifest_path=args.case_source_manifest,
+            search_roots=args.search_root,
+            filename_aliases=_parse_filename_aliases(args.filename_alias),
+            output_dir=args.output_dir,
+            report_path=args.report or None,
+            asset_map_path=args.asset_map or None,
+            source_id=args.source_id,
+        )
+    except (ValueError, FileNotFoundError, json.JSONDecodeError, OSError) as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 2
+
+    if args.pretty:
+        print(json.dumps(report, indent=2, sort_keys=True))
+
+    summary = report["summary"]
+    artifacts = report["artifacts"]
+    print(f"Recovery report: {artifacts['report_path']}")
+    print(f"Private artifact map: {artifacts['private_asset_map_path']}")
+    print(
+        "Recovered private source artifact refs: "
+        f"{summary['recovered_count']}/"
+        f"{summary['private_source_artifact_ref_count']}"
+    )
+    print(f"Ambiguous private source artifact refs: {summary['ambiguous_count']}")
+    print(f"Unresolved private source artifact refs: {summary['unresolved_count']}")
+    print(f"Status: {report['status']}")
+    return 0
+
+
+def _parse_filename_aliases(values: Sequence[str]) -> dict[str, str]:
+    aliases: dict[str, str] = {}
+    for value in values:
+        if "=" not in value:
+            raise ValueError(
+                f"filename alias must use PRIVATE_BASENAME=LOCAL_BASENAME: {value!r}"
+            )
+        source_name, local_name = value.split("=", 1)
+        source_name = source_name.strip()
+        local_name = local_name.strip()
+        if not source_name or not local_name:
+            raise ValueError(
+                f"filename alias must use PRIVATE_BASENAME=LOCAL_BASENAME: {value!r}"
+            )
+        aliases[source_name] = local_name
+    return aliases
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/vulca/learning/real_user_source_artifact_map_recovery.py
+++ b/src/vulca/learning/real_user_source_artifact_map_recovery.py
@@ -1,0 +1,292 @@
+"""Recover local-only private source artifact maps for real user cases."""
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+from vulca.learning.private_asset_map import write_private_asset_map
+from vulca.learning.real_user_source_artifact_coverage import _artifact_refs
+from vulca.learning.tiny_dataset import build_tiny_dataset_examples
+
+
+SCHEMA_VERSION = 1
+REPORT_CASE_TYPE = "learning_real_user_private_source_artifact_recovery_report"
+DEFAULT_OUTPUT_DIR = Path("build/real_user_source_artifact_map_recovery")
+DEFAULT_REPORT_NAME = "real_user_source_artifact_recovery_report.json"
+DEFAULT_ASSET_MAP_NAME = "real_user_source_artifacts.private.asset_map.json"
+DEFAULT_SOURCE_ID = "real_user_source_artifacts_local_recovered"
+
+
+def recover_real_user_private_source_artifact_map(
+    *,
+    repo_root: str | Path,
+    case_source_manifest_path: str | Path,
+    search_roots: Sequence[str | Path],
+    filename_aliases: Mapping[str, str] | None = None,
+    output_dir: str | Path = DEFAULT_OUTPUT_DIR,
+    report_path: str | Path | None = None,
+    asset_map_path: str | Path | None = None,
+    source_id: str = DEFAULT_SOURCE_ID,
+) -> dict[str, Any]:
+    """Write a local private map by matching private source artifact basenames."""
+    roots = [Path(root) for root in search_roots]
+    if not roots:
+        raise ValueError("at least one search root is required")
+    aliases = {
+        str(source_name): str(local_name)
+        for source_name, local_name in (filename_aliases or {}).items()
+        if str(source_name) and str(local_name)
+    }
+
+    output = Path(output_dir)
+    output.mkdir(parents=True, exist_ok=True)
+    resolved_report_path = (
+        Path(report_path) if report_path else output / DEFAULT_REPORT_NAME
+    )
+    resolved_asset_map_path = (
+        Path(asset_map_path) if asset_map_path else output / DEFAULT_ASSET_MAP_NAME
+    )
+
+    private_artifact_refs = _private_source_artifact_refs(
+        repo_root=repo_root,
+        case_source_manifest_path=case_source_manifest_path,
+    )
+    recovered: list[dict[str, Any]] = []
+    ambiguous: list[dict[str, Any]] = []
+    unresolved: list[dict[str, Any]] = []
+    entries: dict[str, str] = {}
+
+    for item in private_artifact_refs:
+        basename = str(item["basename"])
+        candidates = _find_valid_artifact_candidates(
+            _candidate_basenames(basename, aliases),
+            roots,
+        )
+        if len(candidates) == 1:
+            candidate, matched_basename = candidates[0]
+            private_ref = str(item["private_ref"])
+            entries[private_ref] = str(candidate)
+            recovered.append(
+                _safe_record(
+                    item,
+                    candidate_count=1,
+                    matched_basename=matched_basename,
+                    selected_path_digest=_digest_path(candidate),
+                    artifact_probe=_artifact_probe(candidate),
+                )
+            )
+            continue
+        if candidates:
+            ambiguous.append(
+                _safe_record(
+                    item,
+                    candidate_count=len(candidates),
+                    candidate_path_digests=[
+                        _digest_path(candidate) for candidate, _ in candidates
+                    ],
+                )
+            )
+            continue
+        unresolved.append(_safe_record(item, candidate_count=0))
+
+    write_private_asset_map(
+        resolved_asset_map_path,
+        source_id=source_id,
+        entries=entries,
+    )
+    report = {
+        "schema_version": SCHEMA_VERSION,
+        "case_type": REPORT_CASE_TYPE,
+        "status": "ready_to_rerun_source_artifact_coverage"
+        if entries
+        else "needs_user_source_artifacts",
+        "inputs": {
+            "case_source_manifest_path": _safe_path(case_source_manifest_path),
+            "search_root_count": len(roots),
+            "filename_alias_count": len(aliases),
+        },
+        "artifacts": {
+            "report_path": _artifact_name(resolved_report_path, output),
+            "private_asset_map_path": _artifact_name(resolved_asset_map_path, output),
+        },
+        "summary": {
+            "private_source_artifact_ref_count": len(private_artifact_refs),
+            "recovered_count": len(recovered),
+            "ambiguous_count": len(ambiguous),
+            "unresolved_count": len(unresolved),
+        },
+        "recovered": recovered,
+        "ambiguous": ambiguous,
+        "unresolved": unresolved,
+        "safe_handling": {
+            "private_asset_map_contains_local_paths": True,
+            "do_not_commit_private_asset_map": True,
+            "report_omits_local_paths": True,
+        },
+    }
+    resolved_report_path.parent.mkdir(parents=True, exist_ok=True)
+    resolved_report_path.write_text(
+        json.dumps(report, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return report
+
+
+def _private_source_artifact_refs(
+    *,
+    repo_root: str | Path,
+    case_source_manifest_path: str | Path,
+) -> list[dict[str, Any]]:
+    examples = build_tiny_dataset_examples(
+        repo_root=repo_root,
+        case_source_manifest_path=case_source_manifest_path,
+        include_local_seeds=False,
+    )
+    items: list[dict[str, Any]] = []
+    seen: set[tuple[str, str]] = set()
+    for example in examples:
+        case_record = _mapping(_mapping(example.get("input")).get("case_record"))
+        source_case = _mapping(example.get("source_case"))
+        source = _mapping(example.get("source"))
+        for artifact_ref in _artifact_refs(case_record):
+            private_ref = str(artifact_ref.get("ref") or "")
+            if not private_ref.startswith("private://"):
+                continue
+            basename = private_ref.rstrip("/").rsplit("/", 1)[-1]
+            if not basename:
+                continue
+            dedupe_key = (str(source_case.get("case_id") or ""), private_ref)
+            if dedupe_key in seen:
+                continue
+            seen.add(dedupe_key)
+            items.append(
+                {
+                    "case_id": str(source_case.get("case_id") or ""),
+                    "case_type": str(source_case.get("case_type") or ""),
+                    "label": str(artifact_ref.get("label") or ""),
+                    "basename": basename,
+                    "private_ref": private_ref,
+                    "private_ref_digest": _digest_text(private_ref),
+                    "source": {
+                        "source_id": str(source.get("source_id") or ""),
+                        "kind": str(source.get("kind") or ""),
+                        "privacy_scope": str(source.get("privacy_scope") or ""),
+                        "record_index": int(source.get("index") or 0),
+                    },
+                }
+            )
+    return items
+
+
+def _candidate_basenames(
+    basename: str,
+    filename_aliases: Mapping[str, str],
+) -> tuple[str, ...]:
+    alias = filename_aliases.get(basename)
+    if alias and alias != basename:
+        return (basename, alias)
+    return (basename,)
+
+
+def _find_valid_artifact_candidates(
+    basenames: Sequence[str],
+    roots: Sequence[Path],
+) -> list[tuple[Path, str]]:
+    candidates: dict[str, tuple[Path, str]] = {}
+    for root in roots:
+        if not root.exists():
+            continue
+        for basename in basenames:
+            for path in root.rglob(basename):
+                if ".git" in path.parts or not path.exists():
+                    continue
+                resolved = path.resolve()
+                candidates[str(resolved)] = (resolved, basename)
+    return [candidates[key] for key in sorted(candidates)]
+
+
+def _safe_record(
+    item: Mapping[str, Any],
+    *,
+    candidate_count: int,
+    matched_basename: str = "",
+    selected_path_digest: str = "",
+    candidate_path_digests: Sequence[str] = (),
+    artifact_probe: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    record = {
+        "case_id": str(item.get("case_id") or ""),
+        "case_type": str(item.get("case_type") or ""),
+        "source": dict(_mapping(item.get("source"))),
+        "label": str(item.get("label") or ""),
+        "basename": str(item.get("basename") or ""),
+        "private_ref_digest": str(item.get("private_ref_digest") or ""),
+        "candidate_count": candidate_count,
+    }
+    if selected_path_digest:
+        record["selected_path_digest"] = selected_path_digest
+    if matched_basename:
+        record["matched_basename"] = matched_basename
+    if candidate_path_digests:
+        record["candidate_path_digests"] = list(candidate_path_digests)
+    if artifact_probe:
+        record["artifact_probe"] = dict(artifact_probe)
+    return record
+
+
+def _artifact_probe(path: Path) -> dict[str, Any]:
+    if path.is_dir():
+        return {
+            "artifact_kind": "directory",
+            "file_count": _safe_file_count(path),
+        }
+    if path.is_file():
+        return {
+            "artifact_kind": "file",
+            "suffix": path.suffix.lower(),
+            "size_bytes": path.stat().st_size,
+        }
+    return {"artifact_kind": "unknown"}
+
+
+def _safe_file_count(path: Path) -> int:
+    count = 0
+    for child in path.rglob("*"):
+        if child.is_file() and ".git" not in child.parts:
+            count += 1
+    return count
+
+
+def _safe_path(path: str | Path) -> str:
+    value = Path(path)
+    parts = value.parts
+    if "docs" in parts:
+        index = parts.index("docs")
+        return str(Path(*parts[index:]))
+    if "build" in parts:
+        index = parts.index("build")
+        return str(Path(*parts[index:]))
+    return value.name
+
+
+def _artifact_name(path: Path, output_dir: Path) -> str:
+    try:
+        return str(path.relative_to(output_dir))
+    except ValueError:
+        return path.name
+
+
+def _digest_text(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()[:12]
+
+
+def _digest_path(path: Path) -> str:
+    return _digest_text(str(path.resolve()))
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    if isinstance(value, Mapping):
+        return value
+    return {}

--- a/tests/test_real_user_source_artifact_map_recovery.py
+++ b/tests/test_real_user_source_artifact_map_recovery.py
@@ -1,0 +1,219 @@
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+CLI_ENV = dict(
+    os.environ,
+    PYTHONPATH=str(ROOT / "src") + os.pathsep + os.environ.get("PYTHONPATH", ""),
+)
+
+
+def _write_jsonl(path: Path, records: list[dict]) -> None:
+    path.write_text(
+        "\n".join(json.dumps(record, sort_keys=True) for record in records) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _case(case_id: str, **extra) -> dict:
+    return {
+        "schema_version": 1,
+        "case_type": "layer_generate_case",
+        "case_id": case_id,
+        "created_at": "2026-05-07T00:00:00Z",
+        "review": {
+            "reviewed_at": "2026-05-07T00:00:00Z",
+            "human_accept": False,
+            "failure_type": "prompt_ambiguity",
+            "preferred_action": "manual_review",
+        },
+        **extra,
+    }
+
+
+def _write_manifest(tmp_path: Path, records: list[dict]) -> Path:
+    cases = tmp_path / "real_user_cases.private.user_cases.jsonl"
+    _write_jsonl(cases, records)
+    manifest = tmp_path / "real_user_case_source_manifest.json"
+    manifest.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "case_type": "learning_tiny_case_source_manifest",
+                "sources": [
+                    {
+                        "source_id": "real_user_fixture",
+                        "kind": "user_case_log",
+                        "path": cases.name,
+                        "privacy_scope": "private",
+                        "curation_status": "reviewed",
+                    }
+                ],
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return manifest
+
+
+def test_recover_private_source_artifact_map_writes_local_map_and_safe_report(tmp_path):
+    from vulca.learning.real_user_source_artifact_map_recovery import (
+        recover_real_user_private_source_artifact_map,
+    )
+
+    manifest = _write_manifest(
+        tmp_path,
+        [
+            _case(
+                "recoverable_brief",
+                source_summary={
+                    "source_path_hint": "private://local_path/a/case-A-brief",
+                },
+            ),
+            _case(
+                "missing_brief",
+                source_summary={
+                    "source_path_hint": "private://local_path/b/case-B-brief",
+                },
+            ),
+            _case(
+                "ambiguous_brief",
+                source_summary={
+                    "source_path_hint": "private://local_path/c/case-C-brief",
+                },
+            ),
+        ],
+    )
+    search_root = tmp_path / "artifacts"
+    (search_root / "case-A-brief").mkdir(parents=True)
+    (search_root / "case-A-brief" / "proposal.md").write_text(
+        "brief",
+        encoding="utf-8",
+    )
+    (tmp_path / "alt_a" / "case-C-brief").mkdir(parents=True)
+    (tmp_path / "alt_b" / "case-C-brief").mkdir(parents=True)
+
+    report = recover_real_user_private_source_artifact_map(
+        repo_root=tmp_path,
+        case_source_manifest_path=manifest,
+        search_roots=[search_root, tmp_path / "alt_a", tmp_path / "alt_b"],
+        output_dir=tmp_path / "recovery",
+    )
+
+    assert report["case_type"] == (
+        "learning_real_user_private_source_artifact_recovery_report"
+    )
+    assert report["summary"] == {
+        "private_source_artifact_ref_count": 3,
+        "recovered_count": 1,
+        "ambiguous_count": 1,
+        "unresolved_count": 1,
+    }
+    assert report["recovered"][0]["case_id"] == "recoverable_brief"
+    assert report["recovered"][0]["basename"] == "case-A-brief"
+    assert report["ambiguous"][0]["case_id"] == "ambiguous_brief"
+    assert report["unresolved"][0]["case_id"] == "missing_brief"
+
+    encoded_report = json.dumps(report, sort_keys=True)
+    assert str(tmp_path) not in encoded_report
+    assert "private://local_path" not in encoded_report
+
+    asset_map = json.loads(
+        (tmp_path / "recovery" / "real_user_source_artifacts.private.asset_map.json")
+        .read_text(encoding="utf-8")
+    )
+    assert asset_map["case_type"] == "learning_private_asset_map"
+    assert asset_map["entries"] == [
+        {
+            "private_ref": "private://local_path/a/case-A-brief",
+            "local_path": str(search_root / "case-A-brief"),
+        }
+    ]
+
+
+def test_recover_private_source_artifact_map_supports_explicit_filename_alias(tmp_path):
+    from vulca.learning.real_user_source_artifact_map_recovery import (
+        recover_real_user_private_source_artifact_map,
+    )
+
+    manifest = _write_manifest(
+        tmp_path,
+        [
+            _case(
+                "aliased_brief",
+                source_summary={
+                    "source_path_hint": "private://local_path/a/case-A-brief",
+                },
+            )
+        ],
+    )
+    search_root = tmp_path / "artifacts"
+    (search_root / "spring_case").mkdir(parents=True)
+    (search_root / "spring_case" / "proposal.md").write_text(
+        "brief",
+        encoding="utf-8",
+    )
+
+    report = recover_real_user_private_source_artifact_map(
+        repo_root=tmp_path,
+        case_source_manifest_path=manifest,
+        search_roots=[search_root],
+        filename_aliases={"case-A-brief": "spring_case"},
+        output_dir=tmp_path / "recovery",
+    )
+
+    assert report["summary"]["recovered_count"] == 1
+    assert report["recovered"][0]["matched_basename"] == "spring_case"
+
+
+def test_recover_private_source_artifact_map_cli_writes_outputs(tmp_path):
+    manifest = _write_manifest(
+        tmp_path,
+        [
+            _case(
+                "recoverable_brief",
+                source_summary={
+                    "source_path_hint": "private://local_path/a/case-A-brief",
+                },
+            )
+        ],
+    )
+    search_root = tmp_path / "artifacts"
+    output_dir = tmp_path / "recovery"
+    (search_root / "case-A-brief").mkdir(parents=True)
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(ROOT / "scripts/real_user_source_artifact_map_recovery.py"),
+            "--repo-root",
+            str(tmp_path),
+            "--case-source-manifest",
+            str(manifest),
+            "--search-root",
+            str(search_root),
+            "--output-dir",
+            str(output_dir),
+        ],
+        cwd=ROOT,
+        env=CLI_ENV,
+        text=True,
+        capture_output=True,
+        timeout=20,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "Recovered private source artifact refs: 1/1" in result.stdout
+    assert (
+        output_dir / "real_user_source_artifact_recovery_report.json"
+    ).exists()
+    assert (
+        output_dir / "real_user_source_artifacts.private.asset_map.json"
+    ).exists()


### PR DESCRIPTION
## Summary
- add provider-free recovery for private real-user source artifact refs into local-only private asset maps
- add CLI for safe source artifact map recovery with basename aliases
- add TDD coverage for recovered, ambiguous, unresolved, alias, and CLI behavior

## Verification
- PYTHONPATH=src /opt/homebrew/bin/python3.11 -m pytest tests/test_real_user_source_artifact_map_recovery.py -q
- PYTHONPATH=src /opt/homebrew/bin/python3.11 -m pytest tests/test_real_user_source_artifact_map_recovery.py tests/test_real_user_source_artifact_coverage.py tests/test_real_user_asset_map_recovery.py tests/test_real_user_asset_coverage.py -q
- PYTHONPATH=src /opt/homebrew/bin/python3.11 -m pytest tests/test_real_user_source_artifact_map_recovery.py tests/test_real_user_source_artifact_coverage.py tests/test_real_user_asset_map_recovery.py tests/test_real_user_asset_coverage.py tests/test_tiny_training_eval_gate.py tests/test_training_effectiveness_report.py tests/test_aggregated_case_source_eval.py -q
- /opt/homebrew/bin/python3.11 -m py_compile src/vulca/learning/real_user_source_artifact_map_recovery.py scripts/real_user_source_artifact_map_recovery.py tests/test_real_user_source_artifact_map_recovery.py
- ruff check src/vulca/learning/real_user_source_artifact_map_recovery.py scripts/real_user_source_artifact_map_recovery.py tests/test_real_user_source_artifact_map_recovery.py
- git diff --check --cached

## Real smoke
- recovered v1 source artifact refs: 2/2 from local .scratch P2B artifacts
- recovered v2 source artifact refs: 2/2 from local .scratch P2B artifacts
- source artifact coverage after private map: v1 5/5, v2 7/7, total 12/12
- safe reports omit local paths and private refs; private map remains local-only build output and is not committed
- training effectiveness: 50 examples, 21 eval examples, tiny_action_model_v1 action_accuracy 1.0, tiny_agent_v0 action_accuracy 0.42857142857142855, data gaps 0
