### PR TITLE
Add real source-context recovery audit pipeline

### DIFF
--- a/scripts/real_source_context_recovery_audit.py
+++ b/scripts/real_source_context_recovery_audit.py
@@ -1,0 +1,159 @@
+"""Run real source recovery and audit as one provider-free workflow."""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Sequence
+
+
+ROOT = Path(__file__).resolve().parent.parent
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from vulca.learning.real_source_context_recovery_audit import (  # noqa: E402
+    DEFAULT_COMBINED_CASE_SOURCE_MANIFEST,
+    DEFAULT_OUTPUT_DIR,
+    run_real_source_context_recovery_audit,
+)
+from vulca.learning.tiny_dataset import DATASET_SPLITS  # noqa: E402
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Recover local private source image/artifact maps, then run the "
+            "real source-context audit with those maps attached."
+        )
+    )
+    parser.add_argument(
+        "--repo-root",
+        default=str(ROOT),
+        help="Repository root used to resolve case source refs.",
+    )
+    parser.add_argument(
+        "--case-source-manifest",
+        default=str(DEFAULT_COMBINED_CASE_SOURCE_MANIFEST),
+        help="Case source manifest JSON path.",
+    )
+    parser.add_argument(
+        "--artifact-search-root",
+        action="append",
+        default=[],
+        help="Local directory to search for private source artifact directories/files.",
+    )
+    parser.add_argument(
+        "--image-search-root",
+        action="append",
+        default=[],
+        help="Local directory to search for private source images.",
+    )
+    parser.add_argument(
+        "--artifact-filename-alias",
+        action="append",
+        default=[],
+        metavar="PRIVATE_BASENAME=LOCAL_BASENAME",
+        help="Private source artifact basename alias. Repeat as needed.",
+    )
+    parser.add_argument(
+        "--image-filename-alias",
+        action="append",
+        default=[],
+        metavar="PRIVATE_BASENAME=LOCAL_BASENAME",
+        help="Private source image basename alias. Repeat as needed.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        default=str(DEFAULT_OUTPUT_DIR),
+        help=f"Output directory for recovery maps and audit report (default: {DEFAULT_OUTPUT_DIR}).",
+    )
+    parser.add_argument(
+        "--report",
+        default="",
+        help=(
+            "Summary report path "
+            "(default: OUTPUT_DIR/real_source_context_recovery_audit_report.json)."
+        ),
+    )
+    parser.add_argument(
+        "--no-local-seeds",
+        action="store_true",
+        help="Do not include local seed cases in the audit training dataset.",
+    )
+    parser.add_argument(
+        "--train-split",
+        default="train",
+        choices=DATASET_SPLITS,
+        help="Dataset split used to fit train-derived tiny policies.",
+    )
+    parser.add_argument(
+        "--pretty",
+        action="store_true",
+        help="Print the full safe JSON report to stdout after writing it.",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        report = run_real_source_context_recovery_audit(
+            repo_root=args.repo_root,
+            case_source_manifest_path=args.case_source_manifest,
+            artifact_search_roots=args.artifact_search_root,
+            image_search_roots=args.image_search_root,
+            artifact_filename_aliases=_parse_aliases(args.artifact_filename_alias),
+            image_filename_aliases=_parse_aliases(args.image_filename_alias),
+            output_dir=args.output_dir,
+            report_path=args.report or None,
+            include_local_seeds=not args.no_local_seeds,
+            train_split=args.train_split,
+        )
+    except (ValueError, FileNotFoundError, json.JSONDecodeError, OSError) as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 2
+
+    if args.pretty:
+        print(json.dumps(report, indent=2, sort_keys=True))
+
+    summary = report["summary"]
+    print(f"Real source-context recovery audit: {report['artifacts']['report_path']}")
+    print(
+        "Recovered source artifacts: "
+        f"{summary['private_source_artifact_recovered_count']}/"
+        f"{summary['private_source_artifact_ref_count']}"
+    )
+    print(
+        "Recovered source images: "
+        f"{summary['private_source_image_recovered_count']}/"
+        f"{summary['private_source_image_ref_count']}"
+    )
+    print(
+        "Source context available: "
+        f"{summary['source_context_available_count']}/"
+        f"{summary['real_user_case_count']}"
+    )
+    print(f"Review candidates: {summary['review_candidate_count']}")
+    print(f"Status: {report['status']}")
+    return 0
+
+
+def _parse_aliases(values: Sequence[str]) -> dict[str, str]:
+    aliases: dict[str, str] = {}
+    for value in values:
+        if "=" not in value:
+            raise ValueError(
+                f"filename alias must use PRIVATE_BASENAME=LOCAL_BASENAME: {value!r}"
+            )
+        source_name, local_name = value.split("=", 1)
+        source_name = source_name.strip()
+        local_name = local_name.strip()
+        if not source_name or not local_name:
+            raise ValueError(
+                f"filename alias must use PRIVATE_BASENAME=LOCAL_BASENAME: {value!r}"
+            )
+        aliases[source_name] = local_name
+    return aliases
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/vulca/learning/real_source_context_recovery_audit.py
+++ b/src/vulca/learning/real_source_context_recovery_audit.py
@@ -1,0 +1,229 @@
+"""Run private source recovery and real source-context audit as one workflow."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+from vulca.learning.real_source_context_audit import (
+    DEFAULT_COMBINED_CASE_SOURCE_MANIFEST,
+    run_real_source_context_audit_report,
+)
+from vulca.learning.real_user_asset_map_recovery import (
+    DEFAULT_ASSET_MAP_NAME as SOURCE_IMAGE_ASSET_MAP_NAME,
+)
+from vulca.learning.real_user_asset_map_recovery import (
+    recover_real_user_private_asset_map,
+)
+from vulca.learning.real_user_source_artifact_map_recovery import (
+    DEFAULT_ASSET_MAP_NAME as SOURCE_ARTIFACT_ASSET_MAP_NAME,
+)
+from vulca.learning.real_user_source_artifact_map_recovery import (
+    recover_real_user_private_source_artifact_map,
+)
+
+
+SCHEMA_VERSION = 1
+REPORT_CASE_TYPE = "learning_real_source_context_recovery_audit_report"
+DEFAULT_OUTPUT_DIR = Path("build/real_source_context_recovery_audit")
+DEFAULT_REPORT_NAME = "real_source_context_recovery_audit_report.json"
+SOURCE_ARTIFACT_RECOVERY_DIR_NAME = "source_artifact_recovery"
+SOURCE_IMAGE_RECOVERY_DIR_NAME = "source_image_recovery"
+AUDIT_DIR_NAME = "audit"
+
+
+def run_real_source_context_recovery_audit(
+    *,
+    repo_root: str | Path,
+    case_source_manifest_path: str | Path = DEFAULT_COMBINED_CASE_SOURCE_MANIFEST,
+    artifact_search_roots: Sequence[str | Path] = (),
+    image_search_roots: Sequence[str | Path] = (),
+    artifact_filename_aliases: Mapping[str, str] | None = None,
+    image_filename_aliases: Mapping[str, str] | None = None,
+    output_dir: str | Path = DEFAULT_OUTPUT_DIR,
+    report_path: str | Path | None = None,
+    include_local_seeds: bool = True,
+    train_split: str = "train",
+) -> dict[str, Any]:
+    """Recover local private source maps, run audit, and write one safe report."""
+    output = Path(output_dir)
+    output.mkdir(parents=True, exist_ok=True)
+    resolved_report_path = Path(report_path) if report_path else output / DEFAULT_REPORT_NAME
+
+    source_artifact_output = output / SOURCE_ARTIFACT_RECOVERY_DIR_NAME
+    source_image_output = output / SOURCE_IMAGE_RECOVERY_DIR_NAME
+    source_artifact_report = recover_real_user_private_source_artifact_map(
+        repo_root=repo_root,
+        case_source_manifest_path=case_source_manifest_path,
+        search_roots=artifact_search_roots,
+        filename_aliases=artifact_filename_aliases,
+        output_dir=source_artifact_output,
+    )
+    source_image_report = recover_real_user_private_asset_map(
+        repo_root=repo_root,
+        case_source_manifest_path=case_source_manifest_path,
+        search_roots=image_search_roots,
+        filename_aliases=image_filename_aliases,
+        output_dir=source_image_output,
+    )
+
+    private_asset_maps = [
+        source_artifact_output / SOURCE_ARTIFACT_ASSET_MAP_NAME,
+        source_image_output / SOURCE_IMAGE_ASSET_MAP_NAME,
+    ]
+    audit_report = run_real_source_context_audit_report(
+        repo_root=repo_root,
+        case_source_manifest_path=case_source_manifest_path,
+        private_asset_map_paths=private_asset_maps,
+        output_dir=output / AUDIT_DIR_NAME,
+        include_local_seeds=include_local_seeds,
+        train_split=train_split,
+    )
+
+    report = {
+        "schema_version": SCHEMA_VERSION,
+        "case_type": REPORT_CASE_TYPE,
+        "status": _status(audit_report),
+        "inputs": {
+            "repo_root": Path(repo_root).name,
+            "case_source_manifest_path": _safe_path(case_source_manifest_path),
+            "artifact_search_root_count": len(artifact_search_roots),
+            "image_search_root_count": len(image_search_roots),
+            "artifact_filename_alias_count": len(artifact_filename_aliases or {}),
+            "image_filename_alias_count": len(image_filename_aliases or {}),
+            "include_local_seeds": bool(include_local_seeds),
+            "train_split": train_split,
+        },
+        "artifacts": {
+            "report_path": _artifact_name(resolved_report_path, output),
+            "source_artifact_recovery_report_path": _artifact_name(
+                source_artifact_output
+                / "real_user_source_artifact_recovery_report.json",
+                output,
+            ),
+            "source_artifact_private_asset_map_path": _artifact_name(
+                source_artifact_output / SOURCE_ARTIFACT_ASSET_MAP_NAME,
+                output,
+            ),
+            "source_image_recovery_report_path": _artifact_name(
+                source_image_output / "real_user_private_asset_recovery_report.json",
+                output,
+            ),
+            "source_image_private_asset_map_path": _artifact_name(
+                source_image_output / SOURCE_IMAGE_ASSET_MAP_NAME,
+                output,
+            ),
+            "audit_report_path": _artifact_name(
+                output / AUDIT_DIR_NAME / "real_source_context_audit_report.json",
+                output,
+            ),
+        },
+        "summary": _summary(
+            source_artifact_report=source_artifact_report,
+            source_image_report=source_image_report,
+            audit_report=audit_report,
+        ),
+        "source_artifact_recovery": _compact_recovery(source_artifact_report),
+        "source_image_recovery": _compact_recovery(source_image_report),
+        "audit": _compact_audit(audit_report),
+        "safe_handling": {
+            "private_asset_maps_contain_local_paths": True,
+            "do_not_commit_private_asset_maps": True,
+            "report_omits_local_paths": True,
+            "report_omits_private_refs": True,
+            "calls_model_provider": False,
+        },
+    }
+    resolved_report_path.parent.mkdir(parents=True, exist_ok=True)
+    resolved_report_path.write_text(
+        json.dumps(report, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return report
+
+
+def _summary(
+    *,
+    source_artifact_report: Mapping[str, Any],
+    source_image_report: Mapping[str, Any],
+    audit_report: Mapping[str, Any],
+) -> dict[str, int]:
+    artifact_summary = _mapping(source_artifact_report.get("summary"))
+    image_summary = _mapping(source_image_report.get("summary"))
+    audit_summary = _mapping(audit_report.get("summary"))
+    return {
+        "private_source_artifact_ref_count": int(
+            artifact_summary.get("private_source_artifact_ref_count") or 0
+        ),
+        "private_source_artifact_recovered_count": int(
+            artifact_summary.get("recovered_count") or 0
+        ),
+        "private_source_image_ref_count": int(
+            image_summary.get("private_source_ref_count") or 0
+        ),
+        "private_source_image_recovered_count": int(
+            image_summary.get("recovered_count") or 0
+        ),
+        "real_user_case_count": int(audit_summary.get("real_user_case_count") or 0),
+        "source_context_available_count": int(
+            audit_summary.get("source_context_available_count") or 0
+        ),
+        "source_context_unavailable_count": int(
+            audit_summary.get("source_context_unavailable_count") or 0
+        ),
+        "review_candidate_count": int(audit_summary.get("review_candidate_count") or 0),
+    }
+
+
+def _compact_recovery(report: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        "case_type": str(report.get("case_type") or ""),
+        "status": str(report.get("status") or ""),
+        "summary": dict(_mapping(report.get("summary"))),
+        "artifacts": dict(_mapping(report.get("artifacts"))),
+    }
+
+
+def _compact_audit(report: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        "case_type": str(report.get("case_type") or ""),
+        "status": str(report.get("status") or ""),
+        "summary": dict(_mapping(report.get("summary"))),
+        "counts_by_candidate_reason": dict(
+            _mapping(report.get("counts_by_candidate_reason"))
+        ),
+        "counts_by_recommended_review_action": dict(
+            _mapping(report.get("counts_by_recommended_review_action"))
+        ),
+        "artifacts": dict(_mapping(report.get("artifacts"))),
+    }
+
+
+def _status(audit_report: Mapping[str, Any]) -> str:
+    summary = _mapping(audit_report.get("summary"))
+    unavailable = int(summary.get("source_context_unavailable_count") or 0)
+    if unavailable:
+        return "needs_more_source_recovery"
+    return "source_context_ready_for_review"
+
+
+def _artifact_name(path: str | Path, output_dir: str | Path) -> str:
+    value = Path(path)
+    try:
+        return str(value.relative_to(Path(output_dir)))
+    except ValueError:
+        return value.name
+
+
+def _safe_path(path: str | Path) -> str:
+    value = Path(path)
+    parts = value.parts
+    if "docs" in parts:
+        return str(Path(*parts[parts.index("docs") :]))
+    return value.name
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    if isinstance(value, Mapping):
+        return value
+    return {}

--- a/tests/test_real_source_context_recovery_audit.py
+++ b/tests/test_real_source_context_recovery_audit.py
@@ -1,0 +1,249 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from PIL import Image
+
+
+ROOT = Path(__file__).resolve().parent.parent
+CLI_ENV = dict(
+    os.environ,
+    PYTHONPATH=str(ROOT / "src") + os.pathsep + os.environ.get("PYTHONPATH", ""),
+)
+
+
+def _write_jsonl(path: Path, records: list[dict]) -> None:
+    path.write_text(
+        "\n".join(json.dumps(record, sort_keys=True) for record in records) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _write_image(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    Image.new("RGB", (12, 8), color=(30, 90, 150)).save(path)
+
+
+def _case(case_id: str, *, source_ref: str, preferred_action: str) -> dict:
+    record = {
+        "schema_version": 1,
+        "case_type": "layer_generate_case",
+        "case_id": case_id,
+        "created_at": "2026-05-07T00:00:00Z",
+        "inputs": {
+            "user_intent": "Create a source-dependent composition.",
+            "tradition": "",
+            "style_constraints": {"mode": "recovery_fixture"},
+            "layer_plan": {"desired_layer_count": 3, "layers": []},
+            "prompt_stack": {},
+            "provider": "fixture",
+            "model": "fixture",
+        },
+        "decisions": {
+            "fallback_decisions": [],
+            "layer_count": {"planned": 3, "generated": 3, "accepted": 0},
+        },
+        "outputs": {
+            "artifact_dir": "",
+            "layer_manifest_path": "assets/fixture/manifest.json",
+            "layers": [
+                {
+                    "semantic_path": "background.ground",
+                    "asset_path": "assets/fixture/background.png",
+                    "status": "generated",
+                }
+            ],
+            "composite_path": "",
+            "preview_path": "",
+        },
+        "quality": {"gate_passed": False},
+        "review": {
+            "human_accept": False,
+            "failure_type": "",
+            "preferred_action": preferred_action,
+            "reviewer": "recovery_fixture",
+            "reviewed_at": "2026-05-07T00:00:00Z",
+        },
+    }
+    if source_ref.endswith(".png"):
+        record["source_image"] = source_ref
+    else:
+        record["source_summary"] = {"source_path_hint": source_ref}
+    return record
+
+
+def _write_manifest(tmp_path: Path) -> Path:
+    train_source = tmp_path / "train_sources"
+    train_source.mkdir()
+    (train_source / "train_tang.md").write_text(
+        "Tang court mural registry ambiguity.",
+        encoding="utf-8",
+    )
+    _write_image(train_source / "train_source.png")
+    train_cases = tmp_path / "train_cases.jsonl"
+    user_cases = tmp_path / "user_cases.jsonl"
+    _write_jsonl(
+        train_cases,
+        [
+            {
+                **_case(
+                    "train_tang",
+                    source_ref="train_sources/train_tang.md",
+                    preferred_action="manual_review",
+                ),
+                "source_refs": {"source_brief_path": "train_sources/train_tang.md"},
+            },
+            _case(
+                "train_source_image",
+                source_ref="train_sources/train_source.png",
+                preferred_action="manual_review",
+            ),
+        ],
+    )
+    _write_jsonl(
+        user_cases,
+        [
+            _case(
+                "user_private_artifact",
+                source_ref="private://local_path/a/case-A-brief",
+                preferred_action="manual_review",
+            ),
+            _case(
+                "user_private_image",
+                source_ref="private://local_path/b/source.png",
+                preferred_action="manual_review",
+            ),
+        ],
+    )
+    manifest = tmp_path / "manifest.json"
+    manifest.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "case_type": "learning_tiny_case_source_manifest",
+                "sources": [
+                    {
+                        "source_id": "fixture_train",
+                        "kind": "synthetic_case_log",
+                        "path": train_cases.name,
+                        "privacy_scope": "project",
+                        "curation_status": "synthetic_reviewed",
+                        "preferred_split": "train",
+                    },
+                    {
+                        "source_id": "fixture_user",
+                        "kind": "user_case_log",
+                        "path": user_cases.name,
+                        "privacy_scope": "private",
+                        "curation_status": "reviewed",
+                        "preferred_split": "test",
+                    },
+                ],
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return manifest
+
+
+def _write_search_roots(tmp_path: Path) -> tuple[Path, Path]:
+    artifact_root = tmp_path / "artifact_root"
+    source_dir = artifact_root / "case-A-brief"
+    source_dir.mkdir(parents=True)
+    (source_dir / "proposal.md").write_text(
+        "client-only sentence: Tang mural registry ambiguity.",
+        encoding="utf-8",
+    )
+    image_root = tmp_path / "image_root"
+    _write_image(image_root / "source.png")
+    return artifact_root, image_root
+
+
+def test_real_source_context_recovery_audit_runs_recovery_then_audit(tmp_path):
+    from vulca.learning.real_source_context_recovery_audit import (
+        run_real_source_context_recovery_audit,
+    )
+
+    manifest = _write_manifest(tmp_path)
+    artifact_root, image_root = _write_search_roots(tmp_path)
+
+    report = run_real_source_context_recovery_audit(
+        repo_root=tmp_path,
+        case_source_manifest_path=manifest,
+        artifact_search_roots=[artifact_root],
+        image_search_roots=[image_root],
+        output_dir=tmp_path / "recovery_audit",
+        include_local_seeds=False,
+    )
+
+    assert report["case_type"] == "learning_real_source_context_recovery_audit_report"
+    assert report["summary"] == {
+        "private_source_artifact_ref_count": 1,
+        "private_source_artifact_recovered_count": 1,
+        "private_source_image_ref_count": 1,
+        "private_source_image_recovered_count": 1,
+        "real_user_case_count": 2,
+        "source_context_available_count": 2,
+        "source_context_unavailable_count": 0,
+        "review_candidate_count": 2,
+    }
+    assert report["status"] == "source_context_ready_for_review"
+    assert (
+        report["audit"]["summary"]["source_context_available_count"]
+        == report["summary"]["source_context_available_count"]
+    )
+    assert Path(
+        tmp_path / "recovery_audit" / report["artifacts"]["report_path"]
+    ).exists()
+
+    encoded = json.dumps(report, sort_keys=True)
+    assert str(tmp_path) not in encoded
+    assert "private://local_path" not in encoded
+    assert "client-only sentence" not in encoded
+
+
+def test_real_source_context_recovery_audit_cli_writes_report(tmp_path):
+    manifest = _write_manifest(tmp_path)
+    artifact_root, image_root = _write_search_roots(tmp_path)
+    output_dir = tmp_path / "recovery_audit"
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(ROOT / "scripts/real_source_context_recovery_audit.py"),
+            "--repo-root",
+            str(tmp_path),
+            "--case-source-manifest",
+            str(manifest),
+            "--artifact-search-root",
+            str(artifact_root),
+            "--image-search-root",
+            str(image_root),
+            "--output-dir",
+            str(output_dir),
+            "--no-local-seeds",
+        ],
+        cwd=ROOT,
+        env=CLI_ENV,
+        text=True,
+        capture_output=True,
+        timeout=20,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    report = json.loads(
+        (output_dir / "real_source_context_recovery_audit_report.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert report["summary"]["source_context_available_count"] == 2
+    assert "Real source-context recovery audit:" in result.stdout
+    assert "Source context available: 2/2" in result.stdout


### PR DESCRIPTION
## Summary
- Add a provider-free pipeline that recovers private source artifact/image maps, then runs the real source-context audit with those maps attached.
- Add CLI scripts/real_source_context_recovery_audit.py for the full recovery+audit workflow.
- Add tests covering safe reports, local-only private maps, and CLI behavior.

## Real smoke result
Command used local search roots outside committed artifacts. Private maps stay under ignored build output.
- Recovered source artifacts: 4/4
- Recovered source images: 2/6
- Source context available: 12/12 real user cases
- Audit reason: 12 source_context_used_no_action_change
- Next review action: 12 verify_source_dependency_label

## Verification
- PYTHONPATH=src python3 -m pytest tests/test_real_source_context_recovery_audit.py tests/test_real_source_context_audit.py tests/test_real_user_source_artifact_map_recovery.py tests/test_real_user_asset_map_recovery.py tests/test_source_context_signals.py -q
- PYTHONPATH=src python3 scripts/real_source_context_recovery_audit.py --repo-root /Users/yhryzy/dev/vulca --case-source-manifest /Users/yhryzy/dev/vulca/.worktrees/real-source-context-recovery-v1/docs/benchmarks/learning/combined_case_source_manifest_v1.json --artifact-search-root /Users/yhryzy/dev/vulca/.scratch/p2b-live-shipgate --image-search-root /Users/yhryzy/dev/vulca/docs/visual-specs/2026-04-23-scottish-chinese-fusion --image-search-root /Users/yhryzy/dev/vulca/assets/showcase/2026-04-23-scottish-chinese-fusion --image-search-root /Users/yhryzy/dev/vulca/docs/visual-specs/2026-04-28-ipad-cartoon-roadside-direct-showcase/source --image-search-root /Users/yhryzy/dev/vulca/assets/showcase/layers_extract_backup --output-dir build/real_source_context_recovery_audit_v1
- python3 -m py_compile src/vulca/learning/real_source_context_recovery_audit.py scripts/real_source_context_recovery_audit.py tests/test_real_source_context_recovery_audit.py
- /opt/homebrew/bin/ruff check src/vulca/learning/real_source_context_recovery_audit.py scripts/real_source_context_recovery_audit.py tests/test_real_source_context_recovery_audit.py
- git diff --check