### PR TITLE
Export reviewed source dependency labels

### DIFF
--- a/scripts/source_dependency_labels.py
+++ b/scripts/source_dependency_labels.py
@@ -1,0 +1,68 @@
+"""Export reviewed source-dependency labels for tiny training datasets."""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Sequence
+
+
+ROOT = Path(__file__).resolve().parent.parent
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from vulca.learning.source_dependency_labels import (  # noqa: E402
+    write_source_dependency_label_pack,
+)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Write a sanitized source-dependency label JSONL and manifest from "
+            "completed real_source_dependency_review JSONL items."
+        )
+    )
+    parser.add_argument("--input", required=True, help="Reviewed review-item JSONL path")
+    parser.add_argument("--output", required=True, help="Output label JSONL path")
+    parser.add_argument("--manifest", required=True, help="Output label manifest path")
+    parser.add_argument("--source-id", required=True, help="Stable label source id")
+    parser.add_argument("--reviewer", default="", help="Reviewer id/name")
+    parser.add_argument(
+        "--reviewed-at",
+        default="",
+        help="Review timestamp, ISO-8601 UTC recommended",
+    )
+    parser.add_argument(
+        "--allow-incomplete",
+        action="store_true",
+        help="Allow unknown labels; default requires completed human_review fields",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        result = write_source_dependency_label_pack(
+            input_path=args.input,
+            output_path=args.output,
+            manifest_path=args.manifest,
+            source_id=args.source_id,
+            reviewer=args.reviewer,
+            reviewed_at=args.reviewed_at or None,
+            require_complete=not args.allow_incomplete,
+        )
+    except (ValueError, FileNotFoundError, json.JSONDecodeError, OSError) as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 2
+
+    print(f"Source dependency labels: {result.record_count}")
+    print(f"Label JSONL: {result.output_path}")
+    print(f"Label manifest: {result.manifest_path}")
+    print(f"Source dependency counts: {result.counts_by_source_dependency}")
+    print(f"Decision basis counts: {result.counts_by_decision_basis}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/vulca/cli.py
+++ b/src/vulca/cli.py
@@ -471,6 +471,14 @@ def main(argv: list[str] | None = None) -> None:
         ),
     )
     cases_export.add_argument(
+        "--source-dependency-manifest",
+        default="",
+        help=(
+            "Explicit source-dependency label manifest to attach as reviewed "
+            "source-context training targets"
+        ),
+    )
+    cases_export.add_argument(
         "--no-local-seeds",
         action="store_true",
         help="Only export records from --case-log inputs",
@@ -1821,6 +1829,9 @@ def _cmd_cases(args: argparse.Namespace) -> None:
                 case_source_manifest_path=args.case_source_manifest or None,
                 auxiliary_signal_manifest_path=(
                     args.auxiliary_signal_manifest or None
+                ),
+                source_dependency_manifest_path=(
+                    args.source_dependency_manifest or None
                 ),
                 include_local_seeds=not args.no_local_seeds,
             )

--- a/src/vulca/learning/source_dependency_labels.py
+++ b/src/vulca/learning/source_dependency_labels.py
@@ -1,0 +1,482 @@
+"""Reviewed source-dependency labels for tiny training datasets."""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from collections import Counter
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+from vulca.layers.redraw_cases import utc_now_iso
+from vulca.learning.case_review import load_cases, write_cases
+from vulca.learning.real_source_dependency_review import (
+    DECISION_BASIS_VALUES,
+    ITEM_CASE_TYPE as REVIEW_ITEM_CASE_TYPE,
+    SCHEMA_VERSION as REVIEW_SCHEMA_VERSION,
+    SOURCE_DEPENDENCY_VALUES,
+)
+
+
+SCHEMA_VERSION = 1
+LABEL_RECORD_CASE_TYPE = "learning_source_dependency_label_record"
+LABEL_MANIFEST_CASE_TYPE = "learning_source_dependency_label_manifest"
+SOURCE_DEPENDENCY_LABEL_LOG_KIND = "source_dependency_label_log"
+REVIEWED_SOURCE_DEPENDENCY_STATUS = "reviewed_source_dependency_label"
+APPROVED_LABEL_USE = "source_dependency_training_label"
+
+
+@dataclass(frozen=True)
+class SourceDependencyLabelPackResult:
+    output_path: str
+    manifest_path: str
+    source_id: str
+    record_count: int
+    counts_by_source_dependency: dict[str, int]
+    counts_by_decision_basis: dict[str, int]
+
+
+def write_source_dependency_label_pack(
+    *,
+    input_path: str | Path,
+    output_path: str | Path,
+    manifest_path: str | Path,
+    source_id: str,
+    reviewer: str = "",
+    reviewed_at: str | None = None,
+    require_complete: bool = True,
+) -> SourceDependencyLabelPackResult:
+    """Write a sanitized label JSONL and manifest from completed review items."""
+    resolved_source_id = str(source_id or "").strip()
+    if not resolved_source_id:
+        raise ValueError("source_id is required")
+
+    review_time = str(reviewed_at or utc_now_iso())
+    labels = [
+        _label_record(
+            item,
+            record_index=index,
+            source_id=resolved_source_id,
+            reviewer=reviewer,
+            reviewed_at=review_time,
+            require_complete=require_complete,
+        )
+        for index, item in enumerate(load_cases(input_path))
+    ]
+
+    output = Path(output_path)
+    manifest = Path(manifest_path)
+    write_cases(output, labels)
+    counts_by_source_dependency = _counts(labels, "source_dependency")
+    counts_by_decision_basis = _counts(labels, "decision_basis")
+    _write_manifest(
+        manifest_path=manifest,
+        output_path=output,
+        source_id=resolved_source_id,
+        record_count=len(labels),
+        counts_by_source_dependency=counts_by_source_dependency,
+        counts_by_decision_basis=counts_by_decision_basis,
+    )
+    return SourceDependencyLabelPackResult(
+        output_path=str(output),
+        manifest_path=str(manifest),
+        source_id=resolved_source_id,
+        record_count=len(labels),
+        counts_by_source_dependency=counts_by_source_dependency,
+        counts_by_decision_basis=counts_by_decision_basis,
+    )
+
+
+def load_source_dependency_labels(manifest_path: str | Path) -> list[dict[str, Any]]:
+    """Load reviewed source-dependency labels from an explicit manifest."""
+    manifest_file = Path(manifest_path)
+    manifest = json.loads(manifest_file.read_text(encoding="utf-8"))
+    if not isinstance(manifest, Mapping):
+        raise ValueError("source dependency label manifest must be an object")
+    if manifest.get("case_type") != LABEL_MANIFEST_CASE_TYPE:
+        raise ValueError(
+            "source dependency label manifest case_type must be "
+            f"{LABEL_MANIFEST_CASE_TYPE!r}"
+        )
+
+    sources = manifest.get("sources")
+    if not isinstance(sources, list):
+        raise ValueError("source dependency label manifest sources must be a list")
+
+    records: list[dict[str, Any]] = []
+    errors: list[str] = []
+    for source_index, source in enumerate(sources):
+        if not isinstance(source, Mapping):
+            errors.append(f"sources[{source_index}] must be an object")
+            continue
+        path = str(source.get("path") or "")
+        if not path:
+            errors.append(f"sources[{source_index}]: path is required")
+            continue
+        if str(source.get("kind") or "") != SOURCE_DEPENDENCY_LABEL_LOG_KIND:
+            errors.append(
+                f"sources[{source_index}]: unsupported kind "
+                f"{str(source.get('kind') or '')!r}"
+            )
+        if str(source.get("curation_status") or "") != REVIEWED_SOURCE_DEPENDENCY_STATUS:
+            errors.append(
+                f"sources[{source_index}]: unsupported curation_status "
+                f"{str(source.get('curation_status') or '')!r}"
+            )
+        source_path = Path(path)
+        if not source_path.is_absolute():
+            source_path = manifest_file.parent / source_path
+        for record_index, record in enumerate(load_cases(source_path)):
+            try:
+                _validate_label_record(record, record_index=record_index)
+            except ValueError as exc:
+                errors.append(f"{source_path}:{record_index + 1}: {exc}")
+                continue
+            records.append(dict(record))
+
+    if errors:
+        raise ValueError("; ".join(errors))
+    return records
+
+
+def attach_source_dependency_labels(
+    examples: Sequence[dict[str, Any]],
+    *,
+    manifest_path: str | Path,
+) -> int:
+    """Mutate dataset examples by attaching reviewed source-dependency labels."""
+    labels_by_key: dict[tuple[str, int, str, str], dict[str, Any]] = {}
+    for label in load_source_dependency_labels(manifest_path):
+        key = _label_match_key(label)
+        if key in labels_by_key:
+            raise ValueError(f"duplicate source dependency label for {key!r}")
+        labels_by_key[key] = label
+
+    attached = 0
+    for example in examples:
+        label = labels_by_key.get(_example_match_key(example))
+        if not label:
+            continue
+        labels = _mapping(label.get("labels"))
+        targets = example.setdefault("targets", {})
+        if not isinstance(targets, dict):
+            raise ValueError(
+                f"dataset example {str(example.get('example_id') or '')!r} "
+                "targets must be an object"
+            )
+        targets["source_dependency"] = str(labels.get("source_dependency") or "")
+        targets["source_decision_basis"] = str(labels.get("decision_basis") or "")
+        targets["source_preferred_action_confirmed"] = labels.get(
+            "preferred_action_confirmed"
+        )
+        targets["source_corrected_preferred_action"] = str(
+            labels.get("corrected_preferred_action") or ""
+        )
+
+        tasks = example.setdefault("tasks", {})
+        if not isinstance(tasks, dict):
+            raise ValueError(
+                f"dataset example {str(example.get('example_id') or '')!r} "
+                "tasks must be an object"
+            )
+        source_context = tasks.setdefault("source_context", {})
+        if not isinstance(source_context, dict):
+            raise ValueError(
+                f"dataset example {str(example.get('example_id') or '')!r} "
+                "tasks.source_context must be an object"
+            )
+        source_context["dependency_classification"] = targets["source_dependency"]
+        source_context["decision_basis_classification"] = targets[
+            "source_decision_basis"
+        ]
+        example["source_dependency_review"] = {
+            "label_id": str(label.get("label_id") or ""),
+            "review_status": REVIEWED_SOURCE_DEPENDENCY_STATUS,
+            "approved_label_use": APPROVED_LABEL_USE,
+        }
+        attached += 1
+    return attached
+
+
+def _label_record(
+    item: Mapping[str, Any],
+    *,
+    record_index: int,
+    source_id: str,
+    reviewer: str,
+    reviewed_at: str,
+    require_complete: bool,
+) -> dict[str, Any]:
+    _validate_review_item(item, record_index=record_index)
+    human_review = _mapping(item.get("human_review"))
+    source_dependency = _validate_source_dependency(
+        human_review.get("source_dependency"),
+        record_index=record_index,
+        require_complete=require_complete,
+    )
+    decision_basis = _validate_decision_basis(
+        human_review.get("decision_basis"),
+        record_index=record_index,
+        require_complete=require_complete,
+    )
+    confirmed = human_review.get("preferred_action_confirmed")
+    if require_complete and not isinstance(confirmed, bool):
+        raise ValueError(
+            f"record {record_index}: incomplete source dependency review: "
+            "human_review.preferred_action_confirmed must be true or false"
+        )
+    corrected_action = str(human_review.get("corrected_preferred_action") or "")
+    if confirmed is False and not corrected_action:
+        raise ValueError(
+            f"record {record_index}: corrected_preferred_action is required when "
+            "preferred_action_confirmed is false"
+        )
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "case_type": LABEL_RECORD_CASE_TYPE,
+        "label_id": _label_id(source_id, item),
+        "source_case": {
+            "case_type": str(item.get("source_case_type") or ""),
+            "case_id": str(item.get("case_id") or ""),
+        },
+        "source": _safe_source(_mapping(item.get("source"))),
+        "current_labels": dict(_mapping(item.get("current_labels"))),
+        "source_context": _safe_source_context(_mapping(item.get("source_context"))),
+        "audit": _safe_audit(_mapping(item.get("audit"))),
+        "labels": {
+            "source_dependency": source_dependency,
+            "decision_basis": decision_basis,
+            "preferred_action_confirmed": confirmed if isinstance(confirmed, bool) else None,
+            "corrected_preferred_action": corrected_action,
+        },
+        "review": {
+            "schema_version": SCHEMA_VERSION,
+            "reviewer": str(reviewer or ""),
+            "reviewed_at": str(reviewed_at or ""),
+            "review_notes_present": bool(str(human_review.get("review_notes") or "")),
+        },
+        "training_use": {
+            "default_training_input": False,
+            "approved_for_source_dependency_training": source_dependency != "unknown",
+            "review_status": REVIEWED_SOURCE_DEPENDENCY_STATUS,
+            "approved_label_use": APPROVED_LABEL_USE,
+        },
+    }
+
+
+def _validate_review_item(item: Mapping[str, Any], *, record_index: int) -> None:
+    if item.get("case_type") != REVIEW_ITEM_CASE_TYPE:
+        raise ValueError(
+            f"record {record_index}: case_type must be {REVIEW_ITEM_CASE_TYPE!r}"
+        )
+    if int(item.get("schema_version") or 0) != REVIEW_SCHEMA_VERSION:
+        raise ValueError(
+            f"record {record_index}: schema_version must be {REVIEW_SCHEMA_VERSION}"
+        )
+    if not str(item.get("case_id") or ""):
+        raise ValueError(f"record {record_index}: case_id is required")
+    if not str(item.get("source_case_type") or ""):
+        raise ValueError(f"record {record_index}: source_case_type is required")
+    source = _mapping(item.get("source"))
+    if not str(source.get("source_id") or ""):
+        raise ValueError(f"record {record_index}: source.source_id is required")
+
+
+def _validate_label_record(record: Mapping[str, Any], *, record_index: int) -> None:
+    if record.get("case_type") != LABEL_RECORD_CASE_TYPE:
+        raise ValueError(
+            f"record {record_index}: case_type must be {LABEL_RECORD_CASE_TYPE!r}"
+        )
+    if int(record.get("schema_version") or 0) != SCHEMA_VERSION:
+        raise ValueError(f"record {record_index}: schema_version must be {SCHEMA_VERSION}")
+    labels = _mapping(record.get("labels"))
+    _validate_source_dependency(
+        labels.get("source_dependency"),
+        record_index=record_index,
+        require_complete=True,
+    )
+    _validate_decision_basis(
+        labels.get("decision_basis"),
+        record_index=record_index,
+        require_complete=True,
+    )
+    training_use = _mapping(record.get("training_use"))
+    if not bool(training_use.get("approved_for_source_dependency_training")):
+        raise ValueError(
+            f"record {record_index}: label is not approved for source dependency training"
+        )
+
+
+def _validate_source_dependency(
+    value: Any,
+    *,
+    record_index: int,
+    require_complete: bool,
+) -> str:
+    normalized = str(value or "").strip()
+    if normalized not in SOURCE_DEPENDENCY_VALUES:
+        raise ValueError(
+            f"record {record_index}: unsupported source_dependency {normalized!r}; "
+            f"expected one of {list(SOURCE_DEPENDENCY_VALUES)}"
+        )
+    if require_complete and normalized == "unknown":
+        raise ValueError(
+            f"record {record_index}: incomplete source dependency review: "
+            "human_review.source_dependency must not be unknown"
+        )
+    return normalized
+
+
+def _validate_decision_basis(
+    value: Any,
+    *,
+    record_index: int,
+    require_complete: bool,
+) -> str:
+    normalized = str(value or "").strip()
+    if normalized not in DECISION_BASIS_VALUES:
+        raise ValueError(
+            f"record {record_index}: unsupported decision_basis {normalized!r}; "
+            f"expected one of {list(DECISION_BASIS_VALUES)}"
+        )
+    if require_complete and normalized == "unknown":
+        raise ValueError(
+            f"record {record_index}: incomplete source dependency review: "
+            "human_review.decision_basis must not be unknown"
+        )
+    return normalized
+
+
+def _write_manifest(
+    *,
+    manifest_path: Path,
+    output_path: Path,
+    source_id: str,
+    record_count: int,
+    counts_by_source_dependency: Mapping[str, int],
+    counts_by_decision_basis: Mapping[str, int],
+) -> None:
+    manifest_path.parent.mkdir(parents=True, exist_ok=True)
+    manifest = {
+        "schema_version": SCHEMA_VERSION,
+        "case_type": LABEL_MANIFEST_CASE_TYPE,
+        "sources": [
+            {
+                "source_id": source_id,
+                "kind": SOURCE_DEPENDENCY_LABEL_LOG_KIND,
+                "path": _manifest_relative_path(output_path, manifest_path.parent),
+                "privacy_scope": "project",
+                "curation_status": REVIEWED_SOURCE_DEPENDENCY_STATUS,
+                "approved_label_use": APPROVED_LABEL_USE,
+                "record_count": int(record_count),
+                "counts_by_source_dependency": dict(
+                    sorted(counts_by_source_dependency.items())
+                ),
+                "counts_by_decision_basis": dict(sorted(counts_by_decision_basis.items())),
+            }
+        ],
+        "record_count": int(record_count),
+        "counts_by_source_dependency": dict(sorted(counts_by_source_dependency.items())),
+        "counts_by_decision_basis": dict(sorted(counts_by_decision_basis.items())),
+        "training_use": {
+            "default_training_input": False,
+            "requires_explicit_dataset_flag": True,
+            "approved_label_use": APPROVED_LABEL_USE,
+        },
+    }
+    manifest_path.write_text(
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _label_match_key(record: Mapping[str, Any]) -> tuple[str, int, str, str]:
+    source = _mapping(record.get("source"))
+    source_case = _mapping(record.get("source_case"))
+    return (
+        str(source.get("source_id") or ""),
+        int(source.get("record_index") or 0),
+        str(source_case.get("case_type") or ""),
+        str(source_case.get("case_id") or ""),
+    )
+
+
+def _example_match_key(example: Mapping[str, Any]) -> tuple[str, int, str, str]:
+    source = _mapping(example.get("source"))
+    source_case = _mapping(example.get("source_case"))
+    return (
+        str(source.get("source_id") or ""),
+        int(source.get("index") or 0),
+        str(source_case.get("case_type") or ""),
+        str(source_case.get("case_id") or ""),
+    )
+
+
+def _label_id(source_id: str, item: Mapping[str, Any]) -> str:
+    seed = json.dumps(
+        {
+            "source_id": source_id,
+            "case_id": str(item.get("case_id") or ""),
+            "source_case_type": str(item.get("source_case_type") or ""),
+            "source": _safe_source(_mapping(item.get("source"))),
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    digest = hashlib.sha256(seed.encode("utf-8")).hexdigest()[:16]
+    return f"source_dependency_label_{digest}"
+
+
+def _counts(records: Sequence[Mapping[str, Any]], key: str) -> dict[str, int]:
+    counts: Counter[str] = Counter()
+    for record in records:
+        labels = _mapping(record.get("labels"))
+        counts[str(labels.get(key) or "unknown")] += 1
+    return dict(sorted(counts.items()))
+
+
+def _safe_source(source: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        "source_id": str(source.get("source_id") or ""),
+        "kind": str(source.get("kind") or ""),
+        "privacy_scope": str(source.get("privacy_scope") or ""),
+        "curation_status": str(source.get("curation_status") or ""),
+        "record_index": int(source.get("record_index") or 0),
+        "split": str(source.get("split") or ""),
+    }
+
+
+def _safe_source_context(source_context: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        "available": bool(source_context.get("available")),
+        "tags": [str(item) for item in source_context.get("tags", []) or []],
+        "source_image_available": bool(source_context.get("source_image_available")),
+        "source_artifact_available_count": int(
+            source_context.get("source_artifact_available_count") or 0
+        ),
+        "source_artifact_text_file_count": int(
+            source_context.get("source_artifact_text_file_count") or 0
+        ),
+    }
+
+
+def _safe_audit(audit: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        "candidate_reason": str(audit.get("candidate_reason") or ""),
+        "recommended_review_action": str(audit.get("recommended_review_action") or ""),
+        "source_context_feature_match_count": int(
+            audit.get("source_context_feature_match_count") or 0
+        ),
+    }
+
+
+def _manifest_relative_path(output_path: Path, manifest_dir: Path) -> str:
+    return Path(os.path.relpath(output_path, manifest_dir)).as_posix()
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    if isinstance(value, Mapping):
+        return value
+    return {}

--- a/src/vulca/learning/tiny_dataset.py
+++ b/src/vulca/learning/tiny_dataset.py
@@ -104,6 +104,7 @@ def build_tiny_dataset_examples(
     case_log_paths: Sequence[str | Path] = (),
     case_source_manifest_path: str | Path | None = None,
     auxiliary_signal_manifest_path: str | Path | None = None,
+    source_dependency_manifest_path: str | Path | None = None,
     include_local_seeds: bool = True,
 ) -> list[dict[str, Any]]:
     """Build leak-resistant tiny dataset examples from seeds and case logs."""
@@ -165,6 +166,15 @@ def build_tiny_dataset_examples(
             examples,
             manifest_path=auxiliary_signal_manifest_path,
         )
+    if source_dependency_manifest_path:
+        from vulca.learning.source_dependency_labels import (
+            attach_source_dependency_labels,
+        )
+
+        attach_source_dependency_labels(
+            examples,
+            manifest_path=source_dependency_manifest_path,
+        )
     return examples
 
 
@@ -176,6 +186,7 @@ def write_tiny_dataset(
     case_log_paths: Sequence[str | Path] = (),
     case_source_manifest_path: str | Path | None = None,
     auxiliary_signal_manifest_path: str | Path | None = None,
+    source_dependency_manifest_path: str | Path | None = None,
     include_local_seeds: bool = True,
     index_path: str | Path | None = None,
 ) -> TinyDatasetWriteResult:
@@ -186,6 +197,7 @@ def write_tiny_dataset(
         case_log_paths=case_log_paths,
         case_source_manifest_path=case_source_manifest_path,
         auxiliary_signal_manifest_path=auxiliary_signal_manifest_path,
+        source_dependency_manifest_path=source_dependency_manifest_path,
         include_local_seeds=include_local_seeds,
     )
     output = Path(output_path)
@@ -206,6 +218,9 @@ def write_tiny_dataset(
                 "case_source_manifest_path": str(case_source_manifest_path or ""),
                 "auxiliary_signal_manifest_path": str(
                     auxiliary_signal_manifest_path or ""
+                ),
+                "source_dependency_manifest_path": str(
+                    source_dependency_manifest_path or ""
                 ),
                 "case_sources": _case_source_summaries(case_sources, examples),
                 "include_local_seeds": bool(include_local_seeds),

--- a/tests/test_source_dependency_labels.py
+++ b/tests/test_source_dependency_labels.py
@@ -1,0 +1,365 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parent.parent
+CLI_ENV = dict(
+    os.environ,
+    PYTHONPATH=str(ROOT / "src") + os.pathsep + os.environ.get("PYTHONPATH", ""),
+)
+
+
+def _write_jsonl(path: Path, records: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "".join(json.dumps(record, sort_keys=True) + "\n" for record in records),
+        encoding="utf-8",
+    )
+
+
+def _read_jsonl(path: Path) -> list[dict]:
+    return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines()]
+
+
+def _review_item(
+    case_id: str,
+    *,
+    source_dependency: str = "required",
+    decision_basis: str = "artifact_source",
+    record_index: int = 0,
+    confirmed: bool | None = True,
+    corrected_action: str = "",
+    notes: str = "client-only sentence /Users/private/source.png",
+) -> dict:
+    return {
+        "schema_version": 1,
+        "case_type": "learning_real_source_dependency_review_item",
+        "case_id": case_id,
+        "source_case_type": "layer_generate_case",
+        "source": {
+            "source_id": "real_user_cases_v2",
+            "kind": "user_case_log",
+            "privacy_scope": "private",
+            "curation_status": "reviewed",
+            "record_index": record_index,
+            "split": "test",
+        },
+        "current_labels": {
+            "preferred_action": "manual_review",
+            "failure_type": "prompt_ambiguity",
+        },
+        "source_context": {
+            "available": True,
+            "tags": ["source_tag:tang_mural"],
+            "source_image_available": True,
+            "source_artifact_available_count": 1,
+            "source_artifact_text_file_count": 2,
+        },
+        "predictions": {
+            "full_action": "manual_review",
+            "without_auxiliary_signals_action": "manual_review",
+            "action_changed_with_source_context": False,
+            "full_matches_target": True,
+            "without_auxiliary_signals_matches_target": True,
+        },
+        "audit": {
+            "candidate_reason": "source_context_used_no_action_change",
+            "recommended_review_action": "verify_source_dependency_label",
+            "source_context_feature_match_count": 2,
+        },
+        "suggested_review": {
+            "source_dependency": "helpful",
+            "decision_basis": "artifact_source",
+            "review_priority": "medium",
+        },
+        "human_review": {
+            "source_dependency": source_dependency,
+            "decision_basis": decision_basis,
+            "preferred_action_confirmed": confirmed,
+            "corrected_preferred_action": corrected_action,
+            "review_notes": notes,
+        },
+    }
+
+
+def _minimal_case(case_id: str) -> dict:
+    return {
+        "schema_version": 1,
+        "case_type": "layer_generate_case",
+        "case_id": case_id,
+        "created_at": "2026-05-07T12:00:00Z",
+        "inputs": {
+            "user_intent": "test intent",
+            "tradition": "test",
+        },
+        "outputs": {
+            "layers": [],
+        },
+        "review": {
+            "human_accept": False,
+            "failure_type": "prompt_ambiguity",
+            "preferred_action": "manual_review",
+        },
+    }
+
+
+def _write_case_source_manifest(tmp_path: Path, case_log: Path) -> Path:
+    manifest = {
+        "schema_version": 1,
+        "case_type": "learning_tiny_case_source_manifest",
+        "sources": [
+            {
+                "source_id": "real_user_cases_v2",
+                "kind": "user_case_log",
+                "path": os.path.relpath(case_log, tmp_path),
+                "privacy_scope": "private",
+                "curation_status": "reviewed",
+                "preferred_split": "test",
+            }
+        ],
+    }
+    path = tmp_path / "case_source_manifest.json"
+    path.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return path
+
+
+def test_source_dependency_label_pack_rejects_incomplete_human_review(tmp_path):
+    from vulca.learning.source_dependency_labels import write_source_dependency_label_pack
+
+    review_path = tmp_path / "review.template.jsonl"
+    _write_jsonl(
+        review_path,
+        [
+            _review_item(
+                "case_a",
+                source_dependency="unknown",
+                decision_basis="unknown",
+                confirmed=None,
+            )
+        ],
+    )
+
+    with pytest.raises(ValueError, match="incomplete source dependency review"):
+        write_source_dependency_label_pack(
+            input_path=review_path,
+            output_path=tmp_path / "labels.jsonl",
+            manifest_path=tmp_path / "labels.manifest.json",
+            source_id="real-source-dependency-review-v1",
+        )
+
+
+def test_source_dependency_label_pack_writes_sanitized_labels_and_manifest(tmp_path):
+    from vulca.learning.source_dependency_labels import write_source_dependency_label_pack
+
+    review_path = tmp_path / "review.reviewed.jsonl"
+    label_path = tmp_path / "source_dependency_labels.reviewed.jsonl"
+    manifest_path = tmp_path / "source_dependency_label_manifest.json"
+    _write_jsonl(
+        review_path,
+        [
+            _review_item("case_a", source_dependency="required"),
+            _review_item(
+                "case_b",
+                source_dependency="not_needed",
+                decision_basis="metadata_only",
+                record_index=1,
+                confirmed=False,
+                corrected_action="adjust_prompt",
+            ),
+        ],
+    )
+
+    result = write_source_dependency_label_pack(
+        input_path=review_path,
+        output_path=label_path,
+        manifest_path=manifest_path,
+        source_id="real-source-dependency-review-v1",
+        reviewer="human-reviewer",
+        reviewed_at="2026-05-07T12:30:00Z",
+    )
+
+    assert result.record_count == 2
+    assert result.counts_by_source_dependency == {"not_needed": 1, "required": 1}
+    records = _read_jsonl(label_path)
+    assert records[0]["case_type"] == "learning_source_dependency_label_record"
+    assert records[0]["labels"] == {
+        "corrected_preferred_action": "",
+        "decision_basis": "artifact_source",
+        "preferred_action_confirmed": True,
+        "source_dependency": "required",
+    }
+    assert records[1]["labels"]["corrected_preferred_action"] == "adjust_prompt"
+    assert records[0]["training_use"] == {
+        "approved_label_use": "source_dependency_training_label",
+        "approved_for_source_dependency_training": True,
+        "default_training_input": False,
+        "review_status": "reviewed_source_dependency_label",
+    }
+
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert manifest["case_type"] == "learning_source_dependency_label_manifest"
+    assert manifest["record_count"] == 2
+    assert manifest["sources"][0]["path"] == "source_dependency_labels.reviewed.jsonl"
+    assert manifest["training_use"]["requires_explicit_dataset_flag"] is True
+
+    encoded = json.dumps(manifest, sort_keys=True)
+    encoded += "\n".join(json.dumps(item, sort_keys=True) for item in records)
+    assert "client-only sentence" not in encoded
+    assert "/Users/private" not in encoded
+
+
+def test_source_dependency_label_manifest_attaches_labels_to_dataset_examples(tmp_path):
+    from vulca.learning.source_dependency_labels import (
+        attach_source_dependency_labels,
+        write_source_dependency_label_pack,
+    )
+
+    review_path = tmp_path / "review.reviewed.jsonl"
+    label_path = tmp_path / "labels.reviewed.jsonl"
+    manifest_path = tmp_path / "labels.manifest.json"
+    _write_jsonl(review_path, [_review_item("case_a", source_dependency="helpful")])
+    write_source_dependency_label_pack(
+        input_path=review_path,
+        output_path=label_path,
+        manifest_path=manifest_path,
+        source_id="real-source-dependency-review-v1",
+    )
+
+    examples = [
+        {
+            "example_id": "example_a",
+            "source": {"source_id": "real_user_cases_v2", "index": 0},
+            "source_case": {
+                "case_type": "layer_generate_case",
+                "case_id": "case_a",
+            },
+            "targets": {},
+            "tasks": {},
+        },
+        {
+            "example_id": "example_b",
+            "source": {"source_id": "real_user_cases_v2", "index": 1},
+            "source_case": {
+                "case_type": "layer_generate_case",
+                "case_id": "case_b",
+            },
+            "targets": {},
+            "tasks": {},
+        },
+    ]
+
+    attached = attach_source_dependency_labels(examples, manifest_path=manifest_path)
+
+    assert attached == 1
+    assert examples[0]["targets"]["source_dependency"] == "helpful"
+    assert examples[0]["targets"]["source_decision_basis"] == "artifact_source"
+    assert examples[0]["tasks"]["source_context"]["dependency_classification"] == "helpful"
+    assert "source_dependency_review" not in examples[1]
+
+
+def test_tiny_dataset_export_accepts_source_dependency_manifest(tmp_path):
+    from vulca.learning.source_dependency_labels import write_source_dependency_label_pack
+    from vulca.learning.tiny_dataset import write_tiny_dataset
+
+    case_log = tmp_path / "real_cases.jsonl"
+    review_path = tmp_path / "review.reviewed.jsonl"
+    label_path = tmp_path / "labels.reviewed.jsonl"
+    source_dependency_manifest = tmp_path / "labels.manifest.json"
+    dataset_path = tmp_path / "tiny_dataset.jsonl"
+    _write_jsonl(case_log, [_minimal_case("case_a")])
+    case_source_manifest = _write_case_source_manifest(tmp_path, case_log)
+    _write_jsonl(review_path, [_review_item("case_a", source_dependency="required")])
+    write_source_dependency_label_pack(
+        input_path=review_path,
+        output_path=label_path,
+        manifest_path=source_dependency_manifest,
+        source_id="real-source-dependency-review-v1",
+    )
+
+    result = write_tiny_dataset(
+        repo_root=ROOT,
+        output_path=dataset_path,
+        case_source_manifest_path=case_source_manifest,
+        source_dependency_manifest_path=source_dependency_manifest,
+        include_local_seeds=False,
+    )
+
+    assert result.example_count == 1
+    example = _read_jsonl(dataset_path)[0]
+    assert example["targets"]["source_dependency"] == "required"
+    assert example["targets"]["source_decision_basis"] == "artifact_source"
+    assert example["tasks"]["source_context"] == {
+        "decision_basis_classification": "artifact_source",
+        "dependency_classification": "required",
+    }
+    index = json.loads(dataset_path.with_suffix(".index.json").read_text(encoding="utf-8"))
+    assert index["source_dependency_manifest_path"] == str(source_dependency_manifest)
+
+
+def test_source_dependency_labels_cli_and_cases_export_dataset_cli(tmp_path):
+    case_log = tmp_path / "real_cases.jsonl"
+    review_path = tmp_path / "review.reviewed.jsonl"
+    label_path = tmp_path / "labels.reviewed.jsonl"
+    source_dependency_manifest = tmp_path / "labels.manifest.json"
+    dataset_path = tmp_path / "tiny_dataset.jsonl"
+    _write_jsonl(case_log, [_minimal_case("case_a")])
+    case_source_manifest = _write_case_source_manifest(tmp_path, case_log)
+    _write_jsonl(review_path, [_review_item("case_a", source_dependency="helpful")])
+
+    label_result = subprocess.run(
+        [
+            sys.executable,
+            str(ROOT / "scripts/source_dependency_labels.py"),
+            "--input",
+            str(review_path),
+            "--output",
+            str(label_path),
+            "--manifest",
+            str(source_dependency_manifest),
+            "--source-id",
+            "real-source-dependency-review-v1",
+            "--reviewer",
+            "human-reviewer",
+            "--reviewed-at",
+            "2026-05-07T12:30:00Z",
+        ],
+        cwd=ROOT,
+        env=CLI_ENV,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert label_result.returncode == 0, label_result.stderr
+    assert "Source dependency labels: 1" in label_result.stdout
+
+    dataset_result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "vulca.cli",
+            "cases",
+            "export-dataset",
+            "--output",
+            str(dataset_path),
+            "--case-source-manifest",
+            str(case_source_manifest),
+            "--source-dependency-manifest",
+            str(source_dependency_manifest),
+            "--no-local-seeds",
+        ],
+        cwd=ROOT,
+        env=CLI_ENV,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert dataset_result.returncode == 0, dataset_result.stderr
+    assert _read_jsonl(dataset_path)[0]["targets"]["source_dependency"] == "helpful"


### PR DESCRIPTION
## Summary
- add a sanitized source-dependency label export from completed real source dependency review JSONL
- add an explicit label manifest and dataset attachment path for source-context training targets
- add `cases export-dataset --source-dependency-manifest` and a standalone `scripts/source_dependency_labels.py` CLI

## Smoke
- generated real source dependency review candidates from combined local cases
- copied non-unknown suggestions into a smoke-only reviewed JSONL to verify the pipe
- exported 10 source dependency labels and attached 10 labels into a tiny dataset

Note: the smoke labels are copied suggestions, not final human labels. Real training should wait for human_review completion.

## Test Plan
- PYTHONPATH=src python3 -m pytest tests/test_source_dependency_labels.py tests/test_real_source_dependency_review.py tests/test_open_model_signal_review.py tests/test_tiny_dataset_export.py -q
- python3 -m py_compile src/vulca/learning/source_dependency_labels.py src/vulca/learning/tiny_dataset.py scripts/source_dependency_labels.py src/vulca/cli.py tests/test_source_dependency_labels.py
- /opt/homebrew/bin/ruff check src/vulca/learning/source_dependency_labels.py src/vulca/learning/tiny_dataset.py scripts/source_dependency_labels.py src/vulca/cli.py tests/test_source_dependency_labels.py
- git diff --check
