### PR TITLE
Unify source dependency in training effectiveness report

### DIFF
--- a/scripts/training_effectiveness_report.py
+++ b/scripts/training_effectiveness_report.py
@@ -17,6 +17,7 @@ from vulca.learning.tiny_dataset import DATASET_SPLITS  # noqa: E402
 from vulca.learning.training_effectiveness import (  # noqa: E402
     DEFAULT_COMBINED_CASE_SOURCE_MANIFEST,
     DEFAULT_OUTPUT_DIR,
+    DEFAULT_SOURCE_DEPENDENCY_MANIFEST,
     format_data_gap,
     run_training_effectiveness_report,
 )
@@ -48,6 +49,17 @@ def main(argv: Sequence[str] | None = None) -> int:
         "--case-source-manifest",
         default=str(DEFAULT_COMBINED_CASE_SOURCE_MANIFEST),
         help="Combined reviewed case source manifest.",
+    )
+    parser.add_argument(
+        "--source-dependency-manifest",
+        default=str(DEFAULT_SOURCE_DEPENDENCY_MANIFEST),
+        help="Reviewed source-dependency label manifest.",
+    )
+    parser.add_argument(
+        "--source-dependency-split",
+        default="all",
+        choices=("all", *DATASET_SPLITS),
+        help="Dataset split for source-dependency eval; default evaluates all labeled examples.",
     )
     parser.add_argument(
         "--no-local-seeds",
@@ -94,6 +106,12 @@ def main(argv: Sequence[str] | None = None) -> int:
             eval_split=args.split,
             train_split=args.train_split,
             min_eval_examples_per_bucket=args.min_eval_examples_per_bucket,
+            source_dependency_manifest_path=args.source_dependency_manifest,
+            source_dependency_eval_split=(
+                None
+                if args.source_dependency_split == "all"
+                else args.source_dependency_split
+            ),
         )
     except (ValueError, FileNotFoundError, json.JSONDecodeError) as exc:
         print(f"Error: {exc}", file=sys.stderr)
@@ -120,6 +138,26 @@ def main(argv: Sequence[str] | None = None) -> int:
         "Accuracy delta vs baseline: "
         f"{effectiveness['accuracy_delta_vs_baseline']}"
     )
+    source_dependency = report["source_dependency"]
+    source_best = source_dependency["best_policy"]
+    print(f"Source dependency labeled examples: {source_dependency['labeled_count']}")
+    print(
+        f"{source_best['policy_name']} dependency_accuracy: "
+        f"{source_best['dependency_accuracy']}"
+    )
+    print(
+        f"{source_best['policy_name']} decision_basis_accuracy: "
+        f"{source_best['decision_basis_accuracy']}"
+    )
+    for row in report["leaderboard"]:
+        if row["task"] != "source_dependency":
+            continue
+        print(
+            "Leaderboard source_dependency: "
+            f"{row['best_policy']} "
+            f"{row['primary_metric']}={row['primary_accuracy']} "
+            f"{row['secondary_metric']}={row['secondary_accuracy']}"
+        )
     hardest_drop = effectiveness.get("ablation_summary", {}).get(
         "largest_accuracy_drop",
         {},
@@ -141,6 +179,11 @@ def main(argv: Sequence[str] | None = None) -> int:
     if not effectiveness["gate_passed"]:
         print("Training effectiveness gate failed:", file=sys.stderr)
         for violation in effectiveness["gate"].get("violations", []) or []:
+            print(f"  {violation}", file=sys.stderr)
+        return 1
+    if not source_dependency["gate_passed"]:
+        print("Source dependency effectiveness gate failed:", file=sys.stderr)
+        for violation in source_dependency["gate"].get("violations", []) or []:
             print(f"  {violation}", file=sys.stderr)
         return 1
 

--- a/src/vulca/learning/training_effectiveness.py
+++ b/src/vulca/learning/training_effectiveness.py
@@ -6,12 +6,17 @@ from pathlib import Path
 from typing import Any, Mapping, Sequence
 
 from vulca.learning.aggregated_case_source_eval import run_aggregated_case_source_eval
+from vulca.learning.source_dependency_eval import (
+    DEFAULT_SOURCE_DEPENDENCY_MANIFEST,
+    POLICY_SOURCE_DEPENDENCY_MAJORITY,
+    run_source_dependency_eval,
+)
 from vulca.learning.tiny_action_model import POLICY_TINY_ACTION_MODEL
 from vulca.learning.tiny_baseline_model import POLICY_TINY_AGENT
 from vulca.learning.tiny_dataset import DATASET_SPLITS
 
 
-SCHEMA_VERSION = 1
+SCHEMA_VERSION = 2
 REPORT_CASE_TYPE = "learning_training_effectiveness_report"
 DEFAULT_OUTPUT_DIR = Path("build/training_effectiveness_report")
 DEFAULT_REPORT_NAME = "training_effectiveness_report.json"
@@ -37,10 +42,17 @@ def run_training_effectiveness_report(
     eval_split: str = "test",
     train_split: str = "train",
     min_eval_examples_per_bucket: int = 1,
+    source_dependency_manifest_path: str | Path = DEFAULT_SOURCE_DEPENDENCY_MANIFEST,
+    source_dependency_eval_split: str | None = None,
 ) -> dict[str, Any]:
     """Run combined tiny eval and summarize model effectiveness plus data gaps."""
     _validate_split(eval_split, label="eval_split")
     _validate_split(train_split, label="train_split")
+    if source_dependency_eval_split is not None:
+        _validate_split(
+            source_dependency_eval_split,
+            label="source_dependency_eval_split",
+        )
     if min_eval_examples_per_bucket < 0:
         raise ValueError("min_eval_examples_per_bucket must be >= 0")
 
@@ -49,6 +61,10 @@ def run_training_effectiveness_report(
     output.mkdir(parents=True, exist_ok=True)
     resolved_report_path = Path(report_path) if report_path else output / DEFAULT_REPORT_NAME
     resolved_manifest_path = _resolve_repo_path(root, case_source_manifest_path)
+    resolved_source_dependency_manifest_path = _resolve_repo_path(
+        root,
+        source_dependency_manifest_path,
+    )
     aggregated_output_dir = output / "aggregated"
     aggregated_report = run_aggregated_case_source_eval(
         repo_root=root,
@@ -59,12 +75,24 @@ def run_training_effectiveness_report(
         eval_split=eval_split,
         train_split=train_split,
     )
+    source_dependency_report = run_source_dependency_eval(
+        repo_root=root,
+        output_dir=output / "source_dependency",
+        case_source_manifest_path=resolved_manifest_path,
+        source_dependency_manifest_path=resolved_source_dependency_manifest_path,
+        include_local_seeds=include_local_seeds,
+        eval_split=source_dependency_eval_split,
+        train_split=train_split,
+    )
     data_gaps = _build_data_gaps(
         aggregated_report,
         min_eval_examples=min_eval_examples_per_bucket,
     )
     effectiveness = _build_effectiveness_summary(aggregated_report)
-    gate_passed = bool(effectiveness["gate_passed"])
+    source_dependency = _build_source_dependency_summary(source_dependency_report)
+    gate_passed = bool(effectiveness["gate_passed"]) and bool(
+        source_dependency["gate_passed"]
+    )
     if not gate_passed:
         status = "failed_gate"
     elif data_gaps:
@@ -83,8 +111,12 @@ def run_training_effectiveness_report(
         "inputs": {
             "repo_root": str(root),
             "case_source_manifest_path": str(resolved_manifest_path),
+            "source_dependency_manifest_path": str(
+                resolved_source_dependency_manifest_path
+            ),
             "include_local_seeds": bool(include_local_seeds),
             "min_eval_examples_per_bucket": int(min_eval_examples_per_bucket),
+            "source_dependency_eval_split": source_dependency["eval_split"],
         },
         "artifacts": {
             "report_path": str(resolved_report_path),
@@ -100,6 +132,15 @@ def run_training_effectiveness_report(
             "tiny_feature_ablation_report_path": aggregated_report["artifacts"][
                 "tiny_feature_ablation_report_path"
             ],
+            "source_dependency_eval_report_path": source_dependency_report["artifacts"][
+                "report_path"
+            ],
+            "source_dependency_dataset_path": source_dependency_report["artifacts"][
+                "dataset_path"
+            ],
+            "source_dependency_comparison_report_path": source_dependency_report[
+                "artifacts"
+            ]["comparison_report_path"],
         },
         "dataset": {
             "example_count": int(dataset_summary.get("example_count") or 0),
@@ -115,6 +156,8 @@ def run_training_effectiveness_report(
         },
         "coverage": _build_coverage_summary(aggregated_report),
         "effectiveness": effectiveness,
+        "source_dependency": source_dependency,
+        "leaderboard": _build_task_leaderboard(effectiveness, source_dependency),
         "data_gaps": data_gaps,
     }
 
@@ -164,6 +207,101 @@ def _build_effectiveness_summary(aggregated_report: Mapping[str, Any]) -> dict[s
         "gate": dict(gate),
         "policy_ranking": _policy_ranking(policy_reports),
     }
+
+
+def _build_source_dependency_summary(
+    source_dependency_report: Mapping[str, Any],
+) -> dict[str, Any]:
+    comparison = _mapping(source_dependency_report.get("comparison"))
+    policy_reports = _mapping(comparison.get("policy_reports"))
+    ranking = [
+        _compact_source_dependency_rank(item)
+        for item in comparison.get("ranked_policies", []) or []
+        if isinstance(item, Mapping)
+    ]
+    best_policy = ranking[0] if ranking else {}
+    return {
+        "gate_passed": bool(_mapping(source_dependency_report.get("gate")).get("passed")),
+        "eval_split": str(source_dependency_report.get("eval_split") or "all"),
+        "labeled_count": int(
+            _mapping(source_dependency_report.get("dataset")).get(
+                "source_dependency_labeled_count",
+            )
+            or 0
+        ),
+        "best_policy": best_policy,
+        "policy_ranking": ranking,
+        "policy_reports": {
+            str(policy_name): _compact_source_dependency_policy_report(report_value)
+            for policy_name, report_value in sorted(policy_reports.items())
+        },
+        "gate": dict(_mapping(source_dependency_report.get("gate"))),
+    }
+
+
+def _compact_source_dependency_rank(rank: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        "policy_name": str(rank.get("policy_name") or ""),
+        "dependency_accuracy": _float_or_none(rank.get("dependency_accuracy")),
+        "decision_basis_accuracy": _float_or_none(rank.get("decision_basis_accuracy")),
+        "evaluated_count": int(rank.get("evaluated_count") or 0),
+        "mismatch_count": int(rank.get("mismatch_count") or 0),
+    }
+
+
+def _compact_source_dependency_policy_report(
+    report_value: Any,
+) -> dict[str, Any]:
+    report = _mapping(report_value)
+    return {
+        "dependency_accuracy": _float_or_none(report.get("dependency_accuracy")),
+        "decision_basis_accuracy": _float_or_none(
+            report.get("decision_basis_accuracy")
+        ),
+        "dependency_labeled_count": int(
+            report.get("dependency_labeled_count") or 0
+        ),
+        "decision_basis_labeled_count": int(
+            report.get("decision_basis_labeled_count") or 0
+        ),
+        "evaluated_count": int(report.get("evaluated_count") or 0),
+        "mismatch_count": int(report.get("mismatch_count") or 0),
+    }
+
+
+def _build_task_leaderboard(
+    effectiveness: Mapping[str, Any],
+    source_dependency: Mapping[str, Any],
+) -> list[dict[str, Any]]:
+    source_best = _mapping(source_dependency.get("best_policy"))
+    return [
+        {
+            "task": "action_routing",
+            "best_policy": str(effectiveness.get("evaluated_policy") or ""),
+            "baseline_policy": str(effectiveness.get("baseline_policy") or ""),
+            "primary_metric": "action_accuracy",
+            "primary_accuracy": _float_or_none(effectiveness.get("action_accuracy")),
+            "secondary_metric": None,
+            "secondary_accuracy": None,
+            "mismatch_count": int(effectiveness.get("mismatch_count") or 0),
+            "gate_passed": bool(effectiveness.get("gate_passed")),
+        },
+        {
+            "task": "source_dependency",
+            "best_policy": str(source_best.get("policy_name") or ""),
+            "baseline_policy": POLICY_SOURCE_DEPENDENCY_MAJORITY,
+            "primary_metric": "dependency_accuracy",
+            "primary_accuracy": _float_or_none(
+                source_best.get("dependency_accuracy")
+            ),
+            "secondary_metric": "decision_basis_accuracy",
+            "secondary_accuracy": _float_or_none(
+                source_best.get("decision_basis_accuracy")
+            ),
+            "mismatch_count": int(source_best.get("mismatch_count") or 0),
+            "gate_passed": bool(source_dependency.get("gate_passed")),
+        },
+    ]
 
 
 def _policy_ranking(policy_reports: Mapping[str, Any]) -> list[dict[str, Any]]:

--- a/tests/test_training_effectiveness_report.py
+++ b/tests/test_training_effectiveness_report.py
@@ -85,6 +85,59 @@ def test_training_effectiveness_report_uses_combined_real_manual_and_seed_data(t
     assert Path(report["artifacts"]["aggregated_report_path"]).exists()
 
 
+def test_training_effectiveness_report_includes_source_dependency_eval_and_leaderboard(
+    tmp_path,
+):
+    from vulca.learning.training_effectiveness import run_training_effectiveness_report
+
+    report = run_training_effectiveness_report(
+        repo_root=ROOT,
+        output_dir=tmp_path / "effectiveness",
+        report_path=tmp_path / "training_effectiveness_report.json",
+    )
+
+    assert report["schema_version"] == 2
+    assert Path(report["artifacts"]["source_dependency_eval_report_path"]).exists()
+    assert Path(report["artifacts"]["source_dependency_dataset_path"]).exists()
+    assert Path(report["artifacts"]["source_dependency_comparison_report_path"]).exists()
+
+    source_dependency = report["source_dependency"]
+    assert source_dependency["eval_split"] == "all"
+    assert source_dependency["gate_passed"] is True
+    assert source_dependency["labeled_count"] == 12
+    assert source_dependency["best_policy"]["policy_name"] == "source_dependency_rule_v1"
+    assert source_dependency["best_policy"]["dependency_accuracy"] == 1.0
+    assert source_dependency["best_policy"]["decision_basis_accuracy"] == 1.0
+    assert source_dependency["best_policy"]["mismatch_count"] == 0
+    assert source_dependency["policy_reports"]["source_dependency_majority"][
+        "decision_basis_accuracy"
+    ] == 0.5
+
+    leaderboard = {item["task"]: item for item in report["leaderboard"]}
+    assert leaderboard["action_routing"] == {
+        "task": "action_routing",
+        "best_policy": "tiny_action_model_v1",
+        "baseline_policy": "tiny_agent_v0",
+        "primary_metric": "action_accuracy",
+        "primary_accuracy": 1.0,
+        "secondary_metric": None,
+        "secondary_accuracy": None,
+        "mismatch_count": 0,
+        "gate_passed": True,
+    }
+    assert leaderboard["source_dependency"] == {
+        "task": "source_dependency",
+        "best_policy": "source_dependency_rule_v1",
+        "baseline_policy": "source_dependency_majority",
+        "primary_metric": "dependency_accuracy",
+        "primary_accuracy": 1.0,
+        "secondary_metric": "decision_basis_accuracy",
+        "secondary_accuracy": 1.0,
+        "mismatch_count": 0,
+        "gate_passed": True,
+    }
+
+
 def test_training_effectiveness_report_has_no_default_eval_coverage_gaps(tmp_path):
     from vulca.learning.training_effectiveness import run_training_effectiveness_report
 
@@ -116,6 +169,14 @@ def test_training_effectiveness_report_script_writes_report_and_prints_summary(t
     assert "Dataset examples: 50" in result.stdout
     assert "Eval examples: 21" in result.stdout
     assert "tiny_action_model_v1 action_accuracy: 1.0" in result.stdout
+    assert "source_dependency_rule_v1 dependency_accuracy: 1.0" in result.stdout
+    assert "source_dependency_rule_v1 decision_basis_accuracy: 1.0" in result.stdout
+    assert "Source dependency labeled examples: 12" in result.stdout
+    assert (
+        "Leaderboard source_dependency: "
+        "source_dependency_rule_v1 dependency_accuracy=1.0 "
+        "decision_basis_accuracy=1.0"
+    ) in result.stdout
     assert "Ablation hardest drop:" in result.stdout
     assert "tiny_agent_v0 action_accuracy:" in result.stdout
     assert "Data gaps: 0" in result.stdout


### PR DESCRIPTION
## Summary
- integrate source-dependency eval into the unified training effectiveness report
- add v2 report fields for source_dependency artifacts, best policy, compact policy reports, and task leaderboard
- print source-dependency leaderboard metrics from the training effectiveness CLI

## Verification
- PYTHONPATH=src python3 -m pytest tests/test_training_effectiveness_report.py -q
- PYTHONPATH=src python3 -m pytest tests/test_training_effectiveness_report.py tests/test_source_dependency_eval.py tests/test_aggregated_case_source_eval.py tests/test_tiny_training_eval_gate.py -q
- PYTHONPATH=src python3 scripts/training_effectiveness_report.py --repo-root . --output-dir build/unified_training_effectiveness_v2 --report build/unified_training_effectiveness_v2/training_effectiveness_report.json
- python3 -m py_compile src/vulca/learning/training_effectiveness.py scripts/training_effectiveness_report.py tests/test_training_effectiveness_report.py
- /opt/homebrew/bin/ruff check src/vulca/learning/training_effectiveness.py scripts/training_effectiveness_report.py tests/test_training_effectiveness_report.py
- git diff --check

## Smoke result
- Dataset examples: 50
- Eval examples: 21
- tiny_action_model_v1 action_accuracy: 1.0
- source_dependency_rule_v1 dependency_accuracy: 1.0
- source_dependency_rule_v1 decision_basis_accuracy: 1.0
- Source dependency labeled examples: 12
