### PR TITLE
Route dry runs with source context signals

### DIFF
--- a/scripts/dry_run_decision_router.py
+++ b/scripts/dry_run_decision_router.py
@@ -58,6 +58,11 @@ def main(argv: Sequence[str] | None = None) -> int:
         help="Reviewed source-dependency label manifest.",
     )
     parser.add_argument(
+        "--auxiliary-signal-manifest",
+        default="",
+        help="Reviewed promoted auxiliary signal manifest to attach to the dataset.",
+    )
+    parser.add_argument(
         "--no-local-seeds",
         action="store_true",
         help="Only export records from the case source manifest.",
@@ -94,6 +99,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             report_path=args.report or None,
             case_source_manifest_path=args.case_source_manifest,
             source_dependency_manifest_path=args.source_dependency_manifest,
+            auxiliary_signal_manifest_path=args.auxiliary_signal_manifest or None,
             include_local_seeds=not args.no_local_seeds,
             eval_split=args.split,
             train_split=args.train_split,

--- a/src/vulca/learning/dry_run_decision_router.py
+++ b/src/vulca/learning/dry_run_decision_router.py
@@ -42,6 +42,7 @@ def run_dry_run_decision_router(
     case_log_paths: Sequence[str | Path] = (),
     case_source_manifest_path: str | Path | None = DEFAULT_CASE_SOURCE_MANIFEST,
     source_dependency_manifest_path: str | Path | None = DEFAULT_SOURCE_DEPENDENCY_MANIFEST,
+    auxiliary_signal_manifest_path: str | Path | None = None,
     include_local_seeds: bool = True,
     eval_split: str = "test",
     train_split: str = "train",
@@ -66,6 +67,10 @@ def run_dry_run_decision_router(
         root,
         source_dependency_manifest_path,
     )
+    resolved_auxiliary_signal_manifest = _resolve_optional_repo_path(
+        root,
+        auxiliary_signal_manifest_path,
+    )
 
     dataset_result = write_tiny_dataset(
         repo_root=root,
@@ -74,6 +79,7 @@ def run_dry_run_decision_router(
         case_log_paths=case_log_paths,
         case_source_manifest_path=resolved_case_source_manifest,
         source_dependency_manifest_path=resolved_source_dependency_manifest,
+        auxiliary_signal_manifest_path=resolved_auxiliary_signal_manifest,
         include_local_seeds=include_local_seeds,
     )
     examples = load_tiny_dataset_examples(dataset_path)
@@ -95,6 +101,9 @@ def run_dry_run_decision_router(
             "case_source_manifest_path": str(resolved_case_source_manifest or ""),
             "source_dependency_manifest_path": str(
                 resolved_source_dependency_manifest or ""
+            ),
+            "auxiliary_signal_manifest_path": str(
+                resolved_auxiliary_signal_manifest or ""
             ),
             "include_local_seeds": bool(include_local_seeds),
             "min_action_confidence": float(min_action_confidence),
@@ -183,13 +192,13 @@ def _decision_record(
     decision_basis = str(source_prediction.decision_basis or "")
     target_dependency = str(targets.get("source_dependency") or "")
     target_basis = str(targets.get("source_decision_basis") or "")
-    source_context_available = _source_context_available(example)
+    source_context = _source_context_summary(example)
     dispatch = _dispatch_record(
         recommended_action=recommended_action,
         action_confidence=confidence,
         min_action_confidence=min_action_confidence,
         source_dependency=source_dependency,
-        source_context_available=source_context_available,
+        source_context_available=bool(source_context["available"]),
         target_dependency=target_dependency,
     )
 
@@ -217,6 +226,7 @@ def _decision_record(
             "target_source_dependency": target_dependency,
             "target_decision_basis": target_basis,
         },
+        "source_context": source_context,
         "dispatch": dispatch,
     }
 
@@ -343,13 +353,81 @@ def _action_rule_reason(action_prediction: Mapping[str, Any]) -> str:
     return fallback_reason or str(action_prediction.get("source_policy") or "")
 
 
-def _source_context_available(example: Mapping[str, Any]) -> bool:
+def _source_context_summary(example: Mapping[str, Any]) -> dict[str, Any]:
     source_context = _mapping(example.get("source_context"))
     if isinstance(source_context.get("available"), bool):
-        return bool(source_context.get("available"))
+        available = bool(source_context.get("available"))
+        if available:
+            return {
+                "available": True,
+                "source": "source_context",
+                "signal_count": 0,
+            }
     if int(source_context.get("source_artifact_available_count") or 0) > 0:
-        return True
-    return bool(source_context.get("source_image_available"))
+        return {
+            "available": True,
+            "source": "source_context",
+            "signal_count": 0,
+        }
+    if bool(source_context.get("source_image_available")):
+        return {
+            "available": True,
+            "source": "source_context",
+            "signal_count": 0,
+        }
+
+    signal_count = _source_context_auxiliary_signal_count(example)
+    if signal_count:
+        return {
+            "available": True,
+            "source": "auxiliary_signal",
+            "signal_count": signal_count,
+        }
+    return {
+        "available": False,
+        "source": "",
+        "signal_count": 0,
+    }
+
+
+def _source_context_auxiliary_signal_count(example: Mapping[str, Any]) -> int:
+    input_block = _mapping(example.get("input"))
+    signals = input_block.get("auxiliary_signals")
+    if not isinstance(signals, Sequence) or isinstance(signals, (str, bytes)):
+        return 0
+    count = 0
+    for signal in signals:
+        if not isinstance(signal, Mapping):
+            continue
+        if not _is_promoted_source_context_signal(signal):
+            continue
+        signal_payload = _mapping(signal.get("signals"))
+        source_image = _mapping(signal_payload.get("source_image"))
+        source_artifacts = _mapping(signal_payload.get("source_artifacts"))
+        tags = signal_payload.get("source_context_tags")
+        has_tags = isinstance(tags, Sequence) and not isinstance(tags, (str, bytes)) and bool(tags)
+        if (
+            bool(source_image.get("available"))
+            or int(source_artifacts.get("available_count") or 0) > 0
+            or bool(source_artifacts.get("artifact_kind_counts"))
+            or has_tags
+        ):
+            count += 1
+    return count
+
+
+def _is_promoted_source_context_signal(signal: Mapping[str, Any]) -> bool:
+    training_use = _mapping(signal.get("training_use"))
+    if not bool(training_use.get("approved_for_auxiliary_training")):
+        return False
+    if str(training_use.get("review_status") or "") != "reviewed_promoted":
+        return False
+    signal_payload = _mapping(signal.get("signals"))
+    if str(signal_payload.get("status") or "") != "completed":
+        return False
+    model_id = str(_mapping(signal.get("model")).get("id") or "")
+    signal_source = str(signal_payload.get("signal_source") or "")
+    return model_id == "source_context_static_v1" or signal_source == "source_context_static"
 
 
 def _counter_by(

--- a/tests/test_dry_run_decision_router.py
+++ b/tests/test_dry_run_decision_router.py
@@ -69,6 +69,27 @@ def _example(
     }
 
 
+def _source_context_signal(example_id: str) -> dict:
+    return {
+        "signal_id": f"source_context_{example_id}",
+        "model": {"id": "source_context_static_v1"},
+        "signals": {
+            "status": "completed",
+            "signal_source": "source_context_static",
+            "source_context_tags": ["source_artifact:present"],
+            "source_image": {"available": False},
+            "source_artifacts": {
+                "available_count": 1,
+                "artifact_kind_counts": {"file": 1},
+            },
+        },
+        "training_use": {
+            "approved_for_auxiliary_training": True,
+            "review_status": "reviewed_promoted",
+        },
+    }
+
+
 def test_dry_run_decisions_combine_action_source_dependency_and_dispatch():
     from vulca.learning.dry_run_decision_router import build_dry_run_decisions
 
@@ -160,6 +181,38 @@ def test_dry_run_decisions_combine_action_source_dependency_and_dispatch():
     assert decompose["dispatch"]["execution_owner"] == "tiny_model"
 
 
+def test_dry_run_decisions_treat_auxiliary_source_context_signal_as_available():
+    from vulca.learning.dry_run_decision_router import build_dry_run_decisions
+
+    train = _example("train_style", split="train")
+    test = _example("test_style_aux_source_context", split="test")
+    test["source_context"] = {
+        "available": False,
+        "source_artifact_available_count": 0,
+        "source_image_available": False,
+    }
+    test["input"]["auxiliary_signals"] = [
+        _source_context_signal("example_test_style_aux_source_context")
+    ]
+
+    decisions = build_dry_run_decisions(
+        [train, test],
+        eval_split="test",
+        train_split="train",
+    )
+
+    assert len(decisions) == 1
+    dispatch = decisions[0]["dispatch"]
+    assert dispatch["fallback_agent"] is False
+    assert dispatch["fallback_reasons"] == []
+    assert dispatch["data_gap_tags"] == []
+    assert decisions[0]["source_context"] == {
+        "available": True,
+        "source": "auxiliary_signal",
+        "signal_count": 1,
+    }
+
+
 def test_dry_run_router_report_summarizes_counts_and_evaluation():
     from vulca.learning.dry_run_decision_router import build_dry_run_router_report
 
@@ -221,6 +274,8 @@ def test_dry_run_decision_router_cli_writes_real_dataset_report(tmp_path):
                 ROOT
                 / "docs/benchmarks/learning/real_source_dependency_label_manifest_v1.json"
             ),
+            "--auxiliary-signal-manifest",
+            "",
             "--split",
             "test",
         ],


### PR DESCRIPTION
## Summary
- allow dry-run decision router to attach promoted auxiliary signal manifests during dataset export
- treat reviewed source-context auxiliary signals as source context availability
- include source_context availability summary in per-case dry-run decisions
- add tests for auxiliary source-context availability and CLI argument support

## Smoke result
With generated source context signal manifest:
- Source context signals: 18/50
- Decisions: 21
- Fallback agent decisions: 17
- no_source_context_for_required_source: 15
- tiny_action_model_v1 action_accuracy: 1.0
- source_dependency_rule_v1 source_dependency_accuracy: 1.0
- source_dependency_rule_v1 decision_basis_accuracy: 1.0

Compared with #100 dry-run without source-context signals:
- Fallback agent decisions improved from 21 -> 17
- no_source_context_for_required_source improved from 19 -> 15

## Verification
- PYTHONPATH=src python3 -m pytest tests/test_dry_run_decision_router.py tests/test_source_context_signals.py tests/test_tiny_dataset_export.py tests/test_tiny_action_model.py -q
- PYTHONPATH=src python3 scripts/source_context_signals.py --repo-root . --case-source-manifest docs/benchmarks/learning/combined_case_source_manifest_v1.json --output build/source_context_router_v1/source_context_signals.promoted.jsonl --manifest build/source_context_router_v1/source_context_signal_promotion_manifest.json --report build/source_context_router_v1/source_context_signal_report.json
- PYTHONPATH=src python3 scripts/dry_run_decision_router.py --repo-root . --output-dir build/source_context_router_v1/dry_run --report build/source_context_router_v1/dry_run/report.json --case-source-manifest docs/benchmarks/learning/combined_case_source_manifest_v1.json --source-dependency-manifest docs/benchmarks/learning/real_source_dependency_label_manifest_v1.json --auxiliary-signal-manifest build/source_context_router_v1/source_context_signal_promotion_manifest.json --split test
- python3 -m py_compile src/vulca/learning/dry_run_decision_router.py scripts/dry_run_decision_router.py tests/test_dry_run_decision_router.py
- /opt/homebrew/bin/ruff check src/vulca/learning/dry_run_decision_router.py scripts/dry_run_decision_router.py tests/test_dry_run_decision_router.py
- git diff --check origin/master..HEAD