### PR TITLE
Add fallback residual audit

### DIFF
--- a/scripts/fallback_residual_audit.py
+++ b/scripts/fallback_residual_audit.py
@@ -1,0 +1,69 @@
+"""Audit residual fallback-agent dry-run decisions."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Sequence
+
+
+ROOT = Path(__file__).resolve().parent.parent
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from vulca.learning.fallback_residual_audit import (  # noqa: E402
+    DEFAULT_REPORT_NAME,
+    run_fallback_residual_audit,
+)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Classify residual fallback-agent dry-run decisions.",
+    )
+    parser.add_argument(
+        "--decision-path",
+        required=True,
+        help="Dry-run decision JSONL path.",
+    )
+    parser.add_argument(
+        "--report",
+        default="",
+        help=f"Report JSON path (default: alongside decision path as {DEFAULT_REPORT_NAME}).",
+    )
+    parser.add_argument(
+        "--pretty",
+        action="store_true",
+        help="Print full JSON report after writing it.",
+    )
+    args = parser.parse_args(argv)
+
+    decision_path = Path(args.decision_path)
+    report_path = Path(args.report) if args.report else decision_path.parent / DEFAULT_REPORT_NAME
+    try:
+        report = run_fallback_residual_audit(
+            decision_path=decision_path,
+            report_path=report_path,
+        )
+    except (FileNotFoundError, json.JSONDecodeError, OSError, ValueError) as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 2
+
+    if args.pretty:
+        print(json.dumps(report, indent=2, sort_keys=True))
+
+    summary = report["summary"]
+    print(f"Fallback residual audit: {report_path}")
+    print(f"Decisions: {summary['decision_count']}")
+    print(f"Fallback agent decisions: {summary['fallback_agent_count']}")
+    print(f"Tiny router candidates: {summary['tiny_router_candidate_count']}")
+    print(f"Agent-required residuals: {summary['agent_required_count']}")
+    print(f"Source-context gaps: {summary['source_context_gap_count']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/vulca/learning/fallback_residual_audit.py
+++ b/src/vulca/learning/fallback_residual_audit.py
@@ -1,0 +1,189 @@
+"""Audit residual fallback-agent decisions after source-context recovery."""
+
+from __future__ import annotations
+
+import json
+from collections import Counter
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+
+SCHEMA_VERSION = 1
+REPORT_CASE_TYPE = "learning_fallback_residual_audit_report"
+DEFAULT_REPORT_NAME = "fallback_residual_audit_report.json"
+
+RESIDUAL_TINY_CONFIDENCE = "tiny_router_confidence_gap"
+RESIDUAL_PROVIDER_RUNTIME = "provider_runtime_fallback"
+RESIDUAL_COMPLEX_OWNERSHIP = "agent_boundary_complex_visual_ownership"
+RESIDUAL_AGENT_ACTION = "agent_boundary_action_fallback"
+RESIDUAL_SOURCE_CONTEXT_GAP = "source_context_gap"
+
+NEXT_CONFIDENCE = "add_confidence_calibration_or_label"
+NEXT_PROVIDER = "route_provider_failure_to_runtime_handler"
+NEXT_AGENT_BOUNDARY = "keep_agent_boundary"
+NEXT_SOURCE_CONTEXT = "recover_source_context"
+
+
+def run_fallback_residual_audit(
+    *,
+    decision_path: str | Path,
+    report_path: str | Path | None = None,
+) -> dict[str, Any]:
+    """Classify dry-run fallback-agent residuals into actionable buckets."""
+    decisions = _load_jsonl(decision_path)
+    fallback_decisions = [
+        decision for decision in decisions if bool(_mapping(decision.get("dispatch")).get("fallback_agent"))
+    ]
+    residual_cases = [_residual_case(decision) for decision in fallback_decisions]
+    residual_cases = sorted(
+        residual_cases,
+        key=lambda item: (item["residual_kind"], item["case_type"], item["case_id"]),
+    )
+    summary = _summary(decisions, residual_cases)
+    report = {
+        "schema_version": SCHEMA_VERSION,
+        "case_type": REPORT_CASE_TYPE,
+        "status": ("needs_agent_or_router_boundary_work" if residual_cases else "no_fallback_residuals"),
+        "inputs": {
+            "decision_path": Path(decision_path).name,
+        },
+        "summary": summary,
+        "counts_by_case_type": _counter_by(residual_cases, "case_type"),
+        "counts_by_residual_kind": _counter_by(residual_cases, "residual_kind"),
+        "counts_by_recommended_next_step": _counter_by(
+            residual_cases,
+            "recommended_next_step",
+        ),
+        "counts_by_fallback_reason": _fallback_reason_counts(residual_cases),
+        "residual_cases": residual_cases,
+        "safe_handling": {
+            "copies_local_paths": False,
+            "copies_private_refs": False,
+            "copies_raw_source_text": False,
+            "calls_model_provider": False,
+        },
+    }
+    if report_path:
+        output = Path(report_path)
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_text(
+            json.dumps(report, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+    return report
+
+
+def _summary(
+    decisions: Sequence[Mapping[str, Any]],
+    residual_cases: Sequence[Mapping[str, Any]],
+) -> dict[str, int]:
+    tiny_router_candidate_count = sum(1 for item in residual_cases if bool(item.get("tiny_router_candidate")))
+    source_context_gap_count = sum(
+        1 for item in residual_cases if item.get("residual_kind") == RESIDUAL_SOURCE_CONTEXT_GAP
+    )
+    return {
+        "decision_count": len(decisions),
+        "fallback_agent_count": len(residual_cases),
+        "agent_required_count": len(residual_cases) - tiny_router_candidate_count,
+        "tiny_router_candidate_count": tiny_router_candidate_count,
+        "source_context_gap_count": source_context_gap_count,
+    }
+
+
+def _residual_case(decision: Mapping[str, Any]) -> dict[str, Any]:
+    action_router = _mapping(decision.get("action_router"))
+    dispatch = _mapping(decision.get("dispatch"))
+    source_dependency = _mapping(decision.get("source_dependency_router"))
+    source_context = _mapping(decision.get("source_context"))
+    fallback_reasons = _string_list(dispatch.get("fallback_reasons"))
+    data_gap_tags = _string_list(dispatch.get("data_gap_tags"))
+    failure_hint = str(action_router.get("failure_hint") or "")
+    residual_kind, next_step, tiny_candidate = _classify_residual(
+        fallback_reasons=fallback_reasons,
+        data_gap_tags=data_gap_tags,
+        failure_hint=failure_hint,
+    )
+    return {
+        "example_id": str(decision.get("example_id") or ""),
+        "case_id": str(decision.get("case_id") or ""),
+        "case_type": str(decision.get("source_case_type") or ""),
+        "recommended_action": str(action_router.get("recommended_action") or ""),
+        "action_confidence": _float_or_none(action_router.get("confidence")),
+        "failure_hint": failure_hint,
+        "fallback_reasons": fallback_reasons,
+        "data_gap_tags": data_gap_tags,
+        "source_context_available": bool(source_context.get("available")),
+        "source_context_signal_count": int(source_context.get("signal_count") or 0),
+        "source_dependency": str(source_dependency.get("recommended_source_dependency") or ""),
+        "decision_basis": str(source_dependency.get("recommended_decision_basis") or ""),
+        "residual_kind": residual_kind,
+        "tiny_router_candidate": tiny_candidate,
+        "recommended_next_step": next_step,
+    }
+
+
+def _classify_residual(
+    *,
+    fallback_reasons: Sequence[str],
+    data_gap_tags: Sequence[str],
+    failure_hint: str,
+) -> tuple[str, str, bool]:
+    if "no_source_context_for_required_source" in data_gap_tags:
+        return RESIDUAL_SOURCE_CONTEXT_GAP, NEXT_SOURCE_CONTEXT, True
+    if "low_action_confidence" in fallback_reasons:
+        return RESIDUAL_TINY_CONFIDENCE, NEXT_CONFIDENCE, True
+    if failure_hint == "provider_failure":
+        return RESIDUAL_PROVIDER_RUNTIME, NEXT_PROVIDER, False
+    if failure_hint in {"occlusion", "under_split"}:
+        return RESIDUAL_COMPLEX_OWNERSHIP, NEXT_AGENT_BOUNDARY, False
+    return RESIDUAL_AGENT_ACTION, NEXT_AGENT_BOUNDARY, False
+
+
+def _fallback_reason_counts(
+    residual_cases: Sequence[Mapping[str, Any]],
+) -> dict[str, int]:
+    counts: Counter[str] = Counter()
+    for item in residual_cases:
+        for reason in _string_list(item.get("fallback_reasons")):
+            counts[reason] += 1
+    return dict(sorted(counts.items()))
+
+
+def _counter_by(items: Sequence[Mapping[str, Any]], key: str) -> dict[str, int]:
+    counts: Counter[str] = Counter()
+    for item in items:
+        value = str(item.get(key) or "unknown")
+        counts[value] += 1
+    return dict(sorted(counts.items()))
+
+
+def _load_jsonl(path: str | Path) -> list[dict[str, Any]]:
+    records: list[dict[str, Any]] = []
+    for line in Path(path).read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        value = json.loads(line)
+        if isinstance(value, Mapping):
+            records.append(dict(value))
+    return records
+
+
+def _string_list(value: Any) -> list[str]:
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes)):
+        return []
+    return [str(item) for item in value]
+
+
+def _float_or_none(value: Any) -> float | None:
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    if isinstance(value, Mapping):
+        return value
+    return {}

--- a/tests/test_fallback_residual_audit.py
+++ b/tests/test_fallback_residual_audit.py
@@ -1,0 +1,199 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+CLI_ENV = dict(
+    os.environ,
+    PYTHONPATH=str(ROOT / "src") + os.pathsep + os.environ.get("PYTHONPATH", ""),
+)
+SCRIPT = ROOT / "scripts" / "fallback_residual_audit.py"
+
+
+def _decision(
+    case_id: str,
+    *,
+    case_type: str,
+    action: str,
+    confidence: float,
+    failure_hint: str,
+    fallback_reasons: list[str],
+    data_gap_tags: list[str] | None = None,
+    source_context_available: bool = True,
+) -> dict:
+    return {
+        "schema_version": 1,
+        "case_type": "learning_dry_run_decision",
+        "example_id": f"tiny_{case_id}",
+        "case_id": case_id,
+        "source_case_type": case_type,
+        "action_router": {
+            "policy_name": "tiny_action_model_v1",
+            "recommended_action": action,
+            "confidence": confidence,
+            "failure_hint": failure_hint,
+            "rule_reason": "fixture",
+        },
+        "source_dependency_router": {
+            "recommended_source_dependency": "required",
+            "recommended_decision_basis": "artifact_source",
+            "confidence": 0.8,
+            "rule_reason": "fixture",
+        },
+        "source_context": {
+            "available": source_context_available,
+            "source": "auxiliary_signal" if source_context_available else "",
+            "signal_count": 1 if source_context_available else 0,
+        },
+        "dispatch": {
+            "fallback_agent": True,
+            "fallback_reasons": fallback_reasons,
+            "data_gap_tags": data_gap_tags or [],
+            "decision_owner": "tiny_model",
+            "execution_owner": "fallback_agent",
+        },
+    }
+
+
+def _write_jsonl(path: Path, records: list[dict]) -> None:
+    path.write_text(
+        "\n".join(json.dumps(record, sort_keys=True) for record in records) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _fixture_decisions() -> list[dict]:
+    return [
+        _decision(
+            "seed_low_confidence",
+            case_type="layer_generate_case",
+            action="accept",
+            confidence=0.4,
+            failure_hint="",
+            fallback_reasons=["low_action_confidence"],
+            data_gap_tags=["low_action_confidence"],
+        ),
+        _decision(
+            "redraw_under_split",
+            case_type="redraw_case",
+            action="fallback_to_agent",
+            confidence=0.82,
+            failure_hint="under_split",
+            fallback_reasons=["action_fallback_to_agent"],
+        ),
+        _decision(
+            "decompose_occlusion",
+            case_type="decompose_case",
+            action="fallback_to_agent",
+            confidence=0.82,
+            failure_hint="occlusion",
+            fallback_reasons=["action_fallback_to_agent"],
+        ),
+        _decision(
+            "layer_provider_failure",
+            case_type="layer_generate_case",
+            action="fallback_to_agent",
+            confidence=0.88,
+            failure_hint="provider_failure",
+            fallback_reasons=["action_fallback_to_agent"],
+            source_context_available=False,
+        ),
+        _decision(
+            "manual_provider_failure",
+            case_type="layer_generate_case",
+            action="fallback_to_agent",
+            confidence=0.88,
+            failure_hint="provider_failure",
+            fallback_reasons=["action_fallback_to_agent"],
+            source_context_available=False,
+        ),
+        _decision(
+            "resolved_case",
+            case_type="redraw_case",
+            action="adjust_mask",
+            confidence=0.91,
+            failure_hint="mask_leak",
+            fallback_reasons=[],
+        )
+        | {"dispatch": {"fallback_agent": False, "fallback_reasons": [], "data_gap_tags": []}},
+    ]
+
+
+def test_fallback_residual_audit_classifies_remaining_agent_work(tmp_path):
+    from vulca.learning.fallback_residual_audit import run_fallback_residual_audit
+
+    decision_path = tmp_path / "dry_run_decisions.jsonl"
+    report_path = tmp_path / "fallback_residual_audit_report.json"
+    _write_jsonl(decision_path, _fixture_decisions())
+
+    report = run_fallback_residual_audit(
+        decision_path=decision_path,
+        report_path=report_path,
+    )
+
+    assert report["case_type"] == "learning_fallback_residual_audit_report"
+    assert report["status"] == "needs_agent_or_router_boundary_work"
+    assert report["summary"] == {
+        "decision_count": 6,
+        "fallback_agent_count": 5,
+        "agent_required_count": 4,
+        "tiny_router_candidate_count": 1,
+        "source_context_gap_count": 0,
+    }
+    assert report["counts_by_residual_kind"] == {
+        "agent_boundary_complex_visual_ownership": 2,
+        "provider_runtime_fallback": 2,
+        "tiny_router_confidence_gap": 1,
+    }
+    assert report["counts_by_recommended_next_step"] == {
+        "keep_agent_boundary": 2,
+        "route_provider_failure_to_runtime_handler": 2,
+        "add_confidence_calibration_or_label": 1,
+    }
+    assert [item["case_id"] for item in report["residual_cases"]] == [
+        "decompose_occlusion",
+        "redraw_under_split",
+        "layer_provider_failure",
+        "manual_provider_failure",
+        "seed_low_confidence",
+    ]
+    seed = next(item for item in report["residual_cases"] if item["case_id"] == "seed_low_confidence")
+    assert seed["residual_kind"] == "tiny_router_confidence_gap"
+    assert seed["recommended_next_step"] == "add_confidence_calibration_or_label"
+    assert report_path.exists()
+
+
+def test_fallback_residual_audit_cli_writes_summary(tmp_path):
+    decision_path = tmp_path / "dry_run_decisions.jsonl"
+    report_path = tmp_path / "fallback_residual_audit_report.json"
+    _write_jsonl(decision_path, _fixture_decisions())
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--decision-path",
+            str(decision_path),
+            "--report",
+            str(report_path),
+        ],
+        cwd=ROOT,
+        env=CLI_ENV,
+        text=True,
+        capture_output=True,
+        timeout=30,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "Fallback residual audit:" in result.stdout
+    assert "Fallback agent decisions: 5" in result.stdout
+    assert "Tiny router candidates: 1" in result.stdout
+    assert "Agent-required residuals: 4" in result.stdout
+    report = json.loads(report_path.read_text(encoding="utf-8"))
+    assert report["summary"]["fallback_agent_count"] == 5


### PR DESCRIPTION
## Summary
- add fallback residual audit module and CLI for dry-run decision JSONL files
- classify remaining fallback-agent decisions into tiny-router confidence gaps, provider runtime fallbacks, and agent visual ownership boundaries
- include unit and CLI coverage with safe reports that omit private paths/source refs

## Verified current private-recovery residuals
- fallback_agent_count: 5
- tiny_router_candidate_count: 1
- agent_required_count: 4
- source_context_gap_count: 0
- residual kinds: 2 complex visual ownership, 2 provider runtime fallback, 1 tiny router confidence gap

## Verification
- PYTHONPATH=src python3 -m pytest tests/test_fallback_residual_audit.py -q
- PYTHONPATH=src python3 scripts/fallback_residual_audit.py --decision-path build/fallback_residual_audit_v1/real_recovery_eval/recovered/dry_run/dry_run_decisions.jsonl --report build/fallback_residual_audit_v1/residual_audit/report.json
- PYTHONPATH=src python3 -m pytest tests/test_fallback_residual_audit.py tests/test_real_source_context_recovery_eval.py tests/test_training_effectiveness_report.py tests/test_source_context_gap_pack.py tests/test_dry_run_decision_router.py -q
- ruff check src/vulca/learning/fallback_residual_audit.py scripts/fallback_residual_audit.py tests/test_fallback_residual_audit.py
- python3 -m py_compile src/vulca/learning/fallback_residual_audit.py scripts/fallback_residual_audit.py
- git diff --check
