### PR TITLE
Add dry-run decision router

### DIFF
--- a/scripts/dry_run_decision_router.py
+++ b/scripts/dry_run_decision_router.py
@@ -1,0 +1,134 @@
+"""Run the provider-free dry-run decision router."""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Sequence
+
+
+ROOT = Path(__file__).resolve().parent.parent
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from vulca.learning.dry_run_decision_router import (  # noqa: E402
+    DEFAULT_MIN_ACTION_CONFIDENCE,
+    DEFAULT_OUTPUT_DIR,
+    run_dry_run_decision_router,
+)
+from vulca.learning.source_dependency_eval import (  # noqa: E402
+    DEFAULT_CASE_SOURCE_MANIFEST,
+    DEFAULT_SOURCE_DEPENDENCY_MANIFEST,
+)
+from vulca.learning.tiny_dataset import DATASET_SPLITS  # noqa: E402
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Run provider-free dry-run routing decisions over a tiny dataset "
+            "split, combining action routing with source-dependency routing."
+        )
+    )
+    parser.add_argument(
+        "--repo-root",
+        default=str(ROOT),
+        help="Repository root (default: this script's repository).",
+    )
+    parser.add_argument(
+        "--output-dir",
+        default=str(DEFAULT_OUTPUT_DIR),
+        help="Directory for generated dataset, decisions, and report.",
+    )
+    parser.add_argument(
+        "--report",
+        default="",
+        help="Report JSON path (default: OUTPUT_DIR/dry_run_decision_router_report.json).",
+    )
+    parser.add_argument(
+        "--case-source-manifest",
+        default=str(DEFAULT_CASE_SOURCE_MANIFEST),
+        help="Combined reviewed case source manifest.",
+    )
+    parser.add_argument(
+        "--source-dependency-manifest",
+        default=str(DEFAULT_SOURCE_DEPENDENCY_MANIFEST),
+        help="Reviewed source-dependency label manifest.",
+    )
+    parser.add_argument(
+        "--no-local-seeds",
+        action="store_true",
+        help="Only export records from the case source manifest.",
+    )
+    parser.add_argument(
+        "--split",
+        default="test",
+        choices=DATASET_SPLITS,
+        help="Dataset split to route.",
+    )
+    parser.add_argument(
+        "--train-split",
+        default="train",
+        choices=DATASET_SPLITS,
+        help="Dataset split used to fit tiny action classifier.",
+    )
+    parser.add_argument(
+        "--min-action-confidence",
+        type=float,
+        default=DEFAULT_MIN_ACTION_CONFIDENCE,
+        help="Below this action confidence, route execution to fallback_agent.",
+    )
+    parser.add_argument(
+        "--pretty",
+        action="store_true",
+        help="Print full JSON report after writing it.",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        report = run_dry_run_decision_router(
+            repo_root=args.repo_root,
+            output_dir=args.output_dir,
+            report_path=args.report or None,
+            case_source_manifest_path=args.case_source_manifest,
+            source_dependency_manifest_path=args.source_dependency_manifest,
+            include_local_seeds=not args.no_local_seeds,
+            eval_split=args.split,
+            train_split=args.train_split,
+            min_action_confidence=args.min_action_confidence,
+        )
+    except (ValueError, FileNotFoundError, json.JSONDecodeError) as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 2
+
+    if args.pretty:
+        print(json.dumps(report, indent=2, sort_keys=True))
+
+    summary = report["summary"]
+    evaluation = report["evaluation"]
+    print(f"Dry-run decision router report: {report['artifacts']['report_path']}")
+    print(f"Dry-run decisions: {report['artifacts']['decision_path']}")
+    print(f"Dataset: {report['artifacts']['dataset_path']}")
+    print(f"Decisions: {summary['decision_count']}")
+    print(f"Fallback agent decisions: {summary['fallback_agent_count']}")
+    print(
+        "tiny_action_model_v1 action_accuracy: "
+        f"{evaluation['action_accuracy']}"
+    )
+    print(
+        "source_dependency_rule_v1 source_dependency_accuracy: "
+        f"{evaluation['source_dependency_accuracy']}"
+    )
+    print(
+        "source_dependency_rule_v1 decision_basis_accuracy: "
+        f"{evaluation['decision_basis_accuracy']}"
+    )
+    if summary["data_gap_counts"]:
+        print(f"Data gap tags: {summary['data_gap_counts']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/vulca/learning/dry_run_decision_router.py
+++ b/src/vulca/learning/dry_run_decision_router.py
@@ -1,0 +1,404 @@
+"""Provider-free dry-run decision router for tiny learning cases."""
+from __future__ import annotations
+
+import json
+from collections import Counter
+from pathlib import Path
+from typing import Any, Iterable, Mapping, Sequence
+
+from vulca.learning.seed_cases import DEFAULT_SEED_MANIFEST
+from vulca.learning.source_dependency_eval import (
+    DEFAULT_CASE_SOURCE_MANIFEST,
+    DEFAULT_SOURCE_DEPENDENCY_MANIFEST,
+    POLICY_SOURCE_DEPENDENCY_RULE,
+    predict_source_dependency_for_example,
+)
+from vulca.learning.tiny_action_model import (
+    POLICY_TINY_ACTION_MODEL,
+    TinyActionClassifier,
+)
+from vulca.learning.tiny_dataset import (
+    DATASET_SPLITS,
+    load_tiny_dataset_examples,
+    write_tiny_dataset,
+)
+
+
+SCHEMA_VERSION = 1
+DECISION_CASE_TYPE = "learning_dry_run_decision"
+REPORT_CASE_TYPE = "learning_dry_run_decision_router_report"
+DEFAULT_OUTPUT_DIR = Path("build/dry_run_decision_router")
+DEFAULT_REPORT_NAME = "dry_run_decision_router_report.json"
+DEFAULT_DECISION_NAME = "dry_run_decisions.jsonl"
+DEFAULT_MIN_ACTION_CONFIDENCE = 0.5
+
+
+def run_dry_run_decision_router(
+    *,
+    repo_root: str | Path,
+    output_dir: str | Path = DEFAULT_OUTPUT_DIR,
+    report_path: str | Path | None = None,
+    manifest_path: str | Path | None = DEFAULT_SEED_MANIFEST,
+    case_log_paths: Sequence[str | Path] = (),
+    case_source_manifest_path: str | Path | None = DEFAULT_CASE_SOURCE_MANIFEST,
+    source_dependency_manifest_path: str | Path | None = DEFAULT_SOURCE_DEPENDENCY_MANIFEST,
+    include_local_seeds: bool = True,
+    eval_split: str = "test",
+    train_split: str = "train",
+    min_action_confidence: float = DEFAULT_MIN_ACTION_CONFIDENCE,
+) -> dict[str, Any]:
+    """Export the tiny dataset and write provider-free dry-run router decisions."""
+    _validate_split(eval_split, label="eval_split")
+    _validate_split(train_split, label="train_split")
+    root = Path(repo_root)
+    output = Path(output_dir)
+    output.mkdir(parents=True, exist_ok=True)
+    dataset_path = output / "tiny_dataset.with_source_dependency.jsonl"
+    decision_path = output / DEFAULT_DECISION_NAME
+    resolved_report_path = (
+        Path(report_path) if report_path else output / DEFAULT_REPORT_NAME
+    )
+    resolved_case_source_manifest = _resolve_optional_repo_path(
+        root,
+        case_source_manifest_path,
+    )
+    resolved_source_dependency_manifest = _resolve_optional_repo_path(
+        root,
+        source_dependency_manifest_path,
+    )
+
+    dataset_result = write_tiny_dataset(
+        repo_root=root,
+        output_path=dataset_path,
+        manifest_path=manifest_path or DEFAULT_SEED_MANIFEST,
+        case_log_paths=case_log_paths,
+        case_source_manifest_path=resolved_case_source_manifest,
+        source_dependency_manifest_path=resolved_source_dependency_manifest,
+        include_local_seeds=include_local_seeds,
+    )
+    examples = load_tiny_dataset_examples(dataset_path)
+    report = build_dry_run_router_report(
+        examples,
+        eval_split=eval_split,
+        train_split=train_split,
+        min_action_confidence=min_action_confidence,
+    )
+    decisions = report["decisions"]
+    _write_jsonl(decision_path, decisions)
+
+    report = {
+        **{key: value for key, value in report.items() if key != "decisions"},
+        "inputs": {
+            "repo_root": str(root),
+            "source_manifest": str(manifest_path or DEFAULT_SEED_MANIFEST),
+            "case_log_paths": [str(path) for path in case_log_paths],
+            "case_source_manifest_path": str(resolved_case_source_manifest or ""),
+            "source_dependency_manifest_path": str(
+                resolved_source_dependency_manifest or ""
+            ),
+            "include_local_seeds": bool(include_local_seeds),
+            "min_action_confidence": float(min_action_confidence),
+        },
+        "artifacts": {
+            "dataset_path": str(dataset_path),
+            "dataset_index_path": dataset_result.index_path,
+            "decision_path": str(decision_path),
+            "report_path": str(resolved_report_path),
+        },
+    }
+    resolved_report_path.parent.mkdir(parents=True, exist_ok=True)
+    resolved_report_path.write_text(
+        json.dumps(report, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return report
+
+
+def build_dry_run_router_report(
+    examples: Iterable[Mapping[str, Any]],
+    *,
+    eval_split: str = "test",
+    train_split: str = "train",
+    min_action_confidence: float = DEFAULT_MIN_ACTION_CONFIDENCE,
+) -> dict[str, Any]:
+    """Build dry-run decisions and aggregate router metrics."""
+    decisions = build_dry_run_decisions(
+        examples,
+        eval_split=eval_split,
+        train_split=train_split,
+        min_action_confidence=min_action_confidence,
+    )
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "case_type": REPORT_CASE_TYPE,
+        "train_split": train_split,
+        "eval_split": eval_split,
+        "summary": _build_summary(decisions),
+        "evaluation": _build_evaluation(decisions),
+        "decisions": decisions,
+    }
+
+
+def build_dry_run_decisions(
+    examples: Iterable[Mapping[str, Any]],
+    *,
+    eval_split: str = "test",
+    train_split: str = "train",
+    min_action_confidence: float = DEFAULT_MIN_ACTION_CONFIDENCE,
+) -> list[dict[str, Any]]:
+    """Combine tiny action and source-dependency decisions for a frozen split."""
+    _validate_split(eval_split, label="eval_split")
+    _validate_split(train_split, label="train_split")
+    items = list(examples)
+    classifier = TinyActionClassifier.fit(items, train_split=train_split)
+    decisions: list[dict[str, Any]] = []
+    for example in items:
+        if str(example.get("split") or "") != eval_split:
+            continue
+        action_prediction = classifier.predict(example)
+        source_prediction = predict_source_dependency_for_example(example)
+        decisions.append(
+            _decision_record(
+                example,
+                action_prediction=action_prediction,
+                source_prediction=source_prediction,
+                min_action_confidence=min_action_confidence,
+            )
+        )
+    return decisions
+
+
+def _decision_record(
+    example: Mapping[str, Any],
+    *,
+    action_prediction: Mapping[str, Any],
+    source_prediction: Any,
+    min_action_confidence: float,
+) -> dict[str, Any]:
+    source_case = _mapping(example.get("source_case"))
+    targets = _mapping(example.get("targets"))
+    confidence = _float(action_prediction.get("confidence"), default=0.0)
+    recommended_action = str(action_prediction.get("recommended_action") or "")
+    source_dependency = str(source_prediction.source_dependency or "")
+    decision_basis = str(source_prediction.decision_basis or "")
+    target_dependency = str(targets.get("source_dependency") or "")
+    target_basis = str(targets.get("source_decision_basis") or "")
+    source_context_available = _source_context_available(example)
+    dispatch = _dispatch_record(
+        recommended_action=recommended_action,
+        action_confidence=confidence,
+        min_action_confidence=min_action_confidence,
+        source_dependency=source_dependency,
+        source_context_available=source_context_available,
+        target_dependency=target_dependency,
+    )
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "case_type": DECISION_CASE_TYPE,
+        "example_id": str(example.get("example_id") or ""),
+        "case_id": str(source_case.get("case_id") or ""),
+        "source_case_type": str(source_case.get("case_type") or ""),
+        "split": str(example.get("split") or ""),
+        "action_router": {
+            "policy_name": POLICY_TINY_ACTION_MODEL,
+            "recommended_action": recommended_action,
+            "confidence": confidence,
+            "failure_hint": str(action_prediction.get("failure_hint") or ""),
+            "rule_reason": _action_rule_reason(action_prediction),
+            "target_action": str(targets.get("preferred_action") or ""),
+        },
+        "source_dependency_router": {
+            "policy_name": POLICY_SOURCE_DEPENDENCY_RULE,
+            "recommended_source_dependency": source_dependency,
+            "recommended_decision_basis": decision_basis,
+            "confidence": _float(source_prediction.confidence, default=0.0),
+            "rule_reason": str(source_prediction.rule_reason or ""),
+            "target_source_dependency": target_dependency,
+            "target_decision_basis": target_basis,
+        },
+        "dispatch": dispatch,
+    }
+
+
+def _dispatch_record(
+    *,
+    recommended_action: str,
+    action_confidence: float,
+    min_action_confidence: float,
+    source_dependency: str,
+    source_context_available: bool,
+    target_dependency: str,
+) -> dict[str, Any]:
+    fallback_reasons: list[str] = []
+    data_gap_tags: list[str] = []
+    if recommended_action == "fallback_to_agent":
+        fallback_reasons.append("action_fallback_to_agent")
+    if action_confidence < min_action_confidence:
+        fallback_reasons.append("low_action_confidence")
+        data_gap_tags.append("low_action_confidence")
+    if source_dependency == "required" and not source_context_available:
+        fallback_reasons.append("source_required_but_unavailable")
+        data_gap_tags.append("no_source_context_for_required_source")
+    if not target_dependency:
+        data_gap_tags.append("no_source_dependency_label")
+
+    fallback_agent = bool(fallback_reasons)
+    return {
+        "decision_owner": (
+            "fallback_agent"
+            if action_confidence < min_action_confidence
+            else "tiny_model"
+        ),
+        "execution_owner": "fallback_agent" if fallback_agent else "tiny_model",
+        "fallback_agent": fallback_agent,
+        "fallback_reasons": fallback_reasons,
+        "data_gap_tags": data_gap_tags,
+    }
+
+
+def _build_summary(decisions: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+    data_gap_counts: Counter[str] = Counter()
+    fallback_reason_counts: Counter[str] = Counter()
+    for decision in decisions:
+        dispatch = _mapping(decision.get("dispatch"))
+        data_gap_counts.update(dispatch.get("data_gap_tags") or [])
+        fallback_reason_counts.update(dispatch.get("fallback_reasons") or [])
+
+    return {
+        "decision_count": len(decisions),
+        "fallback_agent_count": sum(
+            1
+            for decision in decisions
+            if bool(_mapping(decision.get("dispatch")).get("fallback_agent"))
+        ),
+        "counts_by_recommended_action": _counter_by(
+            decisions,
+            lambda item: _mapping(item.get("action_router")).get(
+                "recommended_action"
+            ),
+        ),
+        "counts_by_source_dependency": _counter_by(
+            decisions,
+            lambda item: _mapping(item.get("source_dependency_router")).get(
+                "recommended_source_dependency"
+            ),
+        ),
+        "counts_by_decision_basis": _counter_by(
+            decisions,
+            lambda item: _mapping(item.get("source_dependency_router")).get(
+                "recommended_decision_basis"
+            ),
+        ),
+        "counts_by_execution_owner": _counter_by(
+            decisions,
+            lambda item: _mapping(item.get("dispatch")).get("execution_owner"),
+        ),
+        "fallback_reason_counts": dict(sorted(fallback_reason_counts.items())),
+        "data_gap_counts": dict(sorted(data_gap_counts.items())),
+    }
+
+
+def _build_evaluation(decisions: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+    action_total = 0
+    action_correct = 0
+    dependency_total = 0
+    dependency_correct = 0
+    basis_total = 0
+    basis_correct = 0
+    for decision in decisions:
+        action = _mapping(decision.get("action_router"))
+        source = _mapping(decision.get("source_dependency_router"))
+        target_action = str(action.get("target_action") or "")
+        if target_action:
+            action_total += 1
+            if str(action.get("recommended_action") or "") == target_action:
+                action_correct += 1
+        target_dependency = str(source.get("target_source_dependency") or "")
+        if target_dependency:
+            dependency_total += 1
+            if (
+                str(source.get("recommended_source_dependency") or "")
+                == target_dependency
+            ):
+                dependency_correct += 1
+        target_basis = str(source.get("target_decision_basis") or "")
+        if target_basis:
+            basis_total += 1
+            if str(source.get("recommended_decision_basis") or "") == target_basis:
+                basis_correct += 1
+    return {
+        "action_labeled_count": action_total,
+        "action_accuracy": _ratio(action_correct, action_total),
+        "source_dependency_labeled_count": dependency_total,
+        "source_dependency_accuracy": _ratio(dependency_correct, dependency_total),
+        "decision_basis_labeled_count": basis_total,
+        "decision_basis_accuracy": _ratio(basis_correct, basis_total),
+    }
+
+
+def _action_rule_reason(action_prediction: Mapping[str, Any]) -> str:
+    explanation = _mapping(action_prediction.get("explanation"))
+    fallback_reason = str(explanation.get("fallback_reason") or "")
+    return fallback_reason or str(action_prediction.get("source_policy") or "")
+
+
+def _source_context_available(example: Mapping[str, Any]) -> bool:
+    source_context = _mapping(example.get("source_context"))
+    if isinstance(source_context.get("available"), bool):
+        return bool(source_context.get("available"))
+    if int(source_context.get("source_artifact_available_count") or 0) > 0:
+        return True
+    return bool(source_context.get("source_image_available"))
+
+
+def _counter_by(
+    decisions: Iterable[Mapping[str, Any]],
+    getter: Any,
+) -> dict[str, int]:
+    counts: Counter[str] = Counter()
+    for decision in decisions:
+        value = str(getter(decision) or "unknown")
+        counts[value] += 1
+    return dict(sorted(counts.items()))
+
+
+def _write_jsonl(path: str | Path, records: Sequence[Mapping[str, Any]]) -> None:
+    output = Path(path)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    with output.open("w", encoding="utf-8") as fh:
+        for record in records:
+            fh.write(json.dumps(dict(record), sort_keys=True, separators=(",", ":")))
+            fh.write("\n")
+
+
+def _ratio(numerator: int, denominator: int) -> float | None:
+    if denominator <= 0:
+        return None
+    return round(float(numerator) / float(denominator), 6)
+
+
+def _resolve_optional_repo_path(root: Path, path: str | Path | None) -> Path | None:
+    if not path:
+        return None
+    resolved = Path(path)
+    if resolved.is_absolute():
+        return resolved
+    return root / resolved
+
+
+def _validate_split(value: str, *, label: str) -> None:
+    if value not in DATASET_SPLITS:
+        raise ValueError(f"unsupported {label} {value!r}; expected one of {DATASET_SPLITS}")
+
+
+def _float(value: Any, *, default: float) -> float:
+    if value is None:
+        return default
+    return float(value)
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    if isinstance(value, Mapping):
+        return value
+    return {}

--- a/src/vulca/learning/source_dependency_eval.py
+++ b/src/vulca/learning/source_dependency_eval.py
@@ -258,6 +258,13 @@ def evaluate_source_dependency_policy(
     }
 
 
+def predict_source_dependency_for_example(
+    example: Mapping[str, Any],
+) -> SourceDependencyPrediction:
+    """Predict source dependency for one example using the stable rule policy."""
+    return _rule_prediction(example)
+
+
 def build_source_dependency_comparison_report(
     examples: Iterable[Mapping[str, Any]],
     *,

--- a/tests/test_dry_run_decision_router.py
+++ b/tests/test_dry_run_decision_router.py
@@ -1,0 +1,249 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+CLI_ENV = dict(
+    os.environ,
+    PYTHONPATH=str(ROOT / "src") + os.pathsep + os.environ.get("PYTHONPATH", ""),
+)
+
+
+def _example(
+    case_id: str,
+    *,
+    split: str,
+    case_type: str = "layer_generate_case",
+    failure_type: str = "style_drift",
+    preferred_action: str = "adjust_prompt",
+    source_dependency: str = "required",
+    source_decision_basis: str = "artifact_source",
+    source_context_available: bool = False,
+    action_hint: str = "",
+) -> dict:
+    quality = {
+        "gate_passed": not bool(failure_type),
+        "failures": [failure_type] if failure_type else [],
+    }
+    case_record = {
+        "case_type": case_type,
+        "case_id": case_id,
+        "quality": quality,
+    }
+    if action_hint:
+        case_record["decisions"] = {
+            "fallback_decisions": [{"suggested_action": action_hint}]
+        }
+    return {
+        "schema_version": 1,
+        "case_type": "learning_tiny_dataset_example",
+        "example_id": f"example_{case_id}",
+        "split": split,
+        "source": {
+            "kind": "user_case_log",
+            "source_id": "unit_cases",
+            "privacy_scope": "private",
+            "curation_status": "reviewed",
+        },
+        "source_case": {
+            "case_id": case_id,
+            "case_type": case_type,
+        },
+        "input": {"case_record": case_record},
+        "targets": {
+            "failure_type": failure_type,
+            "preferred_action": preferred_action,
+            "source_dependency": source_dependency,
+            "source_decision_basis": source_decision_basis,
+        },
+        "source_context": {
+            "available": source_context_available,
+            "source_artifact_available_count": 1 if source_context_available else 0,
+            "source_image_available": source_context_available,
+        },
+    }
+
+
+def test_dry_run_decisions_combine_action_source_dependency_and_dispatch():
+    from vulca.learning.dry_run_decision_router import build_dry_run_decisions
+
+    examples = [
+        _example("train_style", split="train"),
+        _example(
+            "train_provider",
+            split="train",
+            failure_type="provider_failure",
+            preferred_action="fallback_to_agent",
+            source_dependency="not_needed",
+            source_decision_basis="metadata_only",
+            action_hint="fallback_to_agent",
+        ),
+        _example("test_style_missing_source", split="test"),
+        _example(
+            "test_provider_failure",
+            split="test",
+            failure_type="provider_failure",
+            preferred_action="fallback_to_agent",
+            source_dependency="not_needed",
+            source_decision_basis="metadata_only",
+            action_hint="fallback_to_agent",
+        ),
+        _example(
+            "test_decompose_source_available",
+            split="test",
+            case_type="decompose_case",
+            failure_type="under_segmentation",
+            preferred_action="split_layer_further",
+            source_dependency="required",
+            source_decision_basis="image_source",
+            source_context_available=True,
+        ),
+    ]
+
+    decisions = build_dry_run_decisions(
+        examples,
+        eval_split="test",
+        train_split="train",
+    )
+
+    by_case = {item["case_id"]: item for item in decisions}
+    assert set(by_case) == {
+        "test_style_missing_source",
+        "test_provider_failure",
+        "test_decompose_source_available",
+    }
+
+    style = by_case["test_style_missing_source"]
+    assert style["action_router"]["policy_name"] == "tiny_action_model_v1"
+    assert style["action_router"]["recommended_action"] == "adjust_prompt"
+    assert style["source_dependency_router"] == {
+        "policy_name": "source_dependency_rule_v1",
+        "recommended_source_dependency": "required",
+        "recommended_decision_basis": "artifact_source",
+        "confidence": 0.8,
+        "rule_reason": "layer_generate_source_artifact_judgement",
+        "target_source_dependency": "required",
+        "target_decision_basis": "artifact_source",
+    }
+    assert style["dispatch"]["decision_owner"] == "tiny_model"
+    assert style["dispatch"]["execution_owner"] == "fallback_agent"
+    assert style["dispatch"]["fallback_agent"] is True
+    assert style["dispatch"]["fallback_reasons"] == [
+        "source_required_but_unavailable"
+    ]
+    assert style["dispatch"]["data_gap_tags"] == [
+        "no_source_context_for_required_source"
+    ]
+
+    provider = by_case["test_provider_failure"]
+    assert provider["action_router"]["recommended_action"] == "fallback_to_agent"
+    assert provider["source_dependency_router"]["recommended_source_dependency"] == (
+        "not_needed"
+    )
+    assert provider["source_dependency_router"]["recommended_decision_basis"] == (
+        "metadata_only"
+    )
+    assert provider["dispatch"]["fallback_reasons"] == ["action_fallback_to_agent"]
+    assert provider["dispatch"]["data_gap_tags"] == []
+
+    decompose = by_case["test_decompose_source_available"]
+    assert decompose["action_router"]["recommended_action"] == "split_layer_further"
+    assert decompose["source_dependency_router"]["recommended_decision_basis"] == (
+        "image_source"
+    )
+    assert decompose["dispatch"]["fallback_agent"] is False
+    assert decompose["dispatch"]["execution_owner"] == "tiny_model"
+
+
+def test_dry_run_router_report_summarizes_counts_and_evaluation():
+    from vulca.learning.dry_run_decision_router import build_dry_run_router_report
+
+    examples = [
+        _example("train_style", split="train"),
+        _example("test_style_missing_source", split="test"),
+        _example(
+            "test_decompose_source_available",
+            split="test",
+            case_type="decompose_case",
+            failure_type="under_segmentation",
+            preferred_action="split_layer_further",
+            source_dependency="required",
+            source_decision_basis="image_source",
+            source_context_available=True,
+        ),
+    ]
+
+    report = build_dry_run_router_report(
+        examples,
+        eval_split="test",
+        train_split="train",
+    )
+
+    assert report["case_type"] == "learning_dry_run_decision_router_report"
+    assert report["summary"]["decision_count"] == 2
+    assert report["summary"]["fallback_agent_count"] == 1
+    assert report["summary"]["counts_by_recommended_action"] == {
+        "adjust_prompt": 1,
+        "split_layer_further": 1,
+    }
+    assert report["summary"]["counts_by_source_dependency"] == {"required": 2}
+    assert report["summary"]["data_gap_counts"] == {
+        "no_source_context_for_required_source": 1
+    }
+    assert report["evaluation"]["action_accuracy"] == 1.0
+    assert report["evaluation"]["source_dependency_accuracy"] == 1.0
+    assert report["evaluation"]["decision_basis_accuracy"] == 1.0
+
+
+def test_dry_run_decision_router_cli_writes_real_dataset_report(tmp_path):
+    output_dir = tmp_path / "decision_router"
+    report_path = tmp_path / "decision_router_report.json"
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(ROOT / "scripts/dry_run_decision_router.py"),
+            "--repo-root",
+            str(ROOT),
+            "--output-dir",
+            str(output_dir),
+            "--report",
+            str(report_path),
+            "--case-source-manifest",
+            str(ROOT / "docs/benchmarks/learning/combined_case_source_manifest_v1.json"),
+            "--source-dependency-manifest",
+            str(
+                ROOT
+                / "docs/benchmarks/learning/real_source_dependency_label_manifest_v1.json"
+            ),
+            "--split",
+            "test",
+        ],
+        cwd=ROOT,
+        env=CLI_ENV,
+        text=True,
+        capture_output=True,
+        timeout=30,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "Dry-run decision router report:" in result.stdout
+    assert "Decisions: 21" in result.stdout
+    assert "tiny_action_model_v1 action_accuracy: 1.0" in result.stdout
+    assert "source_dependency_rule_v1 source_dependency_accuracy:" in result.stdout
+    assert (output_dir / "dry_run_decisions.jsonl").exists()
+    assert report_path.exists()
+
+    report = json.loads(report_path.read_text(encoding="utf-8"))
+    assert report["summary"]["decision_count"] == 21
+    assert report["summary"]["counts_by_source_dependency"]["required"] > 0
+    assert report["evaluation"]["action_accuracy"] == 1.0
+    assert report["artifacts"]["decision_path"] == str(
+        output_dir / "dry_run_decisions.jsonl"
+    )


### PR DESCRIPTION
## Summary
- add provider-free dry-run decision router combining tiny_action_model_v1 action decisions with source_dependency_rule_v1 source-dependency decisions
- emit per-case dry-run decisions with action_router, source_dependency_router, dispatch fallback reasons, and data-gap tags
- add CLI to export dataset, decisions JSONL, and report summary
- expose source_dependency rule prediction through a public helper

## Smoke result
- Decisions: 21
- Fallback agent decisions: 21
- tiny_action_model_v1 action_accuracy: 1.0
- source_dependency_rule_v1 source_dependency_accuracy: 1.0
- source_dependency_rule_v1 decision_basis_accuracy: 1.0
- Data gap tags: {'low_action_confidence': 1, 'no_source_context_for_required_source': 19, 'no_source_dependency_label': 18}

## Verification
- PYTHONPATH=src python3 -m pytest tests/test_dry_run_decision_router.py -q
- PYTHONPATH=src python3 -m pytest tests/test_dry_run_decision_router.py tests/test_source_dependency_eval.py tests/test_training_effectiveness_report.py tests/test_tiny_action_model.py -q
- PYTHONPATH=src python3 scripts/dry_run_decision_router.py --repo-root . --output-dir build/dry_run_decision_router_v1 --report build/dry_run_decision_router_v1/report.json --case-source-manifest docs/benchmarks/learning/combined_case_source_manifest_v1.json --source-dependency-manifest docs/benchmarks/learning/real_source_dependency_label_manifest_v1.json --split test
- python3 -m py_compile src/vulca/learning/dry_run_decision_router.py src/vulca/learning/source_dependency_eval.py scripts/dry_run_decision_router.py tests/test_dry_run_decision_router.py
- /opt/homebrew/bin/ruff check src/vulca/learning/dry_run_decision_router.py src/vulca/learning/source_dependency_eval.py scripts/dry_run_decision_router.py tests/test_dry_run_decision_router.py
- git diff --check
