### PR TITLE
Gate private source recovery workflow

### DIFF
--- a/docs/benchmarks/learning/private_source_recovery_workflow.md
+++ b/docs/benchmarks/learning/private_source_recovery_workflow.md
@@ -1,0 +1,60 @@
+# Private source recovery workflow
+
+This workflow is for local or private environments that have access to real-user
+source artifacts. It must not copy private materials into benchmark case logs,
+reviewed source packets, or shared reports.
+
+## Goal
+
+The public repository dataset should keep private source material out of git.
+After the public source-context packets are present, the remaining default
+training report has two `no_source_context_for_required_source` gaps. Those gaps
+are real-user cases that can be closed only by resolving private source refs to
+local files at eval time.
+
+## Command
+
+Run the provider-free recovery eval with local search roots:
+
+```bash
+PYTHONPATH=src python3 scripts/real_source_context_recovery_eval.py \
+  --repo-root . \
+  --case-source-manifest docs/benchmarks/learning/combined_case_source_manifest_v1.json \
+  --source-dependency-manifest docs/benchmarks/learning/real_source_dependency_label_manifest_v1.json \
+  --artifact-search-root PATH_TO_PRIVATE_SOURCE_ARTIFACTS \
+  --image-search-root PATH_TO_PRIVATE_SOURCE_IMAGES \
+  --output-dir build/private_source_recovery_workflow/real_recovery_eval \
+  --report build/private_source_recovery_workflow/real_recovery_eval/report.json \
+  --max-recovered-source-context-gaps 0 \
+  --min-fallback-agent-reduction 2 \
+  --min-recovered-eval-cases 2
+```
+
+Use `--artifact-filename-alias PRIVATE_BASENAME=LOCAL_BASENAME` or
+`--image-filename-alias PRIVATE_BASENAME=LOCAL_BASENAME` when a local recovered
+directory or file uses a safe local basename that differs from the private ref
+basename.
+
+## Expected result
+
+With the current reviewed real-user cases and a complete local private source
+directory, the recovery eval should report:
+
+- `Source context signals: 31 -> 35`
+- `Dry-run fallback_agent_count: 7 -> 5`
+- `Dry-run no_source_context_for_required_source: 2 -> 0`
+- `Recovered eval cases: 2`
+- `Thresholds: passed`
+
+The remaining fallback count is not a source-context data gap. It is the current
+agent-required or low-confidence routing boundary after source context is
+available.
+
+## Safety rules
+
+- Do not commit generated private asset maps.
+- Do not commit recovered source artifacts or source images.
+- Do not paste private source refs into shared docs.
+- Shared reports should include counts and case ids only, not local paths or raw
+  source text.
+- Private asset maps are local sidecars used only by recovery/audit/eval runs.

--- a/scripts/real_source_context_recovery_eval.py
+++ b/scripts/real_source_context_recovery_eval.py
@@ -104,6 +104,27 @@ def main(argv: Sequence[str] | None = None) -> int:
         action="store_true",
         help="Print the full safe JSON report to stdout after writing it.",
     )
+    parser.add_argument(
+        "--max-recovered-source-context-gaps",
+        type=int,
+        default=None,
+        help=(
+            "Fail if recovered no_source_context_for_required_source count is "
+            "greater than this value."
+        ),
+    )
+    parser.add_argument(
+        "--min-fallback-agent-reduction",
+        type=int,
+        default=None,
+        help="Fail if fallback_agent_count_reduction is below this value.",
+    )
+    parser.add_argument(
+        "--min-recovered-eval-cases",
+        type=int,
+        default=None,
+        help="Fail if fewer than this many eval cases recover dispatch.",
+    )
     args = parser.parse_args(argv)
 
     try:
@@ -159,6 +180,24 @@ def main(argv: Sequence[str] | None = None) -> int:
     )
     print(f"Recovered eval cases: {report['recovered_eval_case_count']}")
     print(f"Status: {report['status']}")
+
+    threshold_failures = _threshold_failures(
+        report,
+        max_recovered_source_context_gaps=args.max_recovered_source_context_gaps,
+        min_fallback_agent_reduction=args.min_fallback_agent_reduction,
+        min_recovered_eval_cases=args.min_recovered_eval_cases,
+    )
+    if threshold_failures:
+        print("Thresholds: failed", file=sys.stderr)
+        for failure in threshold_failures:
+            print(f"- {failure}", file=sys.stderr)
+        return 1
+    if _thresholds_requested(
+        args.max_recovered_source_context_gaps,
+        args.min_fallback_agent_reduction,
+        args.min_recovered_eval_cases,
+    ):
+        print("Thresholds: passed")
     return 0
 
 
@@ -178,6 +217,54 @@ def _parse_aliases(values: Sequence[str]) -> dict[str, str]:
             )
         aliases[source_name] = local_name
     return aliases
+
+
+def _threshold_failures(
+    report: dict,
+    *,
+    max_recovered_source_context_gaps: int | None,
+    min_fallback_agent_reduction: int | None,
+    min_recovered_eval_cases: int | None,
+) -> list[str]:
+    failures: list[str] = []
+    recovered_gaps = int(
+        report["recovered"]["data_gap_counts"].get(
+            "no_source_context_for_required_source",
+            0,
+        )
+    )
+    fallback_reduction = int(report["delta"]["fallback_agent_count_reduction"])
+    recovered_eval_cases = int(report["recovered_eval_case_count"])
+
+    if (
+        max_recovered_source_context_gaps is not None
+        and recovered_gaps > max_recovered_source_context_gaps
+    ):
+        failures.append(
+            "recovered no_source_context_for_required_source "
+            f"{recovered_gaps} > {max_recovered_source_context_gaps}"
+        )
+    if (
+        min_fallback_agent_reduction is not None
+        and fallback_reduction < min_fallback_agent_reduction
+    ):
+        failures.append(
+            "fallback_agent_count_reduction "
+            f"{fallback_reduction} < {min_fallback_agent_reduction}"
+        )
+    if (
+        min_recovered_eval_cases is not None
+        and recovered_eval_cases < min_recovered_eval_cases
+    ):
+        failures.append(
+            f"recovered_eval_case_count {recovered_eval_cases} < "
+            f"{min_recovered_eval_cases}"
+        )
+    return failures
+
+
+def _thresholds_requested(*values: int | None) -> bool:
+    return any(value is not None for value in values)
 
 
 if __name__ == "__main__":

--- a/tests/test_private_source_recovery_workflow_docs.py
+++ b/tests/test_private_source_recovery_workflow_docs.py
@@ -1,0 +1,18 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+DOC = ROOT / "docs/benchmarks/learning/private_source_recovery_workflow.md"
+
+
+def test_private_source_recovery_workflow_doc_is_safe_and_actionable():
+    text = DOC.read_text(encoding="utf-8")
+
+    assert "scripts/real_source_context_recovery_eval.py" in text
+    assert "--max-recovered-source-context-gaps 0" in text
+    assert "--min-fallback-agent-reduction 2" in text
+    assert "--min-recovered-eval-cases 2" in text
+    assert "no_source_context_for_required_source" in text
+    assert "private asset maps" in text
+    assert "/Users/" not in text
+    assert "private://local_path" not in text

--- a/tests/test_real_source_context_recovery_eval.py
+++ b/tests/test_real_source_context_recovery_eval.py
@@ -241,3 +241,78 @@ def test_real_source_context_recovery_eval_cli_writes_summary(tmp_path):
         )
     )
     assert report["delta"]["fallback_agent_count_reduction"] == 1
+
+
+def test_real_source_context_recovery_eval_cli_supports_success_thresholds(tmp_path):
+    manifest, artifact_root, image_root = _write_manifest(tmp_path)
+    output_dir = tmp_path / "recovery_eval"
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--repo-root",
+            str(tmp_path),
+            "--case-source-manifest",
+            str(manifest),
+            "--artifact-search-root",
+            str(artifact_root),
+            "--image-search-root",
+            str(image_root),
+            "--output-dir",
+            str(output_dir),
+            "--no-local-seeds",
+            "--max-recovered-source-context-gaps",
+            "0",
+            "--min-fallback-agent-reduction",
+            "1",
+            "--min-recovered-eval-cases",
+            "1",
+        ],
+        cwd=ROOT,
+        env=CLI_ENV,
+        text=True,
+        capture_output=True,
+        timeout=30,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "Thresholds: passed" in result.stdout
+
+
+def test_real_source_context_recovery_eval_cli_fails_when_thresholds_miss(tmp_path):
+    manifest, artifact_root, image_root = _write_manifest(tmp_path)
+    output_dir = tmp_path / "recovery_eval"
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--repo-root",
+            str(tmp_path),
+            "--case-source-manifest",
+            str(manifest),
+            "--artifact-search-root",
+            str(artifact_root),
+            "--image-search-root",
+            str(image_root),
+            "--output-dir",
+            str(output_dir),
+            "--no-local-seeds",
+            "--max-recovered-source-context-gaps",
+            "0",
+            "--min-fallback-agent-reduction",
+            "2",
+        ],
+        cwd=ROOT,
+        env=CLI_ENV,
+        text=True,
+        capture_output=True,
+        timeout=30,
+        check=False,
+    )
+
+    assert result.returncode == 1
+    assert "Thresholds: failed" in result.stderr
+    assert "fallback_agent_count_reduction 1 < 2" in result.stderr


### PR DESCRIPTION
## Summary
- add threshold gates to real_source_context_recovery_eval CLI for private recovery acceptance
- document the safe private source recovery workflow and expected current metrics
- cover success/failure threshold behavior and doc safety in tests

## Verification
- PYTHONPATH=src python3 -m pytest tests/test_real_source_context_recovery_eval.py::test_real_source_context_recovery_eval_cli_supports_success_thresholds tests/test_real_source_context_recovery_eval.py::test_real_source_context_recovery_eval_cli_fails_when_thresholds_miss tests/test_private_source_recovery_workflow_docs.py -q
- PYTHONPATH=src python3 -m pytest tests/test_real_source_context_recovery_eval.py tests/test_real_source_context_recovery_audit.py tests/test_real_source_context_audit.py tests/test_private_source_recovery_workflow_docs.py tests/test_training_effectiveness_report.py tests/test_source_context_gap_pack.py -q
- PYTHONPATH=src python3 scripts/real_source_context_recovery_eval.py --repo-root . --case-source-manifest docs/benchmarks/learning/combined_case_source_manifest_v1.json --artifact-search-root /Users/yhryzy/dev/vulca/.scratch/p2b-live-shipgate --image-search-root /Users/yhryzy/dev/vulca/.scratch/p2b-live-shipgate --source-dependency-manifest docs/benchmarks/learning/real_source_dependency_label_manifest_v1.json --output-dir build/private_source_recovery_workflow_v1/real_recovery_eval --report build/private_source_recovery_workflow_v1/real_recovery_eval/report.json --max-recovered-source-context-gaps 0 --min-fallback-agent-reduction 2 --min-recovered-eval-cases 2
- ruff check scripts/real_source_context_recovery_eval.py tests/test_real_source_context_recovery_eval.py tests/test_private_source_recovery_workflow_docs.py
- python3 -m py_compile scripts/real_source_context_recovery_eval.py
- git diff --check
