### PR TITLE
Add real source context recovery eval

### DIFF
--- a/scripts/real_source_context_recovery_eval.py
+++ b/scripts/real_source_context_recovery_eval.py
@@ -1,0 +1,184 @@
+"""Evaluate dry-run impact from recovered real-user source context."""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Sequence
+
+
+ROOT = Path(__file__).resolve().parent.parent
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from vulca.learning.real_source_context_recovery_eval import (  # noqa: E402
+    DEFAULT_COMBINED_CASE_SOURCE_MANIFEST,
+    DEFAULT_OUTPUT_DIR,
+    run_real_source_context_recovery_eval,
+)
+from vulca.learning.tiny_dataset import DATASET_SPLITS  # noqa: E402
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Recover local private source context, generate source-context "
+            "signals, and compare dry-run routing before and after recovery."
+        )
+    )
+    parser.add_argument(
+        "--repo-root",
+        default=str(ROOT),
+        help="Repository root used to resolve case source refs.",
+    )
+    parser.add_argument(
+        "--case-source-manifest",
+        default=str(DEFAULT_COMBINED_CASE_SOURCE_MANIFEST),
+        help="Case source manifest JSON path.",
+    )
+    parser.add_argument(
+        "--artifact-search-root",
+        action="append",
+        default=[],
+        help="Local directory to search for private source artifact directories/files.",
+    )
+    parser.add_argument(
+        "--image-search-root",
+        action="append",
+        default=[],
+        help="Local directory to search for private source images.",
+    )
+    parser.add_argument(
+        "--artifact-filename-alias",
+        action="append",
+        default=[],
+        metavar="PRIVATE_BASENAME=LOCAL_BASENAME",
+        help="Private source artifact basename alias. Repeat as needed.",
+    )
+    parser.add_argument(
+        "--image-filename-alias",
+        action="append",
+        default=[],
+        metavar="PRIVATE_BASENAME=LOCAL_BASENAME",
+        help="Private source image basename alias. Repeat as needed.",
+    )
+    parser.add_argument(
+        "--source-dependency-manifest",
+        default="",
+        help="Optional reviewed source-dependency label manifest.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        default=str(DEFAULT_OUTPUT_DIR),
+        help=f"Output directory for recovery eval artifacts (default: {DEFAULT_OUTPUT_DIR}).",
+    )
+    parser.add_argument(
+        "--report",
+        default="",
+        help=(
+            "Summary report path "
+            "(default: OUTPUT_DIR/real_source_context_recovery_eval_report.json)."
+        ),
+    )
+    parser.add_argument(
+        "--no-local-seeds",
+        action="store_true",
+        help="Do not include local seed cases in the eval dataset.",
+    )
+    parser.add_argument(
+        "--split",
+        default="test",
+        choices=DATASET_SPLITS,
+        help="Dataset split to compare.",
+    )
+    parser.add_argument(
+        "--train-split",
+        default="train",
+        choices=DATASET_SPLITS,
+        help="Dataset split used to fit train-derived tiny policies.",
+    )
+    parser.add_argument(
+        "--pretty",
+        action="store_true",
+        help="Print the full safe JSON report to stdout after writing it.",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        report = run_real_source_context_recovery_eval(
+            repo_root=args.repo_root,
+            case_source_manifest_path=args.case_source_manifest,
+            artifact_search_roots=args.artifact_search_root,
+            image_search_roots=args.image_search_root,
+            artifact_filename_aliases=_parse_aliases(args.artifact_filename_alias),
+            image_filename_aliases=_parse_aliases(args.image_filename_alias),
+            source_dependency_manifest_path=args.source_dependency_manifest or None,
+            output_dir=args.output_dir,
+            report_path=args.report or None,
+            include_local_seeds=not args.no_local_seeds,
+            eval_split=args.split,
+            train_split=args.train_split,
+        )
+    except (ValueError, FileNotFoundError, json.JSONDecodeError, OSError) as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 2
+
+    if args.pretty:
+        print(json.dumps(report, indent=2, sort_keys=True))
+
+    baseline = report["baseline"]
+    recovered = report["recovered"]
+    delta = report["delta"]
+    print(f"Real source-context recovery eval: {report['artifacts']['report_path']}")
+    print(
+        "Source context signals: "
+        f"{baseline['source_context_signal_count']} -> "
+        f"{recovered['source_context_signal_count']} "
+        f"(delta {delta['source_context_signal_count']})"
+    )
+    print(
+        "Dry-run fallback_agent_count: "
+        f"{baseline['fallback_agent_count']} -> "
+        f"{recovered['fallback_agent_count']} "
+        f"(reduction {delta['fallback_agent_count_reduction']})"
+    )
+    baseline_gap = baseline["data_gap_counts"].get(
+        "no_source_context_for_required_source",
+        0,
+    )
+    recovered_gap = recovered["data_gap_counts"].get(
+        "no_source_context_for_required_source",
+        0,
+    )
+    print(
+        "Dry-run no_source_context_for_required_source: "
+        f"{baseline_gap} -> {recovered_gap} "
+        f"(reduction {delta['no_source_context_for_required_source_reduction']})"
+    )
+    print(f"Recovered eval cases: {report['recovered_eval_case_count']}")
+    print(f"Status: {report['status']}")
+    return 0
+
+
+def _parse_aliases(values: Sequence[str]) -> dict[str, str]:
+    aliases: dict[str, str] = {}
+    for value in values:
+        if "=" not in value:
+            raise ValueError(
+                f"filename alias must use PRIVATE_BASENAME=LOCAL_BASENAME: {value!r}"
+            )
+        source_name, local_name = value.split("=", 1)
+        source_name = source_name.strip()
+        local_name = local_name.strip()
+        if not source_name or not local_name:
+            raise ValueError(
+                f"filename alias must use PRIVATE_BASENAME=LOCAL_BASENAME: {value!r}"
+            )
+        aliases[source_name] = local_name
+    return aliases
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/vulca/learning/real_source_context_recovery_eval.py
+++ b/src/vulca/learning/real_source_context_recovery_eval.py
@@ -1,0 +1,367 @@
+"""Evaluate dry-run impact from recovered real-user source context."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+from vulca.learning.dry_run_decision_router import run_dry_run_decision_router
+from vulca.learning.real_source_context_recovery_audit import (
+    DEFAULT_COMBINED_CASE_SOURCE_MANIFEST,
+    run_real_source_context_recovery_audit,
+)
+from vulca.learning.source_context_signals import write_source_context_signal_pack
+from vulca.learning.tiny_dataset import DATASET_SPLITS
+
+
+SCHEMA_VERSION = 1
+REPORT_CASE_TYPE = "learning_real_source_context_recovery_eval_report"
+DEFAULT_OUTPUT_DIR = Path("build/real_source_context_recovery_eval")
+DEFAULT_REPORT_NAME = "real_source_context_recovery_eval_report.json"
+BASELINE_DIR_NAME = "baseline"
+RECOVERED_DIR_NAME = "recovered"
+RECOVERY_DIR_NAME = "recovery"
+SOURCE_CONTEXT_GAP_TAG = "no_source_context_for_required_source"
+
+
+def run_real_source_context_recovery_eval(
+    *,
+    repo_root: str | Path,
+    case_source_manifest_path: str | Path = DEFAULT_COMBINED_CASE_SOURCE_MANIFEST,
+    artifact_search_roots: Sequence[str | Path],
+    image_search_roots: Sequence[str | Path],
+    artifact_filename_aliases: Mapping[str, str] | None = None,
+    image_filename_aliases: Mapping[str, str] | None = None,
+    output_dir: str | Path = DEFAULT_OUTPUT_DIR,
+    report_path: str | Path | None = None,
+    source_dependency_manifest_path: str | Path | None = None,
+    include_local_seeds: bool = True,
+    eval_split: str = "test",
+    train_split: str = "train",
+) -> dict[str, Any]:
+    """Recover private source context and compare dry-run routing before/after."""
+    _validate_split(eval_split, label="eval_split")
+    _validate_split(train_split, label="train_split")
+
+    root = Path(repo_root).resolve()
+    output = Path(output_dir)
+    output.mkdir(parents=True, exist_ok=True)
+    resolved_report_path = Path(report_path) if report_path else output / DEFAULT_REPORT_NAME
+
+    baseline = _run_signal_router_pair(
+        repo_root=root,
+        output_dir=output / BASELINE_DIR_NAME,
+        case_source_manifest_path=case_source_manifest_path,
+        private_asset_map_paths=(),
+        source_dependency_manifest_path=source_dependency_manifest_path,
+        include_local_seeds=include_local_seeds,
+        eval_split=eval_split,
+        train_split=train_split,
+    )
+    recovery_output = output / RECOVERY_DIR_NAME
+    recovery_report = run_real_source_context_recovery_audit(
+        repo_root=root,
+        case_source_manifest_path=case_source_manifest_path,
+        artifact_search_roots=artifact_search_roots,
+        image_search_roots=image_search_roots,
+        artifact_filename_aliases=artifact_filename_aliases,
+        image_filename_aliases=image_filename_aliases,
+        output_dir=recovery_output,
+        include_local_seeds=include_local_seeds,
+        train_split=train_split,
+    )
+    recovery_artifacts = _mapping(recovery_report.get("artifacts"))
+    private_asset_maps = (
+        recovery_output / str(recovery_artifacts["source_artifact_private_asset_map_path"]),
+        recovery_output / str(recovery_artifacts["source_image_private_asset_map_path"]),
+    )
+    recovered = _run_signal_router_pair(
+        repo_root=root,
+        output_dir=output / RECOVERED_DIR_NAME,
+        case_source_manifest_path=case_source_manifest_path,
+        private_asset_map_paths=private_asset_maps,
+        source_dependency_manifest_path=source_dependency_manifest_path,
+        include_local_seeds=include_local_seeds,
+        eval_split=eval_split,
+        train_split=train_split,
+    )
+
+    recovered_eval_cases = _recovered_eval_cases(
+        baseline["decision_records"],
+        recovered["decision_records"],
+    )
+    delta = _delta(baseline, recovered)
+    report = {
+        "schema_version": SCHEMA_VERSION,
+        "case_type": REPORT_CASE_TYPE,
+        "status": _status(delta, recovered_eval_cases),
+        "inputs": {
+            "repo_root": root.name,
+            "case_source_manifest_path": _safe_path(root, case_source_manifest_path),
+            "artifact_search_root_count": len(artifact_search_roots),
+            "image_search_root_count": len(image_search_roots),
+            "artifact_filename_alias_count": len(artifact_filename_aliases or {}),
+            "image_filename_alias_count": len(image_filename_aliases or {}),
+            "source_dependency_manifest_path": _safe_path(
+                root,
+                source_dependency_manifest_path,
+            )
+            if source_dependency_manifest_path
+            else "",
+            "include_local_seeds": bool(include_local_seeds),
+            "eval_split": eval_split,
+            "train_split": train_split,
+        },
+        "artifacts": {
+            "report_path": _artifact_name(resolved_report_path, output),
+            "recovery_report_path": str(
+                Path(RECOVERY_DIR_NAME)
+                / str(recovery_artifacts.get("report_path") or "")
+            ),
+            "baseline_source_context_signal_report_path": str(
+                Path(BASELINE_DIR_NAME)
+                / "source_context"
+                / "source_context_signal_report.json"
+            ),
+            "baseline_dry_run_report_path": str(
+                Path(BASELINE_DIR_NAME) / "dry_run" / "report.json"
+            ),
+            "recovered_source_context_signal_report_path": str(
+                Path(RECOVERED_DIR_NAME)
+                / "source_context"
+                / "source_context_signal_report.json"
+            ),
+            "recovered_dry_run_report_path": str(
+                Path(RECOVERED_DIR_NAME) / "dry_run" / "report.json"
+            ),
+        },
+        "recovery": _compact_recovery(recovery_report),
+        "baseline": _compact_run(baseline),
+        "recovered": _compact_run(recovered),
+        "delta": delta,
+        "recovered_eval_case_count": len(recovered_eval_cases),
+        "recovered_eval_cases": recovered_eval_cases,
+        "safe_handling": {
+            "private_asset_maps_contain_local_paths": True,
+            "do_not_commit_private_asset_maps": True,
+            "report_omits_local_paths": True,
+            "report_omits_private_refs": True,
+            "copies_raw_source_text": False,
+            "calls_model_provider": False,
+            "downloads_weights": False,
+        },
+    }
+    resolved_report_path.parent.mkdir(parents=True, exist_ok=True)
+    resolved_report_path.write_text(
+        json.dumps(report, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return report
+
+
+def _run_signal_router_pair(
+    *,
+    repo_root: Path,
+    output_dir: Path,
+    case_source_manifest_path: str | Path,
+    private_asset_map_paths: Sequence[str | Path],
+    source_dependency_manifest_path: str | Path | None,
+    include_local_seeds: bool,
+    eval_split: str,
+    train_split: str,
+) -> dict[str, Any]:
+    source_context_output = output_dir / "source_context"
+    signal_report = write_source_context_signal_pack(
+        repo_root=repo_root,
+        case_source_manifest_path=case_source_manifest_path,
+        private_asset_map_paths=private_asset_map_paths,
+        output_path=source_context_output / "source_context_signals.promoted.jsonl",
+        manifest_path=source_context_output
+        / "source_context_signal_promotion_manifest.json",
+        report_path=source_context_output / "source_context_signal_report.json",
+        include_local_seeds=include_local_seeds,
+    )
+    dry_run_output = output_dir / "dry_run"
+    dry_run_report = run_dry_run_decision_router(
+        repo_root=repo_root,
+        output_dir=dry_run_output,
+        report_path=dry_run_output / "report.json",
+        case_source_manifest_path=case_source_manifest_path,
+        source_dependency_manifest_path=source_dependency_manifest_path,
+        auxiliary_signal_manifest_path=source_context_output
+        / "source_context_signal_promotion_manifest.json",
+        include_local_seeds=include_local_seeds,
+        eval_split=eval_split,
+        train_split=train_split,
+    )
+    decision_records = _load_jsonl(
+        _mapping(dry_run_report.get("artifacts")).get("decision_path", "")
+    )
+    return {
+        "source_context_signal_report": signal_report,
+        "dry_run_report": dry_run_report,
+        "decision_records": decision_records,
+    }
+
+
+def _compact_recovery(recovery_report: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        "status": str(recovery_report.get("status") or ""),
+        "summary": dict(_mapping(recovery_report.get("summary"))),
+        "source_artifact_recovery": dict(
+            _mapping(recovery_report.get("source_artifact_recovery"))
+        ),
+        "source_image_recovery": dict(
+            _mapping(recovery_report.get("source_image_recovery"))
+        ),
+    }
+
+
+def _compact_run(run: Mapping[str, Any]) -> dict[str, Any]:
+    signal_summary = _mapping(
+        _mapping(run.get("source_context_signal_report")).get("summary")
+    )
+    dry_summary = _mapping(_mapping(run.get("dry_run_report")).get("summary"))
+    return {
+        "source_context_signal_count": int(
+            signal_summary.get("promoted_signal_count") or 0
+        ),
+        "source_context_signal_example_count": int(
+            signal_summary.get("example_count") or 0
+        ),
+        "fallback_agent_count": int(dry_summary.get("fallback_agent_count") or 0),
+        "data_gap_counts": dict(_mapping(dry_summary.get("data_gap_counts"))),
+    }
+
+
+def _delta(
+    baseline: Mapping[str, Any],
+    recovered: Mapping[str, Any],
+) -> dict[str, int]:
+    baseline_compact = _compact_run(baseline)
+    recovered_compact = _compact_run(recovered)
+    baseline_gap_count = _data_gap_count(baseline_compact)
+    recovered_gap_count = _data_gap_count(recovered_compact)
+    baseline_fallback = int(baseline_compact.get("fallback_agent_count") or 0)
+    recovered_fallback = int(recovered_compact.get("fallback_agent_count") or 0)
+    baseline_signal_count = int(
+        baseline_compact.get("source_context_signal_count") or 0
+    )
+    recovered_signal_count = int(
+        recovered_compact.get("source_context_signal_count") or 0
+    )
+    return {
+        "source_context_signal_count": recovered_signal_count - baseline_signal_count,
+        "fallback_agent_count": recovered_fallback - baseline_fallback,
+        "fallback_agent_count_reduction": baseline_fallback - recovered_fallback,
+        "no_source_context_for_required_source": recovered_gap_count
+        - baseline_gap_count,
+        "no_source_context_for_required_source_reduction": baseline_gap_count
+        - recovered_gap_count,
+    }
+
+
+def _recovered_eval_cases(
+    baseline_decisions: Sequence[Mapping[str, Any]],
+    recovered_decisions: Sequence[Mapping[str, Any]],
+) -> list[dict[str, Any]]:
+    recovered_by_example_id = {
+        str(item.get("example_id") or ""): item for item in recovered_decisions
+    }
+    rows: list[dict[str, Any]] = []
+    for baseline in baseline_decisions:
+        example_id = str(baseline.get("example_id") or "")
+        recovered = recovered_by_example_id.get(example_id)
+        if recovered is None:
+            continue
+        baseline_dispatch = _mapping(baseline.get("dispatch"))
+        recovered_dispatch = _mapping(recovered.get("dispatch"))
+        if not bool(baseline_dispatch.get("fallback_agent")):
+            continue
+        if bool(recovered_dispatch.get("fallback_agent")):
+            continue
+        rows.append(
+            {
+                "case_id": str(baseline.get("case_id") or ""),
+                "case_type": str(baseline.get("source_case_type") or ""),
+                "example_id": example_id,
+                "removed_data_gap_tags": _list_difference(
+                    baseline_dispatch.get("data_gap_tags"),
+                    recovered_dispatch.get("data_gap_tags"),
+                ),
+                "source_context": dict(_mapping(recovered.get("source_context"))),
+            }
+        )
+    return sorted(rows, key=lambda item: (item["case_type"], item["case_id"]))
+
+
+def _status(delta: Mapping[str, Any], recovered_eval_cases: Sequence[Mapping[str, Any]]) -> str:
+    if recovered_eval_cases and int(delta.get("fallback_agent_count_reduction") or 0) > 0:
+        return "recovered_source_context_improves_dry_run"
+    if int(delta.get("source_context_signal_count") or 0) > 0:
+        return "recovered_source_context_signals_no_dispatch_change"
+    return "needs_more_source_recovery"
+
+
+def _data_gap_count(compact_run: Mapping[str, Any]) -> int:
+    return int(
+        _mapping(compact_run.get("data_gap_counts")).get(
+            SOURCE_CONTEXT_GAP_TAG,
+        )
+        or 0
+    )
+
+
+def _load_jsonl(path: str | Path) -> list[dict[str, Any]]:
+    if not path:
+        return []
+    records: list[dict[str, Any]] = []
+    for line in Path(path).read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        item = json.loads(line)
+        if isinstance(item, Mapping):
+            records.append(dict(item))
+    return records
+
+
+def _list_difference(old_value: Any, new_value: Any) -> list[str]:
+    new_items = set(_string_list(new_value))
+    return [item for item in _string_list(old_value) if item not in new_items]
+
+
+def _string_list(value: Any) -> list[str]:
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes)):
+        return []
+    return [str(item) for item in value]
+
+
+def _safe_path(repo_root: Path, path: str | Path | None) -> str:
+    if not path:
+        return ""
+    value = Path(path)
+    if not value.is_absolute():
+        value = repo_root / value
+    try:
+        return str(value.relative_to(repo_root))
+    except ValueError:
+        return value.name
+
+
+def _artifact_name(path: str | Path, output_dir: str | Path) -> str:
+    value = Path(path)
+    try:
+        return str(value.relative_to(Path(output_dir)))
+    except ValueError:
+        return value.name
+
+
+def _validate_split(value: str, *, label: str) -> None:
+    if value not in DATASET_SPLITS:
+        raise ValueError(f"unsupported {label} {value!r}; expected one of {DATASET_SPLITS}")
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    if isinstance(value, Mapping):
+        return value
+    return {}

--- a/tests/test_real_source_context_recovery_eval.py
+++ b/tests/test_real_source_context_recovery_eval.py
@@ -1,0 +1,243 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+CLI_ENV = dict(
+    os.environ,
+    PYTHONPATH=str(ROOT / "src") + os.pathsep + os.environ.get("PYTHONPATH", ""),
+)
+SCRIPT = ROOT / "scripts" / "real_source_context_recovery_eval.py"
+
+
+def _write_jsonl(path: Path, records: list[dict]) -> None:
+    path.write_text(
+        "\n".join(json.dumps(record, sort_keys=True) for record in records) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _case(case_id: str, *, source_ref: str, preferred_split: str = "") -> dict:
+    record = {
+        "schema_version": 1,
+        "case_type": "layer_generate_case",
+        "case_id": case_id,
+        "created_at": "2026-05-07T00:00:00Z",
+        "inputs": {
+            "user_intent": "Create a Tang court mural poster from the attached source.",
+            "tradition": "",
+            "style_constraints": {"mode": "recovery_eval_fixture"},
+            "layer_plan": {
+                "desired_layer_count": 3,
+                "layers": [
+                    {
+                        "semantic_path": "poster.ground",
+                        "role": "background",
+                        "z_index": 0,
+                        "required": True,
+                    }
+                ],
+            },
+            "prompt_stack": {},
+            "provider": "fixture",
+            "model": "fixture",
+        },
+        "decisions": {
+            "fallback_decisions": [
+                {
+                    "semantic_path": "prompt.tradition",
+                    "suggested_action": "manual_review",
+                    "reason": "source registry ambiguity",
+                }
+            ],
+            "layer_count": {"planned": 3, "generated": 0},
+        },
+        "outputs": {
+            "artifact_dir": "",
+            "layer_manifest_path": "",
+            "layers": [],
+            "composite_path": "",
+            "preview_path": "",
+        },
+        "quality": {"gate_passed": False, "failures": ["prompt_ambiguity"]},
+        "review": {
+            "human_accept": False,
+            "failure_type": "prompt_ambiguity",
+            "preferred_action": "manual_review",
+            "reviewer": "recovery_eval_fixture",
+            "reviewed_at": "2026-05-07T00:00:00Z",
+        },
+    }
+    if source_ref.startswith("private://"):
+        record["source_summary"] = {"source_path_hint": source_ref}
+    else:
+        record["source_refs"] = {"source_brief_path": source_ref}
+    if preferred_split:
+        record["_preferred_split"] = preferred_split
+    return record
+
+
+def _write_manifest(tmp_path: Path) -> tuple[Path, Path, Path]:
+    source_dir = tmp_path / "repo_sources"
+    source_dir.mkdir()
+    (source_dir / "train_tang.md").write_text(
+        "Tang court mural registry ambiguity and manual review signal.",
+        encoding="utf-8",
+    )
+    artifact_root = tmp_path / "private_artifacts"
+    private_dir = artifact_root / "case-B-winter-solstice-error3"
+    private_dir.mkdir(parents=True)
+    (private_dir / "brief.md").write_text(
+        "client-only source text: Tang mural registry ambiguity.",
+        encoding="utf-8",
+    )
+
+    train_cases = tmp_path / "train_cases.jsonl"
+    user_cases = tmp_path / "user_cases.jsonl"
+    _write_jsonl(
+        train_cases,
+        [_case("train_tang_registry", source_ref="repo_sources/train_tang.md")],
+    )
+    _write_jsonl(
+        user_cases,
+        [
+            _case(
+                "user_private_tang_registry",
+                source_ref="private://local_path/fixture/case-B-winter-solstice-error3",
+            )
+        ],
+    )
+    manifest = tmp_path / "manifest.json"
+    manifest.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "case_type": "learning_tiny_case_source_manifest",
+                "sources": [
+                    {
+                        "source_id": "fixture_train",
+                        "kind": "synthetic_case_log",
+                        "path": train_cases.name,
+                        "privacy_scope": "project",
+                        "curation_status": "synthetic_reviewed",
+                        "preferred_split": "train",
+                    },
+                    {
+                        "source_id": "fixture_user",
+                        "kind": "user_case_log",
+                        "path": user_cases.name,
+                        "privacy_scope": "private",
+                        "curation_status": "reviewed",
+                        "preferred_split": "test",
+                    },
+                ],
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return manifest, artifact_root, artifact_root
+
+
+def test_real_source_context_recovery_eval_closes_private_artifact_dry_run_gap(
+    tmp_path,
+):
+    from vulca.learning.real_source_context_recovery_eval import (
+        run_real_source_context_recovery_eval,
+    )
+
+    manifest, artifact_root, image_root = _write_manifest(tmp_path)
+
+    report = run_real_source_context_recovery_eval(
+        repo_root=tmp_path,
+        case_source_manifest_path=manifest,
+        artifact_search_roots=[artifact_root],
+        image_search_roots=[image_root],
+        output_dir=tmp_path / "recovery_eval",
+        report_path=tmp_path
+        / "recovery_eval"
+        / "real_source_context_recovery_eval_report.json",
+        include_local_seeds=False,
+    )
+
+    assert report["case_type"] == "learning_real_source_context_recovery_eval_report"
+    assert report["status"] == "recovered_source_context_improves_dry_run"
+    assert report["recovery"]["summary"]["private_source_artifact_recovered_count"] == 1
+    assert report["baseline"]["source_context_signal_count"] == 1
+    assert report["recovered"]["source_context_signal_count"] == 2
+    assert report["baseline"]["fallback_agent_count"] == 1
+    assert report["recovered"]["fallback_agent_count"] == 0
+    assert report["delta"] == {
+        "source_context_signal_count": 1,
+        "fallback_agent_count": -1,
+        "fallback_agent_count_reduction": 1,
+        "no_source_context_for_required_source": -1,
+        "no_source_context_for_required_source_reduction": 1,
+    }
+    assert report["recovered_eval_cases"] == [
+        {
+            "case_id": "user_private_tang_registry",
+            "case_type": "layer_generate_case",
+            "example_id": report["recovered_eval_cases"][0]["example_id"],
+            "removed_data_gap_tags": ["no_source_context_for_required_source"],
+            "source_context": {
+                "available": True,
+                "signal_count": 1,
+                "source": "auxiliary_signal",
+            },
+        }
+    ]
+    assert Path(tmp_path / "recovery_eval" / report["artifacts"]["report_path"]).exists()
+
+    encoded = json.dumps(report, sort_keys=True)
+    assert str(tmp_path) not in encoded
+    assert "private://local_path" not in encoded
+    assert "client-only source text" not in encoded
+
+
+def test_real_source_context_recovery_eval_cli_writes_summary(tmp_path):
+    manifest, artifact_root, image_root = _write_manifest(tmp_path)
+    output_dir = tmp_path / "recovery_eval"
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--repo-root",
+            str(tmp_path),
+            "--case-source-manifest",
+            str(manifest),
+            "--artifact-search-root",
+            str(artifact_root),
+            "--image-search-root",
+            str(image_root),
+            "--output-dir",
+            str(output_dir),
+            "--no-local-seeds",
+        ],
+        cwd=ROOT,
+        env=CLI_ENV,
+        text=True,
+        capture_output=True,
+        timeout=30,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "Real source-context recovery eval:" in result.stdout
+    assert "Source context signals: 1 -> 2 (delta 1)" in result.stdout
+    assert "Dry-run fallback_agent_count: 1 -> 0 (reduction 1)" in result.stdout
+    assert "Recovered eval cases: 1" in result.stdout
+    report = json.loads(
+        (output_dir / "real_source_context_recovery_eval_report.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert report["delta"]["fallback_agent_count_reduction"] == 1


### PR DESCRIPTION
## Summary
- add a provider-free real source-context recovery eval workflow
- recover private source artifact/image maps, regenerate source-context signals, and compare dry-run routing before vs after recovery
- report recovered eval cases without copying local paths, private refs, or raw source text

## Real local smoke result
Command:
`PYTHONPATH=src python3 scripts/real_source_context_recovery_eval.py --repo-root . --case-source-manifest docs/benchmarks/learning/combined_case_source_manifest_v1.json --artifact-search-root /Users/yhryzy/dev/vulca/.scratch/p2b-live-shipgate --image-search-root /Users/yhryzy/dev/vulca/.scratch/p2b-live-shipgate --source-dependency-manifest docs/benchmarks/learning/real_source_dependency_label_manifest_v1.json --output-dir build/real_source_context_recovery_eval_p0 --report build/real_source_context_recovery_eval_p0/real_source_context_recovery_eval_report.json`

Result:
- Source context signals: 18 -> 22 (delta 4)
- Dry-run fallback_agent_count: 17 -> 15 (reduction 2)
- Dry-run no_source_context_for_required_source: 15 -> 13 (reduction 2)
- Recovered eval cases: 2
- Status: recovered_source_context_improves_dry_run

Recovered eval cases:
- real_v1_winter_solstice_tang_mural_registry_gap
- real_v2_layer_tang_mural_prompt_ambiguity

## Verification
- PYTHONPATH=src python3 -m pytest tests/test_real_source_context_recovery_eval.py tests/test_real_source_context_recovery_audit.py tests/test_real_user_source_artifact_map_recovery.py tests/test_source_context_gap_pack.py tests/test_training_effectiveness_report.py tests/test_dry_run_decision_router.py tests/test_source_context_signals.py -q
- python3 -m py_compile src/vulca/learning/real_source_context_recovery_eval.py scripts/real_source_context_recovery_eval.py tests/test_real_source_context_recovery_eval.py
- /opt/homebrew/bin/ruff check src/vulca/learning/real_source_context_recovery_eval.py scripts/real_source_context_recovery_eval.py tests/test_real_source_context_recovery_eval.py
- git diff --check HEAD~1..HEAD