### PR TITLE
Add source dependency eval

### DIFF
--- a/scripts/source_dependency_eval.py
+++ b/scripts/source_dependency_eval.py
@@ -1,0 +1,196 @@
+"""Run provider-free source-dependency label evaluation."""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Sequence
+
+
+ROOT = Path(__file__).resolve().parent.parent
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from vulca.learning.source_dependency_eval import (  # noqa: E402
+    DEFAULT_CASE_SOURCE_MANIFEST,
+    DEFAULT_MAX_MISMATCHES,
+    DEFAULT_MIN_DEPENDENCY_ACCURACY,
+    DEFAULT_OUTPUT_DIR,
+    DEFAULT_POLICY_NAMES,
+    DEFAULT_SOURCE_DEPENDENCY_MANIFEST,
+    SOURCE_DEPENDENCY_POLICIES,
+    format_source_dependency_gate_violation,
+    parse_policy_float_thresholds,
+    parse_policy_int_thresholds,
+    run_source_dependency_eval,
+)
+from vulca.learning.tiny_dataset import DATASET_SPLITS  # noqa: E402
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Export a tiny dataset with reviewed source-dependency labels, "
+            "evaluate provider-free source-dependency policies, and enforce "
+            "basic accuracy gates."
+        )
+    )
+    parser.add_argument(
+        "--repo-root",
+        default=str(ROOT),
+        help="Repository root (default: this script's repository).",
+    )
+    parser.add_argument(
+        "--output-dir",
+        default=str(DEFAULT_OUTPUT_DIR),
+        help="Directory for generated dataset and comparison JSON.",
+    )
+    parser.add_argument(
+        "--report",
+        default="",
+        help="Stable JSON report path (default: OUTPUT_DIR/source_dependency_eval_report.json).",
+    )
+    parser.add_argument(
+        "--manifest",
+        default="",
+        help="Seed manifest path (default: docs/benchmarks/learning/local_seed_manifest.json).",
+    )
+    parser.add_argument(
+        "--case-log",
+        action="append",
+        default=[],
+        help="Additional reviewed case JSONL path; repeat to include multiple logs.",
+    )
+    parser.add_argument(
+        "--case-source-manifest",
+        default=str(DEFAULT_CASE_SOURCE_MANIFEST),
+        help=(
+            "Reviewed case source manifest to include "
+            f"(default: {DEFAULT_CASE_SOURCE_MANIFEST})."
+        ),
+    )
+    parser.add_argument(
+        "--source-dependency-manifest",
+        default=str(DEFAULT_SOURCE_DEPENDENCY_MANIFEST),
+        help=(
+            "Reviewed source-dependency label manifest "
+            f"(default: {DEFAULT_SOURCE_DEPENDENCY_MANIFEST})."
+        ),
+    )
+    parser.add_argument(
+        "--no-case-source-manifest",
+        action="store_true",
+        help="Do not include the default case source manifest.",
+    )
+    parser.add_argument(
+        "--no-local-seeds",
+        action="store_true",
+        help="Only export records from --case-log/--case-source-manifest inputs.",
+    )
+    parser.add_argument(
+        "--split",
+        default="all",
+        choices=("all", *DATASET_SPLITS),
+        help="Dataset split to evaluate (default: all labeled examples).",
+    )
+    parser.add_argument(
+        "--train-split",
+        default="train",
+        choices=DATASET_SPLITS,
+        help="Dataset split used by train-derived baselines.",
+    )
+    parser.add_argument(
+        "--policy",
+        action="append",
+        default=[],
+        choices=sorted(SOURCE_DEPENDENCY_POLICIES),
+        help=(
+            "Source-dependency policy to evaluate; repeat to include multiple "
+            f"policies (default: {DEFAULT_POLICY_NAMES})."
+        ),
+    )
+    parser.add_argument(
+        "--min-dependency-accuracy",
+        action="append",
+        default=[],
+        metavar="POLICY=VALUE",
+        help=(
+            "Fail if a policy dependency_accuracy is below VALUE. "
+            f"Default: {dict(DEFAULT_MIN_DEPENDENCY_ACCURACY)}."
+        ),
+    )
+    parser.add_argument(
+        "--max-mismatches",
+        action="append",
+        default=[],
+        metavar="POLICY=COUNT",
+        help=(
+            "Fail if a policy has more than COUNT mismatches. "
+            f"Default: {dict(DEFAULT_MAX_MISMATCHES)}."
+        ),
+    )
+    parser.add_argument(
+        "--pretty",
+        action="store_true",
+        help="Print the full JSON report to stdout after writing it.",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        report = run_source_dependency_eval(
+            repo_root=args.repo_root,
+            output_dir=args.output_dir,
+            report_path=args.report or None,
+            manifest_path=args.manifest or None,
+            case_log_paths=args.case_log,
+            case_source_manifest_path=(
+                None if args.no_case_source_manifest else args.case_source_manifest
+            ),
+            source_dependency_manifest_path=args.source_dependency_manifest,
+            include_local_seeds=not args.no_local_seeds,
+            eval_split=None if args.split == "all" else args.split,
+            train_split=args.train_split,
+            policy_names=tuple(args.policy) if args.policy else DEFAULT_POLICY_NAMES,
+            min_dependency_accuracy=parse_policy_float_thresholds(
+                args.min_dependency_accuracy
+            ),
+            max_mismatches=parse_policy_int_thresholds(args.max_mismatches),
+        )
+    except (ValueError, FileNotFoundError, json.JSONDecodeError) as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 2
+
+    if args.pretty:
+        print(json.dumps(report, indent=2, sort_keys=True))
+
+    print(f"Source dependency eval report: {report['artifacts']['report_path']}")
+    print(f"Tiny dataset: {report['artifacts']['dataset_path']}")
+    print(
+        "Source dependency labeled examples: "
+        f"{report['dataset']['source_dependency_labeled_count']}"
+    )
+    for policy in sorted(report["comparison"]["policy_reports"]):
+        policy_report = report["comparison"]["policy_reports"][policy]
+        print(f"{policy} dependency_accuracy: {policy_report['dependency_accuracy']}")
+        print(
+            f"{policy} decision_basis_accuracy: "
+            f"{policy_report['decision_basis_accuracy']}"
+        )
+
+    if not report["gate"]["passed"]:
+        print("Source dependency eval gate failed:", file=sys.stderr)
+        for violation in report["gate"]["violations"]:
+            print(
+                f"  {format_source_dependency_gate_violation(violation)}",
+                file=sys.stderr,
+            )
+        return 1
+
+    print("Source dependency eval gate passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/vulca/learning/source_dependency_eval.py
+++ b/src/vulca/learning/source_dependency_eval.py
@@ -1,0 +1,599 @@
+"""Provider-free evaluation for source-dependency labels."""
+from __future__ import annotations
+
+import json
+from collections import Counter
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Iterable, Mapping, Sequence
+
+from vulca.learning.seed_cases import DEFAULT_SEED_MANIFEST
+from vulca.learning.tiny_dataset import (
+    DATASET_SPLITS,
+    load_tiny_dataset_examples,
+    write_tiny_dataset,
+)
+
+
+SCHEMA_VERSION = 1
+EVAL_REPORT_CASE_TYPE = "learning_source_dependency_eval_report"
+COMPARISON_REPORT_CASE_TYPE = "learning_source_dependency_comparison_report"
+RUN_REPORT_CASE_TYPE = "learning_source_dependency_eval_run_report"
+DEFAULT_OUTPUT_DIR = Path("build/source_dependency_eval")
+DEFAULT_CASE_SOURCE_MANIFEST = Path(
+    "docs/benchmarks/learning/combined_case_source_manifest_v1.json"
+)
+DEFAULT_SOURCE_DEPENDENCY_MANIFEST = Path(
+    "docs/benchmarks/learning/real_source_dependency_label_manifest_v1.json"
+)
+
+POLICY_SOURCE_DEPENDENCY_MAJORITY = "source_dependency_majority"
+POLICY_SOURCE_DEPENDENCY_RULE = "source_dependency_rule_v1"
+POLICY_SOURCE_DEPENDENCY_ORACLE = "source_dependency_label_oracle"
+SOURCE_DEPENDENCY_POLICIES: frozenset[str] = frozenset(
+    {
+        POLICY_SOURCE_DEPENDENCY_MAJORITY,
+        POLICY_SOURCE_DEPENDENCY_RULE,
+        POLICY_SOURCE_DEPENDENCY_ORACLE,
+    }
+)
+DEFAULT_POLICY_NAMES: tuple[str, ...] = (
+    POLICY_SOURCE_DEPENDENCY_MAJORITY,
+    POLICY_SOURCE_DEPENDENCY_RULE,
+)
+DEFAULT_MIN_DEPENDENCY_ACCURACY: Mapping[str, float] = {
+    POLICY_SOURCE_DEPENDENCY_RULE: 1.0,
+}
+DEFAULT_MAX_MISMATCHES: Mapping[str, int] = {
+    POLICY_SOURCE_DEPENDENCY_RULE: 0,
+}
+
+
+@dataclass(frozen=True)
+class SourceDependencyPrediction:
+    source_dependency: str
+    decision_basis: str
+    rule_reason: str
+    confidence: float
+
+
+def run_source_dependency_eval(
+    *,
+    repo_root: str | Path,
+    output_dir: str | Path = DEFAULT_OUTPUT_DIR,
+    report_path: str | Path | None = None,
+    manifest_path: str | Path | None = DEFAULT_SEED_MANIFEST,
+    case_log_paths: Sequence[str | Path] = (),
+    case_source_manifest_path: str | Path | None = DEFAULT_CASE_SOURCE_MANIFEST,
+    source_dependency_manifest_path: str | Path | None = DEFAULT_SOURCE_DEPENDENCY_MANIFEST,
+    include_local_seeds: bool = True,
+    eval_split: str | None = None,
+    train_split: str = "train",
+    policy_names: Sequence[str] = DEFAULT_POLICY_NAMES,
+    min_dependency_accuracy: Mapping[str, float] | None = None,
+    max_mismatches: Mapping[str, int] | None = None,
+) -> dict[str, Any]:
+    """Export a source-dependency dataset and evaluate provider-free policies."""
+    if eval_split is not None:
+        _validate_split(eval_split, label="eval_split")
+    _validate_split(train_split, label="train_split")
+    if source_dependency_manifest_path is None:
+        raise ValueError("source_dependency_manifest_path is required")
+
+    root = Path(repo_root)
+    output = Path(output_dir)
+    output.mkdir(parents=True, exist_ok=True)
+    dataset_path = output / "tiny_dataset.with_source_dependency.jsonl"
+    comparison_report_path = output / "source_dependency_comparison.json"
+    resolved_report_path = (
+        Path(report_path)
+        if report_path
+        else output / "source_dependency_eval_report.json"
+    )
+    resolved_case_source_manifest = _resolve_optional_repo_path(
+        root,
+        case_source_manifest_path,
+    )
+    resolved_source_dependency_manifest = _resolve_optional_repo_path(
+        root,
+        source_dependency_manifest_path,
+    )
+    dataset_result = write_tiny_dataset(
+        repo_root=root,
+        output_path=dataset_path,
+        manifest_path=manifest_path or DEFAULT_SEED_MANIFEST,
+        case_log_paths=case_log_paths,
+        case_source_manifest_path=resolved_case_source_manifest,
+        source_dependency_manifest_path=resolved_source_dependency_manifest,
+        include_local_seeds=include_local_seeds,
+    )
+    examples = load_tiny_dataset_examples(dataset_path)
+    comparison = build_source_dependency_comparison_report(
+        examples,
+        train_split=train_split,
+        eval_split=eval_split,
+        policy_names=policy_names,
+    )
+    comparison_report_path.write_text(
+        json.dumps(comparison, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    min_thresholds = dict(DEFAULT_MIN_DEPENDENCY_ACCURACY)
+    min_thresholds.update(min_dependency_accuracy or {})
+    max_thresholds = dict(DEFAULT_MAX_MISMATCHES)
+    max_thresholds.update(max_mismatches or {})
+    gate = build_source_dependency_eval_gate_result(
+        comparison,
+        min_dependency_accuracy=min_thresholds,
+        max_mismatches=max_thresholds,
+    )
+    report = {
+        "schema_version": SCHEMA_VERSION,
+        "case_type": RUN_REPORT_CASE_TYPE,
+        "train_split": train_split,
+        "eval_split": eval_split or "all",
+        "inputs": {
+            "repo_root": str(root),
+            "source_manifest": str(manifest_path or DEFAULT_SEED_MANIFEST),
+            "case_log_paths": [str(path) for path in case_log_paths],
+            "case_source_manifest_path": str(resolved_case_source_manifest or ""),
+            "source_dependency_manifest_path": str(
+                resolved_source_dependency_manifest or ""
+            ),
+            "include_local_seeds": bool(include_local_seeds),
+        },
+        "artifacts": {
+            "dataset_path": str(dataset_path),
+            "dataset_index_path": dataset_result.index_path,
+            "comparison_report_path": str(comparison_report_path),
+            "report_path": str(resolved_report_path),
+        },
+        "dataset": {
+            **asdict(dataset_result),
+            "source_dependency_labeled_count": _source_dependency_labeled_count(
+                examples,
+                eval_split=eval_split,
+            ),
+        },
+        "comparison": comparison,
+        "gate": gate,
+    }
+    resolved_report_path.parent.mkdir(parents=True, exist_ok=True)
+    resolved_report_path.write_text(
+        json.dumps(report, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return report
+
+
+def evaluate_source_dependency_policy(
+    examples: Iterable[Mapping[str, Any]],
+    *,
+    policy_name: str = POLICY_SOURCE_DEPENDENCY_RULE,
+    dataset_split: str | None = None,
+    train_split: str = "train",
+) -> dict[str, Any]:
+    """Evaluate one source-dependency policy on exported tiny dataset examples."""
+    if policy_name not in SOURCE_DEPENDENCY_POLICIES:
+        raise ValueError(
+            f"unsupported source dependency policy {policy_name!r}; "
+            f"expected one of {sorted(SOURCE_DEPENDENCY_POLICIES)}"
+        )
+    all_items = list(examples)
+    items = _filter_by_split(all_items, dataset_split)
+    majority = _majority_prediction(all_items, train_split=train_split)
+
+    dependency_total = 0
+    dependency_correct = 0
+    decision_basis_total = 0
+    decision_basis_correct = 0
+    skipped_count = 0
+    mismatches: list[dict[str, Any]] = []
+    recommendations: list[dict[str, Any]] = []
+
+    for example in items:
+        targets = _mapping(example.get("targets"))
+        target_dependency = str(targets.get("source_dependency") or "")
+        target_basis = str(targets.get("source_decision_basis") or "")
+        if not target_dependency:
+            skipped_count += 1
+            continue
+
+        prediction = _predict_source_dependency(
+            example,
+            policy_name=policy_name,
+            majority=majority,
+        )
+        recommendation = _recommendation_record(
+            example,
+            prediction=prediction,
+            target_dependency=target_dependency,
+            target_basis=target_basis,
+        )
+        recommendations.append(recommendation)
+
+        has_mismatch = False
+        dependency_total += 1
+        if prediction.source_dependency == target_dependency:
+            dependency_correct += 1
+        else:
+            has_mismatch = True
+
+        if target_basis:
+            decision_basis_total += 1
+            if prediction.decision_basis == target_basis:
+                decision_basis_correct += 1
+            else:
+                has_mismatch = True
+
+        if has_mismatch:
+            mismatches.append(recommendation)
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "case_type": EVAL_REPORT_CASE_TYPE,
+        "policy_name": policy_name,
+        "split": dataset_split or "all",
+        "example_count": len(items),
+        "evaluated_count": dependency_total,
+        "skipped_count": skipped_count,
+        "dependency_labeled_count": dependency_total,
+        "dependency_accuracy": _ratio(dependency_correct, dependency_total),
+        "decision_basis_labeled_count": decision_basis_total,
+        "decision_basis_accuracy": _ratio(
+            decision_basis_correct,
+            decision_basis_total,
+        ),
+        "mismatch_count": len(mismatches),
+        "mismatches": mismatches,
+        "recommendations": recommendations,
+        "counts_by_target_source_dependency": _target_counts(
+            recommendations,
+            "target_source_dependency",
+        ),
+        "counts_by_recommended_source_dependency": _target_counts(
+            recommendations,
+            "recommended_source_dependency",
+        ),
+    }
+
+
+def build_source_dependency_comparison_report(
+    examples: Iterable[Mapping[str, Any]],
+    *,
+    train_split: str = "train",
+    eval_split: str | None = None,
+    policy_names: Sequence[str] = DEFAULT_POLICY_NAMES,
+) -> dict[str, Any]:
+    """Compare source-dependency policies on a fixed dataset split."""
+    items = list(examples)
+    reports = {
+        policy: evaluate_source_dependency_policy(
+            items,
+            policy_name=policy,
+            dataset_split=eval_split,
+            train_split=train_split,
+        )
+        for policy in policy_names
+    }
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "case_type": COMPARISON_REPORT_CASE_TYPE,
+        "train_split": train_split,
+        "eval_split": eval_split or "all",
+        "example_count": len(_filter_by_split(items, eval_split)),
+        "source_dependency_labeled_count": _source_dependency_labeled_count(
+            items,
+            eval_split=eval_split,
+        ),
+        "policy_reports": reports,
+        "ranked_policies": _rank_policy_reports(reports),
+    }
+
+
+def build_source_dependency_eval_gate_result(
+    comparison_report: Mapping[str, Any],
+    *,
+    min_dependency_accuracy: Mapping[str, float],
+    max_mismatches: Mapping[str, int],
+) -> dict[str, Any]:
+    """Check source-dependency eval thresholds."""
+    policy_reports = _mapping(comparison_report.get("policy_reports"))
+    violations: list[dict[str, Any]] = []
+    for policy, threshold in sorted(min_dependency_accuracy.items()):
+        metrics = _mapping(policy_reports.get(policy))
+        actual = metrics.get("dependency_accuracy")
+        if actual is None or float(actual) < float(threshold):
+            violations.append(
+                {
+                    "policy": str(policy),
+                    "metric": "dependency_accuracy",
+                    "actual": actual,
+                    "expected": f">= {_format_number(float(threshold))}",
+                }
+            )
+    for policy, threshold in sorted(max_mismatches.items()):
+        metrics = _mapping(policy_reports.get(policy))
+        actual = metrics.get("mismatch_count")
+        if actual is None or int(actual) > int(threshold):
+            violations.append(
+                {
+                    "policy": str(policy),
+                    "metric": "mismatch_count",
+                    "actual": actual,
+                    "expected": f"<= {int(threshold)}",
+                }
+            )
+    return {
+        "passed": not violations,
+        "thresholds": {
+            "min_dependency_accuracy": {
+                policy: float(value)
+                for policy, value in sorted(min_dependency_accuracy.items())
+            },
+            "max_mismatches": {
+                policy: int(value) for policy, value in sorted(max_mismatches.items())
+            },
+        },
+        "violations": violations,
+    }
+
+
+def format_source_dependency_gate_violation(violation: Mapping[str, Any]) -> str:
+    policy = str(violation.get("policy") or "")
+    metric = str(violation.get("metric") or "")
+    actual = violation.get("actual")
+    expected = str(violation.get("expected") or "")
+    if metric == "dependency_accuracy":
+        threshold = expected.replace(">= ", "")
+        return f"{policy} dependency_accuracy {actual} < {threshold}"
+    if metric == "mismatch_count":
+        threshold = expected.replace("<= ", "")
+        return f"{policy} mismatch_count {actual} > {threshold}"
+    return f"{policy} {metric} {actual} violates {expected}"
+
+
+def parse_policy_float_thresholds(values: Sequence[str]) -> dict[str, float]:
+    thresholds: dict[str, float] = {}
+    for raw in values:
+        policy, value = _split_policy_threshold(raw)
+        try:
+            thresholds[policy] = float(value)
+        except ValueError as exc:
+            raise ValueError(
+                f"invalid threshold value {value!r} for policy {policy!r}"
+            ) from exc
+    return thresholds
+
+
+def parse_policy_int_thresholds(values: Sequence[str]) -> dict[str, int]:
+    thresholds: dict[str, int] = {}
+    for raw in values:
+        policy, value = _split_policy_threshold(raw)
+        try:
+            number = float(value)
+        except ValueError as exc:
+            raise ValueError(
+                f"invalid threshold value {value!r} for policy {policy!r}"
+            ) from exc
+        count = int(number)
+        if count != number:
+            raise ValueError(
+                f"integer threshold required for policy {policy!r}: {value!r}"
+            )
+        thresholds[policy] = count
+    return thresholds
+
+
+def _predict_source_dependency(
+    example: Mapping[str, Any],
+    *,
+    policy_name: str,
+    majority: SourceDependencyPrediction,
+) -> SourceDependencyPrediction:
+    if policy_name == POLICY_SOURCE_DEPENDENCY_ORACLE:
+        targets = _mapping(example.get("targets"))
+        return SourceDependencyPrediction(
+            source_dependency=str(targets.get("source_dependency") or ""),
+            decision_basis=str(targets.get("source_decision_basis") or ""),
+            rule_reason="label_oracle",
+            confidence=1.0,
+        )
+    if policy_name == POLICY_SOURCE_DEPENDENCY_MAJORITY:
+        return majority
+    return _rule_prediction(example)
+
+
+def _rule_prediction(example: Mapping[str, Any]) -> SourceDependencyPrediction:
+    source_case = _mapping(example.get("source_case"))
+    targets = _mapping(example.get("targets"))
+    case_type = str(source_case.get("case_type") or "")
+    failure_type = str(targets.get("failure_type") or "")
+
+    if failure_type == "provider_failure":
+        return SourceDependencyPrediction(
+            source_dependency="not_needed",
+            decision_basis="metadata_only",
+            rule_reason="provider_failure_metadata",
+            confidence=0.9,
+        )
+
+    if case_type in {"redraw_case", "decompose_case"}:
+        return SourceDependencyPrediction(
+            source_dependency="required",
+            decision_basis="image_source",
+            rule_reason=f"{case_type}_visual_judgement",
+            confidence=0.85,
+        )
+
+    return SourceDependencyPrediction(
+        source_dependency="required",
+        decision_basis="artifact_source",
+        rule_reason="layer_generate_source_artifact_judgement",
+        confidence=0.8,
+    )
+
+
+def _majority_prediction(
+    examples: Sequence[Mapping[str, Any]],
+    *,
+    train_split: str,
+) -> SourceDependencyPrediction:
+    train_items = _labeled_items(_filter_by_split(examples, train_split))
+    if not train_items:
+        train_items = _labeled_items(examples)
+    return SourceDependencyPrediction(
+        source_dependency=_majority_value(
+            _mapping(item.get("targets")).get("source_dependency") for item in train_items
+        )
+        or "required",
+        decision_basis=_majority_value(
+            _mapping(item.get("targets")).get("source_decision_basis")
+            for item in train_items
+        )
+        or "artifact_source",
+        rule_reason=f"majority_from_{train_split}",
+        confidence=0.5,
+    )
+
+
+def _recommendation_record(
+    example: Mapping[str, Any],
+    *,
+    prediction: SourceDependencyPrediction,
+    target_dependency: str,
+    target_basis: str,
+) -> dict[str, Any]:
+    source_case = _mapping(example.get("source_case"))
+    targets = _mapping(example.get("targets"))
+    return {
+        "example_id": str(example.get("example_id") or ""),
+        "case_id": str(source_case.get("case_id") or ""),
+        "source_case_type": str(source_case.get("case_type") or ""),
+        "failure_type": str(targets.get("failure_type") or ""),
+        "preferred_action": str(targets.get("preferred_action") or ""),
+        "target_source_dependency": target_dependency,
+        "recommended_source_dependency": prediction.source_dependency,
+        "target_decision_basis": target_basis,
+        "recommended_decision_basis": prediction.decision_basis,
+        "rule_reason": prediction.rule_reason,
+        "confidence": prediction.confidence,
+    }
+
+
+def _rank_policy_reports(reports: Mapping[str, Mapping[str, Any]]) -> list[dict[str, Any]]:
+    rows = []
+    for policy_name, report in sorted(reports.items()):
+        rows.append(
+            {
+                "policy_name": policy_name,
+                "dependency_accuracy": report.get("dependency_accuracy"),
+                "decision_basis_accuracy": report.get("decision_basis_accuracy"),
+                "evaluated_count": int(report.get("evaluated_count") or 0),
+                "mismatch_count": int(report.get("mismatch_count") or 0),
+            }
+        )
+    return sorted(
+        rows,
+        key=lambda item: (
+            -_sortable_accuracy(item.get("dependency_accuracy")),
+            -_sortable_accuracy(item.get("decision_basis_accuracy")),
+            -int(item["evaluated_count"]),
+            int(item["mismatch_count"]),
+            str(item["policy_name"]),
+        ),
+    )
+
+
+def _filter_by_split(
+    examples: Sequence[Mapping[str, Any]],
+    split: str | None,
+) -> list[Mapping[str, Any]]:
+    if not split:
+        return list(examples)
+    return [item for item in examples if str(item.get("split") or "") == split]
+
+
+def _labeled_items(
+    examples: Iterable[Mapping[str, Any]],
+) -> list[Mapping[str, Any]]:
+    return [
+        item
+        for item in examples
+        if str(_mapping(item.get("targets")).get("source_dependency") or "")
+    ]
+
+
+def _source_dependency_labeled_count(
+    examples: Sequence[Mapping[str, Any]],
+    *,
+    eval_split: str | None,
+) -> int:
+    return len(_labeled_items(_filter_by_split(examples, eval_split)))
+
+
+def _target_counts(
+    recommendations: Sequence[Mapping[str, Any]],
+    key: str,
+) -> dict[str, int]:
+    counts: Counter[str] = Counter()
+    for item in recommendations:
+        counts[str(item.get(key) or "unknown")] += 1
+    return dict(sorted(counts.items()))
+
+
+def _majority_value(values: Iterable[Any]) -> str:
+    counts: Counter[str] = Counter(
+        str(value or "") for value in values if str(value or "")
+    )
+    if not counts:
+        return ""
+    return sorted(counts.items(), key=lambda item: (-item[1], item[0]))[0][0]
+
+
+def _ratio(numerator: int, denominator: int) -> float | None:
+    if denominator <= 0:
+        return None
+    return round(float(numerator) / float(denominator), 6)
+
+
+def _sortable_accuracy(value: Any) -> float:
+    if value is None:
+        return -1.0
+    return float(value)
+
+
+def _validate_split(value: str, *, label: str) -> None:
+    if value not in DATASET_SPLITS:
+        raise ValueError(f"unsupported {label} {value!r}; expected one of {DATASET_SPLITS}")
+
+
+def _resolve_optional_repo_path(root: Path, path: str | Path | None) -> Path | None:
+    if not path:
+        return None
+    resolved = Path(path)
+    if resolved.is_absolute():
+        return resolved
+    return root / resolved
+
+
+def _split_policy_threshold(raw: str) -> tuple[str, str]:
+    if "=" not in raw:
+        raise ValueError(f"threshold must be POLICY=VALUE, got {raw!r}")
+    policy, value = raw.split("=", 1)
+    policy = policy.strip()
+    value = value.strip()
+    if not policy or not value:
+        raise ValueError(f"threshold must be POLICY=VALUE, got {raw!r}")
+    return policy, value
+
+
+def _format_number(value: float) -> str:
+    text = f"{value:.6f}".rstrip("0").rstrip(".")
+    return text or "0"
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    if isinstance(value, Mapping):
+        return value
+    return {}

--- a/tests/test_source_dependency_eval.py
+++ b/tests/test_source_dependency_eval.py
@@ -1,0 +1,258 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+CLI_ENV = dict(
+    os.environ,
+    PYTHONPATH=str(ROOT / "src") + os.pathsep + os.environ.get("PYTHONPATH", ""),
+)
+
+
+def _example(
+    case_id: str,
+    *,
+    case_type: str = "layer_generate_case",
+    failure_type: str = "prompt_ambiguity",
+    source_dependency: str = "required",
+    decision_basis: str = "artifact_source",
+    source_artifact_count: int = 1,
+    source_image_available: bool = False,
+    split: str = "test",
+) -> dict:
+    return {
+        "schema_version": 1,
+        "case_type": "learning_tiny_dataset_example",
+        "example_id": f"example_{case_id}",
+        "split": split,
+        "source_case": {
+            "case_id": case_id,
+            "case_type": case_type,
+        },
+        "input": {
+            "case_record": {
+                "case_type": case_type,
+                "case_id": case_id,
+                "review": {
+                    "failure_type": failure_type,
+                    "preferred_action": "manual_review",
+                },
+            },
+        },
+        "targets": {
+            "failure_type": failure_type,
+            "preferred_action": "manual_review",
+            "source_dependency": source_dependency,
+            "source_decision_basis": decision_basis,
+        },
+        "tasks": {
+            "source_context": {
+                "dependency_classification": source_dependency,
+                "decision_basis_classification": decision_basis,
+            }
+        },
+        "source_dependency_review": {
+            "label_id": f"label_{case_id}",
+            "review_status": "reviewed_source_dependency_label",
+        },
+        "source_context": {
+            "available": bool(source_artifact_count or source_image_available),
+            "source_artifact_available_count": source_artifact_count,
+            "source_image_available": source_image_available,
+        },
+    }
+
+
+def _read_jsonl(path: Path) -> list[dict]:
+    return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines()]
+
+
+def test_source_dependency_rule_scores_dependency_and_basis_without_labels():
+    from vulca.learning.source_dependency_eval import (
+        POLICY_SOURCE_DEPENDENCY_RULE,
+        evaluate_source_dependency_policy,
+    )
+
+    examples = [
+        _example(
+            "provider_failure",
+            failure_type="provider_failure",
+            source_dependency="not_needed",
+            decision_basis="metadata_only",
+            source_artifact_count=3,
+            source_image_available=True,
+        ),
+        _example(
+            "layer_prompt",
+            failure_type="prompt_ambiguity",
+            source_dependency="required",
+            decision_basis="artifact_source",
+        ),
+        _example(
+            "decompose_under",
+            case_type="decompose_case",
+            failure_type="under_segmentation",
+            source_dependency="required",
+            decision_basis="image_source",
+        ),
+    ]
+
+    report = evaluate_source_dependency_policy(
+        examples,
+        policy_name=POLICY_SOURCE_DEPENDENCY_RULE,
+    )
+
+    assert report["policy_name"] == "source_dependency_rule_v1"
+    assert report["dependency_labeled_count"] == 3
+    assert report["dependency_accuracy"] == 1.0
+    assert report["decision_basis_accuracy"] == 1.0
+    assert report["mismatch_count"] == 0
+    assert [item["recommended_source_dependency"] for item in report["recommendations"]] == [
+        "not_needed",
+        "required",
+        "required",
+    ]
+
+
+def test_source_dependency_majority_baseline_is_ranked_below_rule():
+    from vulca.learning.source_dependency_eval import (
+        POLICY_SOURCE_DEPENDENCY_MAJORITY,
+        POLICY_SOURCE_DEPENDENCY_RULE,
+        build_source_dependency_comparison_report,
+    )
+
+    examples = [
+        _example(
+            "train_required",
+            source_dependency="required",
+            decision_basis="artifact_source",
+            split="train",
+        ),
+        _example(
+            "train_not_needed",
+            failure_type="provider_failure",
+            source_dependency="not_needed",
+            decision_basis="metadata_only",
+            split="train",
+        ),
+        _example(
+            "test_not_needed",
+            failure_type="provider_failure",
+            source_dependency="not_needed",
+            decision_basis="metadata_only",
+            source_artifact_count=3,
+            source_image_available=True,
+            split="test",
+        ),
+        _example(
+            "test_decompose",
+            case_type="decompose_case",
+            failure_type="under_segmentation",
+            source_dependency="required",
+            decision_basis="image_source",
+            split="test",
+        ),
+    ]
+
+    comparison = build_source_dependency_comparison_report(
+        examples,
+        eval_split="test",
+        train_split="train",
+        policy_names=(POLICY_SOURCE_DEPENDENCY_MAJORITY, POLICY_SOURCE_DEPENDENCY_RULE),
+    )
+
+    assert comparison["case_type"] == "learning_source_dependency_comparison_report"
+    assert comparison["example_count"] == 2
+    assert comparison["policy_reports"][POLICY_SOURCE_DEPENDENCY_RULE][
+        "dependency_accuracy"
+    ] == 1.0
+    assert comparison["policy_reports"][POLICY_SOURCE_DEPENDENCY_MAJORITY][
+        "dependency_accuracy"
+    ] == 0.5
+    assert comparison["ranked_policies"][0]["policy_name"] == POLICY_SOURCE_DEPENDENCY_RULE
+
+
+def test_source_dependency_eval_cli_exports_dataset_and_report(tmp_path):
+    output_dir = tmp_path / "source_dependency_eval"
+    report_path = tmp_path / "source_dependency_eval_report.json"
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(ROOT / "scripts/source_dependency_eval.py"),
+            "--repo-root",
+            str(ROOT),
+            "--output-dir",
+            str(output_dir),
+            "--report",
+            str(report_path),
+            "--case-source-manifest",
+            str(ROOT / "docs/benchmarks/learning/combined_case_source_manifest_v1.json"),
+            "--source-dependency-manifest",
+            str(ROOT / "docs/benchmarks/learning/real_source_dependency_label_manifest_v1.json"),
+            "--no-local-seeds",
+        ],
+        cwd=ROOT,
+        env=CLI_ENV,
+        text=True,
+        capture_output=True,
+        timeout=30,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "Source dependency eval report:" in result.stdout
+    assert "source_dependency_rule_v1 dependency_accuracy: 1.0" in result.stdout
+    assert (output_dir / "tiny_dataset.with_source_dependency.jsonl").exists()
+    assert report_path.exists()
+
+    report = json.loads(report_path.read_text(encoding="utf-8"))
+    assert report["case_type"] == "learning_source_dependency_eval_run_report"
+    assert report["dataset"]["source_dependency_labeled_count"] == 12
+    policy_reports = report["comparison"]["policy_reports"]
+    assert policy_reports["source_dependency_rule_v1"]["dependency_accuracy"] == 1.0
+    assert policy_reports["source_dependency_rule_v1"]["decision_basis_accuracy"] == 1.0
+    assert policy_reports["source_dependency_majority"]["dependency_accuracy"] < 1.0
+
+    examples = _read_jsonl(output_dir / "tiny_dataset.with_source_dependency.jsonl")
+    assert sum(1 for item in examples if item["targets"].get("source_dependency")) == 12
+
+
+def test_source_dependency_eval_cli_fails_threshold(tmp_path):
+    output_dir = tmp_path / "source_dependency_eval"
+    report_path = tmp_path / "source_dependency_eval_report.json"
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(ROOT / "scripts/source_dependency_eval.py"),
+            "--repo-root",
+            str(ROOT),
+            "--output-dir",
+            str(output_dir),
+            "--report",
+            str(report_path),
+            "--case-source-manifest",
+            str(ROOT / "docs/benchmarks/learning/combined_case_source_manifest_v1.json"),
+            "--source-dependency-manifest",
+            str(ROOT / "docs/benchmarks/learning/real_source_dependency_label_manifest_v1.json"),
+            "--no-local-seeds",
+            "--min-dependency-accuracy",
+            "source_dependency_rule_v1=1.01",
+        ],
+        cwd=ROOT,
+        env=CLI_ENV,
+        text=True,
+        capture_output=True,
+        timeout=30,
+        check=False,
+    )
+
+    assert result.returncode == 1
+    assert "Source dependency eval gate failed" in result.stderr
+    assert "source_dependency_rule_v1 dependency_accuracy 1.0 < 1.01" in result.stderr


### PR DESCRIPTION
## Summary
- add a provider-free source-dependency eval module and CLI
- compare `source_dependency_majority` against `source_dependency_rule_v1`
- gate `source_dependency_rule_v1` with dependency_accuracy >= 1.0 and mismatch_count <= 0 by default

## Real smoke
Command:
`PYTHONPATH=src python3 scripts/source_dependency_eval.py --repo-root /Users/yhryzy/dev/vulca/.worktrees/source-dependency-eval-v1 --output-dir build/source_dependency_eval_v1 --report build/source_dependency_eval_v1/source_dependency_eval_report.json --case-source-manifest docs/benchmarks/learning/combined_case_source_manifest_v1.json --source-dependency-manifest docs/benchmarks/learning/real_source_dependency_label_manifest_v1.json --no-local-seeds`

Results:
- source dependency labeled examples: 12
- source_dependency_rule_v1 dependency_accuracy: 1.0
- source_dependency_rule_v1 decision_basis_accuracy: 1.0
- source_dependency_majority dependency_accuracy: 0.833333
- source_dependency_majority decision_basis_accuracy: 0.5

## Test Plan
- PYTHONPATH=src python3 -m pytest tests/test_source_dependency_eval.py tests/test_source_dependency_labels.py tests/test_tiny_dataset_export.py -q
- python3 -m py_compile src/vulca/learning/source_dependency_eval.py scripts/source_dependency_eval.py tests/test_source_dependency_eval.py
- /opt/homebrew/bin/ruff check src/vulca/learning/source_dependency_eval.py scripts/source_dependency_eval.py tests/test_source_dependency_eval.py
- git diff --check
