### PR TITLE
feat(learning): add source context auxiliary signals

### DIFF
--- a/scripts/source_context_signals.py
+++ b/scripts/source_context_signals.py
@@ -1,0 +1,120 @@
+"""Write promoted provider-free source-context auxiliary signals."""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Sequence
+
+
+ROOT = Path(__file__).resolve().parent.parent
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from vulca.learning.source_context_signals import (  # noqa: E402
+    DEFAULT_COMBINED_CASE_SOURCE_MANIFEST,
+    DEFAULT_OUTPUT_DIR,
+    write_source_context_signal_pack,
+)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Extract provider-free source-context summaries into explicitly "
+            "promoted auxiliary signal records."
+        )
+    )
+    parser.add_argument(
+        "--repo-root",
+        default=str(ROOT),
+        help="Repository root (default: this script's repository).",
+    )
+    parser.add_argument(
+        "--case-source-manifest",
+        default=str(DEFAULT_COMBINED_CASE_SOURCE_MANIFEST),
+        help="Reviewed case source manifest JSON path.",
+    )
+    parser.add_argument(
+        "--private-asset-map",
+        action="append",
+        default=[],
+        help=(
+            "Private local image/artifact map JSON path. Repeat to include "
+            "multiple maps. Local paths are never copied into signal records."
+        ),
+    )
+    parser.add_argument(
+        "--output",
+        default=str(DEFAULT_OUTPUT_DIR / "source_context_signals.promoted.jsonl"),
+        help="Promoted source context signal JSONL output path.",
+    )
+    parser.add_argument(
+        "--manifest",
+        default=str(DEFAULT_OUTPUT_DIR / "source_context_signal_promotion_manifest.json"),
+        help="Auxiliary signal promotion manifest output path.",
+    )
+    parser.add_argument(
+        "--report",
+        default=str(DEFAULT_OUTPUT_DIR / "source_context_signal_report.json"),
+        help="Safe source context signal report output path.",
+    )
+    parser.add_argument(
+        "--source-id",
+        default="source_context_static_v1",
+        help="source_id to write into the auxiliary signal manifest.",
+    )
+    parser.add_argument(
+        "--no-local-seeds",
+        action="store_true",
+        help="Only export records from --case-source-manifest.",
+    )
+    parser.add_argument(
+        "--max-examples",
+        type=int,
+        default=None,
+        help="Optional maximum number of examples to inspect.",
+    )
+    parser.add_argument(
+        "--pretty",
+        action="store_true",
+        help="Print the full JSON report to stdout after writing it.",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        report = write_source_context_signal_pack(
+            repo_root=args.repo_root,
+            case_source_manifest_path=args.case_source_manifest,
+            private_asset_map_paths=args.private_asset_map,
+            output_path=args.output,
+            manifest_path=args.manifest,
+            report_path=args.report,
+            include_local_seeds=not args.no_local_seeds,
+            max_examples=args.max_examples,
+            source_id=args.source_id,
+        )
+    except (ValueError, FileNotFoundError, json.JSONDecodeError, OSError) as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 2
+
+    if args.pretty:
+        print(json.dumps(report, indent=2, sort_keys=True))
+
+    summary = report["summary"]
+    print(f"Source context signal report: {report['artifacts']['report_path']}")
+    print(f"Promoted signal output: {report['artifacts']['output_path']}")
+    print(f"Promotion manifest: {report['artifacts']['manifest_path']}")
+    print(
+        "Source context signals: "
+        f"{summary['promoted_signal_count']}/{summary['example_count']}"
+    )
+    print(f"Skipped examples: {summary['skipped_count']}")
+    print(f"Status: {report['status']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/vulca/learning/source_context_signals.py
+++ b/src/vulca/learning/source_context_signals.py
@@ -1,0 +1,591 @@
+"""Provider-free source-context auxiliary signals for tiny learning."""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from collections import Counter
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+from PIL import Image, UnidentifiedImageError
+
+from vulca.learning.florence_signal_runner import resolve_case_source_image_path
+from vulca.learning.open_model_signal_review import (
+    OPEN_MODEL_SIGNAL_LOG_KIND,
+    PROJECT_PRIVACY_SCOPE,
+    PROMOTION_MANIFEST_CASE_TYPE,
+    REVIEWED_AUXILIARY_SIGNAL_STATUS,
+)
+from vulca.learning.open_model_signals import (
+    SCHEMA_VERSION as SIGNAL_SCHEMA_VERSION,
+    SIGNAL_RECORD_CASE_TYPE,
+)
+from vulca.learning.private_asset_map import load_private_asset_maps
+from vulca.learning.real_user_source_artifact_coverage import _artifact_refs
+from vulca.learning.tiny_dataset import build_tiny_dataset_examples
+from vulca.learning.training_effectiveness import (
+    DEFAULT_COMBINED_CASE_SOURCE_MANIFEST,
+)
+
+
+SCHEMA_VERSION = 1
+REPORT_CASE_TYPE = "learning_source_context_signal_report"
+SOURCE_CONTEXT_MODEL_ID = "source_context_static_v1"
+DEFAULT_OUTPUT_DIR = Path("build/source_context_signals")
+DEFAULT_SIGNAL_OUTPUT_NAME = "source_context_signals.promoted.jsonl"
+DEFAULT_MANIFEST_NAME = "source_context_signal_promotion_manifest.json"
+DEFAULT_REPORT_NAME = "source_context_signal_report.json"
+DEFAULT_SOURCE_ID = "source_context_static_v1"
+TEXT_SUFFIXES: frozenset[str] = frozenset({".md", ".txt", ".json", ".jsonl"})
+MAX_TEXT_FILES = 16
+MAX_TEXT_BYTES_PER_FILE = 200_000
+
+
+SOURCE_TAG_PATTERNS: Mapping[str, tuple[str, ...]] = {
+    "source_tag:brand_design": ("brand", "logo", "sponsor", "title", "venue"),
+    "source_tag:film_festival": ("film festival", "film", "festival"),
+    "source_tag:gongbi": ("gongbi", "song dynasty", "song-dynasty"),
+    "source_tag:layered_generation": ("layer", "layers", "z_index", "semantic_path"),
+    "source_tag:poster": ("poster", "a2", "a3", "11x17"),
+    "source_tag:registry_ambiguity": ("registry", "ambiguity", "unregistered"),
+    "source_tag:spring_festival": ("spring festival", "festival", "spring"),
+    "source_tag:tang_mural": ("tang", "mural", "court mural"),
+}
+
+
+def write_source_context_signal_pack(
+    *,
+    repo_root: str | Path,
+    case_source_manifest_path: str | Path = DEFAULT_COMBINED_CASE_SOURCE_MANIFEST,
+    private_asset_map_paths: Sequence[str | Path] = (),
+    output_path: str | Path | None = None,
+    manifest_path: str | Path | None = None,
+    report_path: str | Path | None = None,
+    include_local_seeds: bool = True,
+    max_examples: int | None = None,
+    source_id: str = DEFAULT_SOURCE_ID,
+) -> dict[str, Any]:
+    """Write reviewed-promoted provider-free source context signal records."""
+    if max_examples is not None and max_examples < 0:
+        raise ValueError("max_examples must be >= 0")
+
+    root = Path(repo_root)
+    resolved_manifest = _resolve_repo_path(root, case_source_manifest_path)
+    resolved_output = Path(output_path) if output_path else (
+        root / DEFAULT_OUTPUT_DIR / DEFAULT_SIGNAL_OUTPUT_NAME
+    )
+    resolved_pack_manifest = Path(manifest_path) if manifest_path else (
+        root / DEFAULT_OUTPUT_DIR / DEFAULT_MANIFEST_NAME
+    )
+    resolved_report = Path(report_path) if report_path else (
+        root / DEFAULT_OUTPUT_DIR / DEFAULT_REPORT_NAME
+    )
+    private_asset_map = load_private_asset_maps(private_asset_map_paths)
+    examples = build_tiny_dataset_examples(
+        repo_root=root,
+        case_source_manifest_path=resolved_manifest,
+        include_local_seeds=include_local_seeds,
+    )
+    if max_examples is not None:
+        examples = examples[:max_examples]
+
+    records: list[dict[str, Any]] = []
+    skipped = 0
+    for example in examples:
+        record = _build_source_context_signal_record(
+            example,
+            repo_root=root,
+            private_asset_map=private_asset_map,
+        )
+        if record is None:
+            skipped += 1
+            continue
+        records.append(record)
+
+    _write_jsonl(resolved_output, records)
+    _write_promotion_manifest(
+        manifest_path=resolved_pack_manifest,
+        output_path=resolved_output,
+        source_id=source_id,
+        record_count=len(records),
+    )
+    report = _build_report(
+        examples=examples,
+        records=records,
+        skipped=skipped,
+        repo_root=root,
+        case_source_manifest_path=resolved_manifest,
+        output_path=resolved_output,
+        manifest_path=resolved_pack_manifest,
+        report_path=resolved_report,
+        include_local_seeds=include_local_seeds,
+        private_asset_map_count=len(private_asset_map_paths),
+    )
+    resolved_report.parent.mkdir(parents=True, exist_ok=True)
+    resolved_report.write_text(
+        json.dumps(report, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return report
+
+
+def _build_source_context_signal_record(
+    example: Mapping[str, Any],
+    *,
+    repo_root: Path,
+    private_asset_map: Mapping[str, str | Path],
+) -> dict[str, Any] | None:
+    source_case = _mapping(example.get("source_case"))
+    case_record = _mapping(_mapping(example.get("input")).get("case_record"))
+    source_image = _source_image_signal(
+        case_record,
+        repo_root=repo_root,
+        private_asset_map=private_asset_map,
+    )
+    source_artifacts = _source_artifact_signal(
+        case_record,
+        repo_root=repo_root,
+        private_asset_map=private_asset_map,
+    )
+    has_source_context = (
+        bool(source_image["available"])
+        or int(source_artifacts["available_count"] or 0) > 0
+    )
+    if not has_source_context:
+        return None
+
+    tags = sorted(
+        set(source_image["tags"])
+        | set(source_artifacts["tags"])
+        | set(_case_visible_source_tags(case_record))
+    )
+
+    signal_id = _make_signal_id(example)
+    return {
+        "schema_version": SIGNAL_SCHEMA_VERSION,
+        "case_type": SIGNAL_RECORD_CASE_TYPE,
+        "signal_id": signal_id,
+        "example_id": str(example.get("example_id") or ""),
+        "source_case": {
+            "case_type": str(source_case.get("case_type") or ""),
+            "case_id": str(source_case.get("case_id") or ""),
+            "schema_version": int(source_case.get("schema_version") or 0),
+        },
+        "model": {
+            "id": SOURCE_CONTEXT_MODEL_ID,
+            "name": "Provider-free source context summarizer",
+            "model_role": "source_context_static",
+            "output_training_policy": "auxiliary_training_feature",
+            "default_runtime_enabled": True,
+        },
+        "signals": {
+            "status": "completed",
+            "signal_source": "source_context_static",
+            "label_source": "provider_free_deterministic",
+            "source_context_tags": tags,
+            "source_image": source_image["summary"],
+            "source_artifacts": source_artifacts["summary"],
+        },
+        "signal_review": {
+            "schema_version": SCHEMA_VERSION,
+            "decision": "promote",
+            "reviewer": SOURCE_CONTEXT_MODEL_ID,
+            "reviewed_at": "",
+            "notes": "Provider-free deterministic source context summary.",
+        },
+        "training_use": {
+            "default_training_input": False,
+            "approved_for_auxiliary_training": True,
+            "review_status": "reviewed_promoted",
+            "approved_signal_use": "auxiliary_training_feature",
+        },
+    }
+
+
+def _source_image_signal(
+    case_record: Mapping[str, Any],
+    *,
+    repo_root: Path,
+    private_asset_map: Mapping[str, str | Path],
+) -> dict[str, Any]:
+    resolved = resolve_case_source_image_path(
+        case_record,
+        repo_root=repo_root,
+        private_asset_map=private_asset_map,
+    )
+    summary: dict[str, Any] = {
+        "available": resolved.path is not None,
+        "ref_kind": resolved.ref_kind,
+    }
+    tags: list[str] = []
+    if resolved.path is None:
+        return {"available": False, "summary": summary, "tags": tags}
+
+    probe = _image_probe(resolved.path)
+    summary.update(probe)
+    tags.append("source_image:present")
+    aspect = str(probe.get("aspect") or "")
+    if aspect:
+        tags.append(f"source_image.aspect:{aspect}")
+    size_bucket = str(probe.get("size_bucket") or "")
+    if size_bucket:
+        tags.append(f"source_image.size:{size_bucket}")
+    return {"available": True, "summary": summary, "tags": tags}
+
+
+def _source_artifact_signal(
+    case_record: Mapping[str, Any],
+    *,
+    repo_root: Path,
+    private_asset_map: Mapping[str, str | Path],
+) -> dict[str, Any]:
+    artifact_paths = [
+        path
+        for path in (
+            _resolve_artifact_ref(
+                str(item.get("ref") or ""),
+                repo_root=repo_root,
+                private_asset_map=private_asset_map,
+            )
+            for item in _artifact_refs(case_record)
+        )
+        if path is not None and path.exists()
+    ]
+    kind_counts: Counter[str] = Counter()
+    suffix_counts: Counter[str] = Counter()
+    tags: list[str] = []
+    text_chunks: list[str] = []
+    text_file_count = 0
+
+    for path in artifact_paths:
+        if path.is_dir():
+            kind_counts["directory"] += 1
+            for child in _iter_text_files(path):
+                suffix_counts[child.suffix.lower()] += 1
+                text_file_count += 1
+                text_chunks.append(_read_text_prefix(child))
+        elif path.is_file():
+            kind_counts["file"] += 1
+            suffix_counts[path.suffix.lower()] += 1
+            if path.suffix.lower() in TEXT_SUFFIXES:
+                text_file_count += 1
+                text_chunks.append(_read_text_prefix(path))
+
+    if artifact_paths:
+        tags.append("source_artifact:present")
+    tags.extend(_controlled_tags_from_text("\n".join(text_chunks)))
+    summary = {
+        "available_count": len(artifact_paths),
+        "artifact_kind_counts": dict(sorted(kind_counts.items())),
+        "suffix_counts": dict(sorted(suffix_counts.items())),
+        "text_file_count": text_file_count,
+        "text_char_bucket": _count_bucket(sum(len(chunk) for chunk in text_chunks)),
+    }
+    return {
+        "available_count": len(artifact_paths),
+        "summary": summary,
+        "tags": tags,
+    }
+
+
+def _resolve_artifact_ref(
+    ref: str,
+    *,
+    repo_root: Path,
+    private_asset_map: Mapping[str, str | Path],
+) -> Path | None:
+    if not ref:
+        return None
+    if ref.startswith("private://"):
+        mapped = private_asset_map.get(ref)
+        return Path(mapped) if mapped is not None else None
+    if ref.startswith("http://") or ref.startswith("https://"):
+        return None
+    path = Path(ref)
+    if not path.is_absolute():
+        path = repo_root / path
+    return path
+
+
+def _iter_text_files(path: Path) -> tuple[Path, ...]:
+    files: list[Path] = []
+    for child in sorted(path.rglob("*")):
+        if len(files) >= MAX_TEXT_FILES:
+            break
+        if not child.is_file() or ".git" in child.parts:
+            continue
+        if child.suffix.lower() not in TEXT_SUFFIXES:
+            continue
+        files.append(child)
+    return tuple(files)
+
+
+def _read_text_prefix(path: Path) -> str:
+    try:
+        data = path.read_bytes()[:MAX_TEXT_BYTES_PER_FILE]
+        return data.decode("utf-8", errors="ignore")
+    except OSError:
+        return ""
+
+
+def _case_visible_source_tags(case_record: Mapping[str, Any]) -> tuple[str, ...]:
+    visible_text: list[str] = []
+    inputs = _mapping(case_record.get("inputs"))
+    for key in ("tradition", "user_intent"):
+        value = inputs.get(key)
+        if isinstance(value, str):
+            visible_text.append(value)
+    style_constraints = _mapping(inputs.get("style_constraints"))
+    for value in style_constraints.values():
+        if isinstance(value, str):
+            visible_text.append(value)
+        elif isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+            visible_text.extend(str(item) for item in value)
+    source_summary = _mapping(case_record.get("source_summary"))
+    for key in ("origin", "physical_form"):
+        value = source_summary.get(key)
+        if isinstance(value, str):
+            visible_text.append(value)
+    return _controlled_tags_from_text("\n".join(visible_text))
+
+
+def _controlled_tags_from_text(text: str) -> tuple[str, ...]:
+    lowered = text.lower()
+    tags: list[str] = []
+    for tag, patterns in SOURCE_TAG_PATTERNS.items():
+        if _matches_tag_patterns(lowered, patterns):
+            tags.append(tag)
+    return tuple(tags)
+
+
+def _matches_tag_patterns(text: str, patterns: Sequence[str]) -> bool:
+    for pattern in patterns:
+        if pattern in text:
+            return True
+    return False
+
+
+def _image_probe(path: Path) -> dict[str, Any]:
+    try:
+        with Image.open(path) as image:
+            width = int(image.width)
+            height = int(image.height)
+            return {
+                "width": width,
+                "height": height,
+                "format": str(image.format or "").lower(),
+                "aspect": _aspect_bucket(width, height),
+                "size_bucket": _pixel_bucket(width * height),
+            }
+    except (OSError, UnidentifiedImageError):
+        return {
+            "width": 0,
+            "height": 0,
+            "format": "",
+            "aspect": "",
+            "size_bucket": "invalid",
+        }
+
+
+def _aspect_bucket(width: int, height: int) -> str:
+    if width <= 0 or height <= 0:
+        return "unknown"
+    ratio = width / height
+    if ratio > 1.15:
+        return "landscape"
+    if ratio < 0.87:
+        return "portrait"
+    return "square"
+
+
+def _pixel_bucket(pixels: int) -> str:
+    if pixels <= 0:
+        return "unknown"
+    if pixels < 250_000:
+        return "small"
+    if pixels < 1_500_000:
+        return "medium"
+    return "large"
+
+
+def _count_bucket(value: int) -> str:
+    if value <= 0:
+        return "zero"
+    if value < 500:
+        return "short"
+    if value < 5_000:
+        return "medium"
+    return "long"
+
+
+def _build_report(
+    *,
+    examples: Sequence[Mapping[str, Any]],
+    records: Sequence[Mapping[str, Any]],
+    skipped: int,
+    repo_root: Path,
+    case_source_manifest_path: Path,
+    output_path: Path,
+    manifest_path: Path,
+    report_path: Path,
+    include_local_seeds: bool,
+    private_asset_map_count: int,
+) -> dict[str, Any]:
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "case_type": REPORT_CASE_TYPE,
+        "status": "ready_for_auxiliary_signal_training" if records else "no_signals",
+        "inputs": {
+            "repo_root": _safe_repo_root(repo_root),
+            "case_source_manifest_path": _safe_path(case_source_manifest_path),
+            "include_local_seeds": bool(include_local_seeds),
+            "private_asset_map_count": int(private_asset_map_count),
+        },
+        "artifacts": {
+            "output_path": _safe_artifact_path(repo_root, output_path),
+            "manifest_path": _safe_artifact_path(repo_root, manifest_path),
+            "report_path": _safe_artifact_path(repo_root, report_path),
+        },
+        "summary": {
+            "example_count": len(examples),
+            "promoted_signal_count": len(records),
+            "skipped_count": int(skipped),
+        },
+        "counts_by_source_kind": _counts_by_source_kind(records),
+        "counts_by_case_type": _counts_by_case_type(records),
+        "training_use": {
+            "default_training_input": False,
+            "requires_explicit_dataset_flag": True,
+            "approved_signal_use": "auxiliary_training_feature",
+        },
+        "safety": {
+            "copies_raw_source_text": False,
+            "copies_local_paths": False,
+            "copies_private_refs": False,
+            "calls_model_provider": False,
+            "downloads_weights": False,
+        },
+    }
+
+
+def _counts_by_source_kind(records: Sequence[Mapping[str, Any]]) -> dict[str, int]:
+    counts: Counter[str] = Counter()
+    for record in records:
+        signals = _mapping(record.get("signals"))
+        source_image = _mapping(signals.get("source_image"))
+        source_artifacts = _mapping(signals.get("source_artifacts"))
+        if bool(source_image.get("available")):
+            counts["source_image"] += 1
+        if int(source_artifacts.get("available_count") or 0) > 0:
+            counts["source_artifact"] += 1
+    return dict(sorted(counts.items()))
+
+
+def _counts_by_case_type(records: Sequence[Mapping[str, Any]]) -> dict[str, int]:
+    counts: Counter[str] = Counter()
+    for record in records:
+        counts[str(_mapping(record.get("source_case")).get("case_type") or "unknown")] += 1
+    return dict(sorted(counts.items()))
+
+
+def _write_promotion_manifest(
+    *,
+    manifest_path: Path,
+    output_path: Path,
+    source_id: str,
+    record_count: int,
+) -> None:
+    manifest_path.parent.mkdir(parents=True, exist_ok=True)
+    manifest = {
+        "schema_version": SCHEMA_VERSION,
+        "case_type": PROMOTION_MANIFEST_CASE_TYPE,
+        "sources": [
+            {
+                "source_id": str(source_id or DEFAULT_SOURCE_ID),
+                "kind": OPEN_MODEL_SIGNAL_LOG_KIND,
+                "path": _manifest_relative_path(output_path, manifest_path.parent),
+                "privacy_scope": PROJECT_PRIVACY_SCOPE,
+                "curation_status": REVIEWED_AUXILIARY_SIGNAL_STATUS,
+                "approved_signal_use": "auxiliary_training_feature",
+                "record_count": int(record_count),
+                "counts_by_model": {SOURCE_CONTEXT_MODEL_ID: int(record_count)},
+            }
+        ],
+        "record_count": int(record_count),
+        "counts_by_model": {SOURCE_CONTEXT_MODEL_ID: int(record_count)},
+        "training_use": {
+            "default_training_input": False,
+            "requires_explicit_dataset_flag": True,
+            "approved_signal_use": "auxiliary_training_feature",
+        },
+    }
+    manifest_path.write_text(
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _make_signal_id(example: Mapping[str, Any]) -> str:
+    seed = json.dumps(
+        {
+            "example_id": str(example.get("example_id") or ""),
+            "model_id": SOURCE_CONTEXT_MODEL_ID,
+            "case_type": SIGNAL_RECORD_CASE_TYPE,
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    digest = hashlib.sha256(seed.encode("utf-8")).hexdigest()[:16]
+    return f"source_context_signal_{digest}"
+
+
+def _write_jsonl(path: str | Path, records: Sequence[Mapping[str, Any]]) -> None:
+    output = Path(path)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    with output.open("w", encoding="utf-8") as fh:
+        for record in records:
+            fh.write(json.dumps(dict(record), sort_keys=True, separators=(",", ":")))
+            fh.write("\n")
+
+
+def _resolve_repo_path(repo_root: str | Path, path: str | Path) -> Path:
+    resolved = Path(path)
+    if not resolved.is_absolute():
+        resolved = Path(repo_root) / resolved
+    return resolved
+
+
+def _safe_repo_root(path: str | Path) -> str:
+    return Path(path).name
+
+
+def _safe_path(path: str | Path) -> str:
+    value = Path(path)
+    parts = value.parts
+    if "docs" in parts:
+        index = parts.index("docs")
+        return str(Path(*parts[index:]))
+    if "build" in parts:
+        index = parts.index("build")
+        return str(Path(*parts[index:]))
+    return value.name
+
+
+def _safe_artifact_path(repo_root: str | Path, path: str | Path) -> str:
+    artifact_path = Path(path)
+    try:
+        return str(artifact_path.relative_to(Path(repo_root)))
+    except ValueError:
+        return artifact_path.name
+
+
+def _manifest_relative_path(output_path: Path, manifest_dir: Path) -> str:
+    rel = os.path.relpath(output_path, manifest_dir)
+    return Path(rel).as_posix()
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    if isinstance(value, Mapping):
+        return value
+    return {}

--- a/src/vulca/learning/tiny_action_model.py
+++ b/src/vulca/learning/tiny_action_model.py
@@ -504,6 +504,7 @@ def _auxiliary_signal_features(example: Mapping[str, Any]) -> tuple[str, ...]:
                 max_tokens=8,
             )
         )
+        features.extend(_aux_source_context_features(signals))
         mask_count = _number(signals.get("mask_count"))
         if mask_count is not None:
             features.append(f"aux_signal.sam_mask_count:{_mask_count_bucket(mask_count)}")
@@ -516,6 +517,39 @@ def _auxiliary_signal_features(example: Mapping[str, Any]) -> tuple[str, ...]:
         if boundary_complexity:
             features.append(f"aux_signal.boundary_complexity:{boundary_complexity}")
     return tuple(features)
+
+
+def _aux_source_context_features(signals: Mapping[str, Any]) -> tuple[str, ...]:
+    features: list[str] = []
+    tags = signals.get("source_context_tags")
+    if isinstance(tags, Sequence) and not isinstance(tags, (str, bytes)):
+        for tag in tags:
+            safe_tag = _safe_source_context_tag(str(tag or ""))
+            if safe_tag:
+                features.append(f"aux_signal.source_context_tag:{safe_tag}")
+
+    source_artifacts = _mapping(signals.get("source_artifacts"))
+    artifact_kind_counts = source_artifacts.get("artifact_kind_counts")
+    if isinstance(artifact_kind_counts, Mapping):
+        for kind, count in sorted(artifact_kind_counts.items()):
+            if _positive_number(count):
+                safe_kind = _safe_source_context_tag(str(kind or ""))
+                if safe_kind:
+                    features.append(f"aux_signal.source_artifact_kind:{safe_kind}")
+
+    source_image = _mapping(signals.get("source_image"))
+    if bool(source_image.get("available")):
+        features.append("aux_signal.source_image:present")
+    aspect = _safe_source_context_tag(str(source_image.get("aspect") or ""))
+    if aspect:
+        features.append(f"aux_signal.source_image_aspect:{aspect}")
+    return tuple(features)
+
+
+def _safe_source_context_tag(value: str) -> str:
+    normalized = value.strip().lower().replace(" ", "_")
+    cleaned = re.sub(r"[^a-z0-9_.:-]+", "_", normalized).strip("_")
+    return cleaned[:80]
 
 
 def _aux_text_features(

--- a/tests/test_source_context_signals.py
+++ b/tests/test_source_context_signals.py
@@ -1,0 +1,297 @@
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from PIL import Image
+
+
+ROOT = Path(__file__).resolve().parent.parent
+CLI_ENV = dict(
+    os.environ,
+    PYTHONPATH=str(ROOT / "src") + os.pathsep + os.environ.get("PYTHONPATH", ""),
+)
+
+
+def _read_jsonl(path: Path) -> list[dict]:
+    return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines()]
+
+
+def _write_jsonl(path: Path, records: list[dict]) -> None:
+    path.write_text(
+        "\n".join(json.dumps(record, sort_keys=True) for record in records) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _case(case_id: str, **extra) -> dict:
+    return {
+        "schema_version": 1,
+        "case_type": "layer_generate_case",
+        "case_id": case_id,
+        "created_at": "2026-05-07T00:00:00Z",
+        "review": {
+            "reviewed_at": "2026-05-07T00:00:00Z",
+            "human_accept": False,
+            "failure_type": "prompt_ambiguity",
+            "preferred_action": "manual_review",
+        },
+        **extra,
+    }
+
+
+def _write_manifest(tmp_path: Path, records: list[dict]) -> Path:
+    cases = tmp_path / "real_user_cases.private.user_cases.jsonl"
+    _write_jsonl(cases, records)
+    manifest = tmp_path / "real_user_case_source_manifest.json"
+    manifest.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "case_type": "learning_tiny_case_source_manifest",
+                "sources": [
+                    {
+                        "source_id": "real_user_fixture",
+                        "kind": "user_case_log",
+                        "path": cases.name,
+                        "privacy_scope": "private",
+                        "curation_status": "reviewed",
+                    }
+                ],
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return manifest
+
+
+def test_source_context_signal_pack_writes_promoted_safe_auxiliary_signals(tmp_path):
+    from vulca.learning.private_asset_map import write_private_asset_map
+    from vulca.learning.source_context_signals import write_source_context_signal_pack
+    from vulca.learning.tiny_action_model import extract_tiny_action_features
+    from vulca.learning.tiny_dataset import build_tiny_dataset_examples
+
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    (docs / "brief.md").write_text(
+        "Production poster brief with sponsor band, title hierarchy, and film festival context.",
+        encoding="utf-8",
+    )
+    private_dir = tmp_path / "private_artifacts" / "case-b"
+    private_dir.mkdir(parents=True)
+    (private_dir / "proposal.md").write_text(
+        "client-only sentence: Tang court mural mood with registry ambiguity.",
+        encoding="utf-8",
+    )
+    image_path = tmp_path / "private_assets" / "source.png"
+    image_path.parent.mkdir()
+    Image.new("RGB", (16, 9), color=(20, 80, 160)).save(image_path)
+
+    manifest = _write_manifest(
+        tmp_path,
+        [
+            _case(
+                "repo_brief_case",
+                source_refs={"source_brief_path": "docs/brief.md"},
+            ),
+            _case(
+                "private_artifact_case",
+                source_summary={
+                    "source_path_hint": "private://local_path/private123/case-b",
+                },
+            ),
+            _case(
+                "private_image_case",
+                source_image="private://local_path/private456/source.png",
+            ),
+        ],
+    )
+    private_map = tmp_path / "source.private.asset_map.json"
+    write_private_asset_map(
+        private_map,
+        source_id="fixture_private_context",
+        entries={
+            "private://local_path/private123/case-b": str(private_dir),
+            "private://local_path/private456/source.png": str(image_path),
+        },
+    )
+    output_path = tmp_path / "signals.promoted.jsonl"
+    manifest_path = tmp_path / "signals.promotion_manifest.json"
+    report_path = tmp_path / "signals.report.json"
+
+    report = write_source_context_signal_pack(
+        repo_root=tmp_path,
+        case_source_manifest_path=manifest,
+        private_asset_map_paths=(private_map,),
+        output_path=output_path,
+        manifest_path=manifest_path,
+        report_path=report_path,
+        include_local_seeds=False,
+    )
+
+    assert report["case_type"] == "learning_source_context_signal_report"
+    assert report["summary"] == {
+        "example_count": 3,
+        "promoted_signal_count": 3,
+        "skipped_count": 0,
+    }
+    records = _read_jsonl(output_path)
+    assert len(records) == 3
+    assert all(item["case_type"] == "learning_open_model_signal_record" for item in records)
+    assert all(
+        item["training_use"]["review_status"] == "reviewed_promoted"
+        for item in records
+    )
+    tags_by_case = {
+        item["source_case"]["case_id"]: set(item["signals"]["source_context_tags"])
+        for item in records
+    }
+    assert "source_tag:film_festival" in tags_by_case["repo_brief_case"]
+    assert "source_tag:tang_mural" in tags_by_case["private_artifact_case"]
+    assert "source_image:present" in tags_by_case["private_image_case"]
+    assert "source_image.aspect:landscape" in tags_by_case["private_image_case"]
+
+    encoded = output_path.read_text(encoding="utf-8")
+    encoded += report_path.read_text(encoding="utf-8")
+    encoded += manifest_path.read_text(encoding="utf-8")
+    assert str(tmp_path) not in encoded
+    assert "private://local_path" not in encoded
+    assert "client-only sentence" not in encoded
+
+    examples = build_tiny_dataset_examples(
+        repo_root=tmp_path,
+        case_source_manifest_path=manifest,
+        auxiliary_signal_manifest_path=manifest_path,
+        include_local_seeds=False,
+    )
+    target = next(
+        item for item in examples if item["source_case"]["case_id"] == "repo_brief_case"
+    )
+    features = extract_tiny_action_features(target)
+    assert "aux_signal.model:source_context_static_v1" in features
+    assert "aux_signal.source_context_tag:source_tag:film_festival" in features
+    assert "aux_signal.source_artifact_kind:file" in features
+
+
+def test_tiny_action_model_can_learn_from_source_context_tags():
+    from vulca.learning.tiny_action_model import (
+        TinyActionClassifier,
+        extract_tiny_action_features,
+    )
+
+    def example(example_id, split, target_action, tags):
+        return {
+            "example_id": example_id,
+            "split": split,
+            "source_case": {
+                "case_id": example_id,
+                "case_type": "layer_generate_case",
+            },
+            "input": {
+                "case_record": {
+                    "case_type": "layer_generate_case",
+                    "quality": {"gate_passed": False},
+                },
+                "auxiliary_signals": [
+                    {
+                        "signal_id": f"source_signal_{example_id}",
+                        "model": {"id": "source_context_static_v1"},
+                        "signals": {
+                            "status": "completed",
+                            "signal_source": "source_context_static",
+                            "source_context_tags": tags,
+                            "source_artifacts": {
+                                "artifact_kind_counts": {"directory": 1},
+                            },
+                        },
+                        "training_use": {
+                            "approved_for_auxiliary_training": True,
+                            "review_status": "reviewed_promoted",
+                        },
+                    }
+                ],
+            },
+            "targets": {"preferred_action": target_action},
+        }
+
+    train = example(
+        "train_tang_registry",
+        "train",
+        "manual_review",
+        ["source_tag:tang_mural", "source_tag:registry_ambiguity"],
+    )
+    distractor = example(
+        "train_gongbi",
+        "train",
+        "adjust_prompt",
+        ["source_tag:gongbi", "source_tag:spring_festival"],
+    )
+    test = example(
+        "test_tang_registry",
+        "test",
+        "manual_review",
+        ["source_tag:tang_mural", "source_tag:registry_ambiguity"],
+    )
+
+    features = extract_tiny_action_features(test)
+    assert "aux_signal.source_context_tag:source_tag:tang_mural" in features
+    assert "aux_signal.source_artifact_kind:directory" in features
+    prediction = TinyActionClassifier.fit([train, distractor]).predict(test)
+
+    assert prediction["recommended_action"] == "manual_review"
+    assert "aux_signal.source_context_tag:source_tag:tang_mural" in prediction[
+        "explanation"
+    ]["matched_features"]
+
+
+def test_source_context_signal_cli_writes_outputs(tmp_path):
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    (docs / "brief.md").write_text("Film festival poster brief.", encoding="utf-8")
+    manifest = _write_manifest(
+        tmp_path,
+        [
+            _case(
+                "repo_brief_case",
+                source_refs={"source_brief_path": "docs/brief.md"},
+            )
+        ],
+    )
+    output_path = tmp_path / "signals.promoted.jsonl"
+    manifest_path = tmp_path / "signals.promotion_manifest.json"
+    report_path = tmp_path / "signals.report.json"
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(ROOT / "scripts/source_context_signals.py"),
+            "--repo-root",
+            str(tmp_path),
+            "--case-source-manifest",
+            str(manifest),
+            "--output",
+            str(output_path),
+            "--manifest",
+            str(manifest_path),
+            "--report",
+            str(report_path),
+            "--no-local-seeds",
+        ],
+        cwd=ROOT,
+        env=CLI_ENV,
+        text=True,
+        capture_output=True,
+        timeout=20,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "Source context signals: 1/1" in result.stdout
+    assert output_path.exists()
+    assert manifest_path.exists()
+    assert json.loads(report_path.read_text(encoding="utf-8"))["summary"][
+        "promoted_signal_count"
+    ] == 1


### PR DESCRIPTION
## Summary
- add provider-free source-context signal pack generation for source images and source artifacts
- write explicitly promoted auxiliary signal JSONL + promotion manifest without copying local paths, private refs, or raw source text
- teach tiny_action_model_v1 to consume source_context_tags, artifact-kind, and source-image features from promoted auxiliary signals

## Verification
- PYTHONPATH=src /opt/homebrew/bin/python3.11 -m pytest tests/test_source_context_signals.py -q
- PYTHONPATH=src /opt/homebrew/bin/python3.11 -m pytest tests/test_source_context_signals.py tests/test_tiny_action_model.py tests/test_open_model_signal_review.py tests/test_tiny_training_eval_gate.py tests/test_tiny_feature_ablation.py -q
- PYTHONPATH=src /opt/homebrew/bin/python3.11 -m pytest tests/test_source_context_signals.py tests/test_tiny_action_model.py tests/test_open_model_signal_review.py tests/test_tiny_training_eval_gate.py tests/test_tiny_feature_ablation.py tests/test_real_user_source_artifact_map_recovery.py tests/test_real_user_source_artifact_coverage.py -q
- /opt/homebrew/bin/python3.11 -m py_compile src/vulca/learning/source_context_signals.py scripts/source_context_signals.py src/vulca/learning/tiny_action_model.py tests/test_source_context_signals.py
- ruff check src/vulca/learning/source_context_signals.py scripts/source_context_signals.py src/vulca/learning/tiny_action_model.py tests/test_source_context_signals.py
- git diff --check --cached

## Real smoke
- recovered P2B source artifact refs: v1 2/2, v2 2/2
- recovered private source image refs: v1 2/2, v2 2/4; remaining v2 image refs still have repo source artifacts available
- source-context signals with local seeds: 24/50 examples, safe grep passed on promoted output/report/manifest
- source-context signals without local seeds: 17/38 examples, safe grep passed on promoted output/report/manifest
- tiny_training_eval_gate with source-context aux signals passed
- aggregate still does not depend on aux signals yet: without_auxiliary_signals remains 1.0, so the next step is a source-context challenge/holdout where metadata labels are insufficient
