### PR TITLE
Add local seed source context

### DIFF
--- a/docs/benchmarks/learning/local_seed_manifest.json
+++ b/docs/benchmarks/learning/local_seed_manifest.json
@@ -57,6 +57,9 @@
       "layer_manifest_path": "assets/demo/v2/scenario1-redo/manifest.json",
       "composite_path": "assets/demo/v2/scenario1-redo/after.png",
       "preview_path": "assets/demo/v2/scenario1-redo/after.png",
+      "source_refs": {
+        "source_brief_path": "docs/benchmarks/learning/local_seed_source_context_sources_v1/scenario1_redo_layer_generate.md"
+      },
       "human_accept": true,
       "failure_type": "",
       "preferred_action": "accept"

--- a/docs/benchmarks/learning/local_seed_source_context_sources_v1/scenario1_redo_layer_generate.md
+++ b/docs/benchmarks/learning/local_seed_source_context_sources_v1/scenario1_redo_layer_generate.md
@@ -1,0 +1,22 @@
+# scenario1_redo_layer_generate source packet
+
+Reviewed local seed source packet for accepted layer generation output.
+
+Case id: layer_generate_20260505T144500Z_e3c92ef7660d.
+
+Source contract:
+- semantic_path background_sky_and_mist uses z_index 0.
+- semantic_path distant_mountains uses z_index 1.
+- semantic_path midground_landscape uses z_index 2.
+- semantic_path foreground_island_pavilion_pines uses z_index 3.
+- semantic_path calligraphy_and_seals uses z_index 4.
+
+Decision context:
+- This is an accepted tracked artifact for a Chinese xieyi layered landscape.
+- The source context is the tracked manifest-backed layer plan and generated assets.
+- Source context should remove the missing-source data gap, but the dry-run router may
+  still keep agent fallback if action confidence remains low.
+
+Privacy review:
+- Project local seed packet only.
+- No private local paths or user source files are referenced.

--- a/src/vulca/learning/seed_cases.py
+++ b/src/vulca/learning/seed_cases.py
@@ -1,4 +1,5 @@
 """Build local seed case logs from tracked Vulca artifacts."""
+
 from __future__ import annotations
 
 import hashlib
@@ -115,27 +116,30 @@ def _build_redraw_seeds(
             area_pct=0.0,
         )
         records.append(
-            build_redraw_case(
-                artwork_dir=str(Path(source_artifact).parent),
-                source_image=source_artifact,
-                layer_info=layer,
-                instruction=str(item.get("notes", "")),
-                provider="local_seed",
-                model="tracked_artifact",
-                route_requested="seed",
-                source_layer_path=source_artifact,
-                redrawn_layer_path="",
-                redraw_advisory={
-                    "route_chosen": "",
-                    "quality_gate_passed": False,
-                    "quality_failures": [str(item["failure_type"])],
-                },
-                created_at=CREATED_AT,
-                human_accept=False,
-                failure_type=str(item["failure_type"]),
-                preferred_action=str(item["preferred_action"]),
-                reviewer="seed_manifest",
-                reviewed_at=CREATED_AT,
+            _with_source_refs(
+                build_redraw_case(
+                    artwork_dir=str(Path(source_artifact).parent),
+                    source_image=source_artifact,
+                    layer_info=layer,
+                    instruction=str(item.get("notes", "")),
+                    provider="local_seed",
+                    model="tracked_artifact",
+                    route_requested="seed",
+                    source_layer_path=source_artifact,
+                    redrawn_layer_path="",
+                    redraw_advisory={
+                        "route_chosen": "",
+                        "quality_gate_passed": False,
+                        "quality_failures": [str(item["failure_type"])],
+                    },
+                    created_at=CREATED_AT,
+                    human_accept=False,
+                    failure_type=str(item["failure_type"]),
+                    preferred_action=str(item["preferred_action"]),
+                    reviewer="seed_manifest",
+                    reviewed_at=CREATED_AT,
+                ),
+                item,
             )
         )
     return records
@@ -154,23 +158,26 @@ def _build_decompose_seeds(
         manifest_file = _repo_file(root, manifest_path)
         manifest_data = json.loads(manifest_file.read_text(encoding="utf-8"))
         records.append(
-            build_decompose_case(
-                source_image=source_image,
-                mode=str(item.get("mode", "")),
-                provider=str(item.get("provider", "")),
-                model=str(item.get("model", "")),
-                tradition=str(item.get("tradition", "")),
-                output_dir=output_dir,
-                manifest_path=manifest_path,
-                manifest_data=manifest_data,
-                target_layer_hints=[],
-                created_at=CREATED_AT,
-                human_accept=bool(item.get("human_accept", False)),
-                failure_type=str(item.get("failure_type", "")),
-                preferred_action=str(item.get("preferred_action", "")),
-                reviewer="seed_manifest",
-                reviewed_at=CREATED_AT,
-                notes=str(item.get("notes", "")),
+            _with_source_refs(
+                build_decompose_case(
+                    source_image=source_image,
+                    mode=str(item.get("mode", "")),
+                    provider=str(item.get("provider", "")),
+                    model=str(item.get("model", "")),
+                    tradition=str(item.get("tradition", "")),
+                    output_dir=output_dir,
+                    manifest_path=manifest_path,
+                    manifest_data=manifest_data,
+                    target_layer_hints=[],
+                    created_at=CREATED_AT,
+                    human_accept=bool(item.get("human_accept", False)),
+                    failure_type=str(item.get("failure_type", "")),
+                    preferred_action=str(item.get("preferred_action", "")),
+                    reviewer="seed_manifest",
+                    reviewed_at=CREATED_AT,
+                    notes=str(item.get("notes", "")),
+                ),
+                item,
             )
         )
     return records
@@ -199,25 +206,28 @@ def _build_layer_generate_seeds(
                 _repo_file(root, Path(artifact_dir) / layer_file)
         layer_status = _accepted_layer_status(item)
         records.append(
-            build_layer_generate_case(
-                user_intent=str(item["user_intent"]),
-                tradition=str(item.get("tradition", "")),
-                style_constraints=_style_constraints(manifest_data),
-                layer_plan=_layer_plan(layers),
-                prompt_stack=_prompt_stack(layers),
-                provider=str(item.get("provider", "")),
-                model=str(item.get("model", "")),
-                artifact_dir=artifact_dir,
-                layer_manifest_path=layer_manifest_path,
-                layers=_layer_outputs(artifact_dir, layers, status=layer_status),
-                composite_path=composite_path,
-                preview_path=preview_path,
-                created_at=CREATED_AT,
-                human_accept=bool(item.get("human_accept", False)),
-                failure_type=str(item.get("failure_type", "")),
-                preferred_action=str(item.get("preferred_action", "")),
-                reviewer="seed_manifest",
-                reviewed_at=CREATED_AT,
+            _with_source_refs(
+                build_layer_generate_case(
+                    user_intent=str(item["user_intent"]),
+                    tradition=str(item.get("tradition", "")),
+                    style_constraints=_style_constraints(manifest_data),
+                    layer_plan=_layer_plan(layers),
+                    prompt_stack=_prompt_stack(layers),
+                    provider=str(item.get("provider", "")),
+                    model=str(item.get("model", "")),
+                    artifact_dir=artifact_dir,
+                    layer_manifest_path=layer_manifest_path,
+                    layers=_layer_outputs(artifact_dir, layers, status=layer_status),
+                    composite_path=composite_path,
+                    preview_path=preview_path,
+                    created_at=CREATED_AT,
+                    human_accept=bool(item.get("human_accept", False)),
+                    failure_type=str(item.get("failure_type", "")),
+                    preferred_action=str(item.get("preferred_action", "")),
+                    reviewer="seed_manifest",
+                    reviewed_at=CREATED_AT,
+                ),
+                item,
             )
         )
     return records
@@ -229,6 +239,16 @@ def _accepted_layer_status(item: Mapping[str, Any]) -> str:
     return "generated"
 
 
+def _with_source_refs(
+    record: dict[str, Any],
+    item: Mapping[str, Any],
+) -> dict[str, Any]:
+    source_refs = item.get("source_refs")
+    if isinstance(source_refs, Mapping):
+        record["source_refs"] = {str(key): str(value) for key, value in source_refs.items() if str(key) and str(value)}
+    return record
+
+
 def _style_constraints(manifest_data: Mapping[str, Any]) -> dict[str, Any]:
     return {
         "positive": ["tracked layered artifact", "manifest-backed layer assets"],
@@ -236,9 +256,7 @@ def _style_constraints(manifest_data: Mapping[str, Any]) -> dict[str, Any]:
         "palette": [],
         "composition": [],
         "required_motifs": [
-            str(layer.get("name", ""))
-            for layer in manifest_data.get("layers", []) or []
-            if layer.get("name")
+            str(layer.get("name", "")) for layer in manifest_data.get("layers", []) or [] if layer.get("name")
         ],
         "prohibited_motifs": [],
     }

--- a/tests/test_learning_seed_cases.py
+++ b/tests/test_learning_seed_cases.py
@@ -10,6 +10,7 @@ CLI_ENV = dict(
     os.environ,
     PYTHONPATH=str(ROOT / "src") + os.pathsep + os.environ.get("PYTHONPATH", ""),
 )
+LOCAL_SEED_SOURCE_DIR = ROOT / "docs/benchmarks/learning/local_seed_source_context_sources_v1"
 
 
 def _read_jsonl(path: Path):
@@ -43,16 +44,40 @@ def test_build_local_seed_cases_uses_tracked_repo_artifacts():
     assert layer_generate["review"]["preferred_action"] == "accept"
     assert layer_generate["outputs"]["layers"]
     assert {item["status"] for item in layer_generate["outputs"]["layers"]} == {"accepted"}
-    assert {
-        item["outputs"]["artifact_dir"]
-        for item in bundle["layer_generate_case"]
-    } == {
+    assert {item["outputs"]["artifact_dir"] for item in bundle["layer_generate_case"]} == {
         "assets/demo/v2/layers-extract",
         "assets/demo/v2/scenario1",
         "assets/demo/v2/scenario1-redo",
         "assets/showcase/layers/great-wave",
         "assets/showcase/layers_v2/nighthawks",
     }
+
+
+def test_build_local_seed_cases_preserves_reviewed_source_refs():
+    from vulca.learning.seed_cases import DEFAULT_SEED_MANIFEST, build_local_seed_cases
+
+    bundle = build_local_seed_cases(ROOT, DEFAULT_SEED_MANIFEST)
+    seed = next(
+        item
+        for item in bundle["layer_generate_case"]
+        if item["case_id"] == "layer_generate_20260505T144500Z_e3c92ef7660d"
+    )
+
+    source_refs = seed["source_refs"]
+    assert source_refs == {
+        "source_brief_path": (
+            "docs/benchmarks/learning/local_seed_source_context_sources_v1/scenario1_redo_layer_generate.md"
+        )
+    }
+    packet_path = ROOT / source_refs["source_brief_path"]
+    assert packet_path.exists()
+    assert packet_path.parent == LOCAL_SEED_SOURCE_DIR
+    packet_text = packet_path.read_text(encoding="utf-8")
+    assert "layer_generate_20260505T144500Z_e3c92ef7660d" in packet_text
+    assert "semantic_path" in packet_text
+    assert "z_index" in packet_text
+    assert "/Users/" not in packet_text
+    assert "private://local_path" not in packet_text
 
 
 def test_write_local_seed_case_logs_creates_reviewable_jsonl(tmp_path):

--- a/tests/test_source_context_gap_pack.py
+++ b/tests/test_source_context_gap_pack.py
@@ -25,24 +25,21 @@ def test_source_context_gap_pack_prioritizes_remaining_v3_router_gaps(tmp_path):
     assert report["case_type"] == "learning_source_context_gap_pack_report"
     assert report["status"] == "needs_source_context_gap_pack"
     assert report["summary"] == {
-        "remaining_gap_count": 3,
-        "source_context_gap_closable_count": 3,
+        "remaining_gap_count": 2,
+        "source_context_gap_closable_count": 2,
         "tiny_model_dispatch_recoverable_count": 2,
-        "still_agent_required_after_source_context_count": 1,
+        "still_agent_required_after_source_context_count": 0,
     }
     assert report["counts_by_case_type"] == {
-        "layer_generate_case": 3,
+        "layer_generate_case": 2,
     }
     assert report["counts_by_source_kind"] == {
-        "local_seed": 1,
         "user_case_log": 2,
     }
     assert report["counts_by_gap_task"] == {
         "recover_real_user_source_context": 2,
-        "review_seed_source_dependency": 1,
     }
     assert report["counts_by_secondary_blocker"] == {
-        "low_action_confidence": 1,
         "source_context_only": 2,
     }
 
@@ -51,20 +48,13 @@ def test_source_context_gap_pack_prioritizes_remaining_v3_router_gaps(tmp_path):
     assert groups["recover_real_user_source_context"]["case_count"] == 2
     assert "author_synthetic_source_packet" not in groups
 
-    real_cases = [
-        item
-        for item in report["gap_cases"]
-        if item["gap_task"] == "recover_real_user_source_context"
-    ]
+    real_cases = [item for item in report["gap_cases"] if item["gap_task"] == "recover_real_user_source_context"]
     assert [item["case_id"] for item in real_cases] == [
         "real_v1_winter_solstice_tang_mural_registry_gap",
         "real_v2_layer_tang_mural_prompt_ambiguity",
     ]
     assert all(item["priority"] == "p0" for item in real_cases)
-    assert all(
-        item["expected_effect"] == "remove_source_context_fallback"
-        for item in real_cases
-    )
+    assert all(item["expected_effect"] == "remove_source_context_fallback" for item in real_cases)
 
     assert Path(report["artifacts"]["training_effectiveness_report_path"]).exists()
     assert Path(report["artifacts"]["report_path"]).exists()
@@ -99,10 +89,11 @@ def test_source_context_gap_pack_cli_writes_summary(tmp_path):
     assert result.returncode == 0, result.stderr
     assert report_path.exists()
     assert "Source context gap pack report:" in result.stdout
-    assert "Remaining source-context gaps: 3" in result.stdout
+    assert "Remaining source-context gaps: 2" in result.stdout
     assert "Tiny-model dispatch recoverable after source context: 2" in result.stdout
     assert "Gap task recover_real_user_source_context: 2" in result.stdout
     assert "Gap task author_synthetic_source_packet:" not in result.stdout
+    assert "Gap task review_seed_source_dependency:" not in result.stdout
 
     report = json.loads(report_path.read_text(encoding="utf-8"))
-    assert report["summary"]["remaining_gap_count"] == 3
+    assert report["summary"]["remaining_gap_count"] == 2

--- a/tests/test_training_effectiveness_report.py
+++ b/tests/test_training_effectiveness_report.py
@@ -69,18 +69,11 @@ def test_training_effectiveness_report_uses_combined_real_manual_and_seed_data(t
     assert report["effectiveness"]["accuracy_delta_vs_baseline"] > 0
     assert report["effectiveness"]["ablation_summary"]["full_action_accuracy"] == 1.0
     assert (
-        report["effectiveness"]["ablation_summary"]["largest_accuracy_drop"][
-            "variant_id"
-        ]
+        report["effectiveness"]["ablation_summary"]["largest_accuracy_drop"]["variant_id"]
         == "without_failure_and_action_hints"
     )
-    assert (
-        "tiny_feature_ablation_report_path"
-        in report["artifacts"]
-    )
-    ranked = {
-        item["policy_name"]: item for item in report["effectiveness"]["policy_ranking"]
-    }
+    assert "tiny_feature_ablation_report_path" in report["artifacts"]
+    ranked = {item["policy_name"]: item for item in report["effectiveness"]["policy_ranking"]}
     assert ranked["tiny_action_model_v1"]["action_accuracy"] == 1.0
     assert Path(report["artifacts"]["aggregated_report_path"]).exists()
 
@@ -109,9 +102,7 @@ def test_training_effectiveness_report_includes_source_dependency_eval_and_leade
     assert source_dependency["best_policy"]["dependency_accuracy"] == 1.0
     assert source_dependency["best_policy"]["decision_basis_accuracy"] == 1.0
     assert source_dependency["best_policy"]["mismatch_count"] == 0
-    assert source_dependency["policy_reports"]["source_dependency_majority"][
-        "decision_basis_accuracy"
-    ] == 0.5
+    assert source_dependency["policy_reports"]["source_dependency_majority"]["decision_basis_accuracy"] == 0.5
 
     leaderboard = {item["task"]: item for item in report["leaderboard"]}
     assert leaderboard["action_routing"] == {
@@ -159,26 +150,25 @@ def test_training_effectiveness_report_compares_source_context_router_improvemen
     assert router["status"] == "improved_with_source_context_signals"
     assert router["source_context_signal_summary"] == {
         "example_count": 50,
-        "promoted_signal_count": 30,
-        "skipped_count": 20,
+        "promoted_signal_count": 31,
+        "skipped_count": 19,
     }
     assert router["baseline_without_source_context_signals"]["fallback_agent_count"] == 21
     assert router["with_source_context_signals"]["fallback_agent_count"] == 7
     assert router["delta"] == {
         "fallback_agent_count": -14,
         "fallback_agent_count_reduction": 14,
-        "no_source_context_for_required_source": -16,
-        "no_source_context_for_required_source_reduction": 16,
+        "no_source_context_for_required_source": -17,
+        "no_source_context_for_required_source_reduction": 17,
     }
     assert router["improved_case_count"] == 14
-    assert router["remaining_no_source_context_gap_count"] == 3
-    assert {
-        item["case_type"] for item in router["improved_cases"]
-    } == {"redraw_case", "decompose_case", "layer_generate_case"}
-    assert all(
-        item["source_context"]["source"] == "auxiliary_signal"
-        for item in router["improved_cases"]
-    )
+    assert router["remaining_no_source_context_gap_count"] == 2
+    assert {item["case_type"] for item in router["improved_cases"]} == {
+        "redraw_case",
+        "decompose_case",
+        "layer_generate_case",
+    }
+    assert all(item["source_context"]["source"] == "auxiliary_signal" for item in router["improved_cases"])
 
     leaderboard = {item["task"]: item for item in report["leaderboard"]}
     assert leaderboard["dry_run_dispatch"] == {
@@ -188,7 +178,7 @@ def test_training_effectiveness_report_compares_source_context_router_improvemen
         "primary_metric": "fallback_agent_count_reduction",
         "primary_accuracy": 14,
         "secondary_metric": "no_source_context_gap_reduction",
-        "secondary_accuracy": 16,
+        "secondary_accuracy": 17,
         "mismatch_count": 0,
         "gate_passed": True,
     }
@@ -229,19 +219,14 @@ def test_training_effectiveness_report_script_writes_report_and_prints_summary(t
     assert "source_dependency_rule_v1 decision_basis_accuracy: 1.0" in result.stdout
     assert "Source dependency labeled examples: 12" in result.stdout
     assert (
-        "Leaderboard source_dependency: "
-        "source_dependency_rule_v1 dependency_accuracy=1.0 "
-        "decision_basis_accuracy=1.0"
+        "Leaderboard source_dependency: source_dependency_rule_v1 dependency_accuracy=1.0 decision_basis_accuracy=1.0"
     ) in result.stdout
     assert "Ablation hardest drop:" in result.stdout
-    assert "Source context signals: 30/50" in result.stdout
+    assert "Source context signals: 31/50" in result.stdout
     assert "Dry-run fallback_agent_count: 21 -> 7 (reduction 14)" in result.stdout
-    assert (
-        "Dry-run no_source_context_for_required_source: 19 -> 3 (reduction 16)"
-        in result.stdout
-    )
+    assert "Dry-run no_source_context_for_required_source: 19 -> 2 (reduction 17)" in result.stdout
     assert "Dry-run improved cases: 14" in result.stdout
-    assert "Dry-run remaining source-context gaps: 3" in result.stdout
+    assert "Dry-run remaining source-context gaps: 2" in result.stdout
     assert "tiny_agent_v0 action_accuracy:" in result.stdout
     assert "Data gaps: 0" in result.stdout
     assert "source.kind local_seed: eval 0/12" not in result.stdout


### PR DESCRIPTION
## Summary
- preserve source_refs from local seed manifest entries when building seed case logs
- add reviewed source-context packet for scenario1_redo_layer_generate local seed
- update training effectiveness and source-context gap expectations after the local seed source gap is closed

Stacked after #106.

## Verification
- PYTHONPATH=src python3 -m pytest tests/test_learning_seed_cases.py::test_build_local_seed_cases_preserves_reviewed_source_refs tests/test_training_effectiveness_report.py::test_training_effectiveness_report_compares_source_context_router_improvement tests/test_source_context_gap_pack.py::test_source_context_gap_pack_prioritizes_remaining_v3_router_gaps -q
- PYTHONPATH=src python3 -m pytest tests/test_learning_seed_cases.py tests/test_training_effectiveness_report.py tests/test_source_context_gap_pack.py tests/test_source_context_signals.py tests/test_dry_run_decision_router.py -q
- PYTHONPATH=src python3 -m pytest tests/test_learning_seed_cases.py tests/test_tiny_dataset_export.py tests/test_training_effectiveness_report.py tests/test_source_context_gap_pack.py tests/test_source_context_signals.py tests/test_dry_run_decision_router.py tests/test_taxonomy_holdout_cases_v1.py tests/test_manual_curated_cases_v1.py tests/test_backlog_manual_cases_v1.py -q
- PYTHONPATH=src python3 scripts/training_effectiveness_report.py --repo-root . --output-dir build/local_seed_source_context_v1/training_effectiveness --report build/local_seed_source_context_v1/training_effectiveness/report.json
- PYTHONPATH=src python3 scripts/real_source_context_recovery_eval.py --repo-root . --case-source-manifest docs/benchmarks/learning/combined_case_source_manifest_v1.json --artifact-search-root /Users/yhryzy/dev/vulca/.scratch/p2b-live-shipgate --image-search-root /Users/yhryzy/dev/vulca/.scratch/p2b-live-shipgate --source-dependency-manifest docs/benchmarks/learning/real_source_dependency_label_manifest_v1.json --output-dir build/local_seed_source_context_v1/real_recovery_eval --report build/local_seed_source_context_v1/real_recovery_eval/report.json
- ruff check src/vulca/learning/seed_cases.py tests/test_learning_seed_cases.py tests/test_training_effectiveness_report.py tests/test_source_context_gap_pack.py
- git diff --check
