### PR TITLE
Calibrate accept confidence fallback

### DIFF
--- a/src/vulca/learning/dry_run_decision_router.py
+++ b/src/vulca/learning/dry_run_decision_router.py
@@ -242,9 +242,18 @@ def _dispatch_record(
 ) -> dict[str, Any]:
     fallback_reasons: list[str] = []
     data_gap_tags: list[str] = []
+    confidence_calibration = ""
     if recommended_action == "fallback_to_agent":
         fallback_reasons.append("action_fallback_to_agent")
-    if action_confidence < min_action_confidence:
+    low_confidence = action_confidence < min_action_confidence
+    accept_with_source_context = (
+        recommended_action == "accept"
+        and source_context_available
+        and source_dependency == "required"
+    )
+    if low_confidence and accept_with_source_context:
+        confidence_calibration = "accept_with_source_context"
+    elif low_confidence:
         fallback_reasons.append("low_action_confidence")
         data_gap_tags.append("low_action_confidence")
     if source_dependency == "required" and not source_context_available:
@@ -257,13 +266,14 @@ def _dispatch_record(
     return {
         "decision_owner": (
             "fallback_agent"
-            if action_confidence < min_action_confidence
+            if "low_action_confidence" in fallback_reasons
             else "tiny_model"
         ),
         "execution_owner": "fallback_agent" if fallback_agent else "tiny_model",
         "fallback_agent": fallback_agent,
         "fallback_reasons": fallback_reasons,
         "data_gap_tags": data_gap_tags,
+        "confidence_calibration": confidence_calibration,
     }
 
 

--- a/tests/test_dry_run_decision_router.py
+++ b/tests/test_dry_run_decision_router.py
@@ -213,6 +213,36 @@ def test_dry_run_decisions_treat_auxiliary_source_context_signal_as_available():
     }
 
 
+def test_dry_run_decisions_do_not_fallback_accepted_cases_with_source_context():
+    from vulca.learning.dry_run_decision_router import build_dry_run_decisions
+
+    train = _example("train_style", split="train")
+    accepted = _example(
+        "test_accepted_with_source_context",
+        split="test",
+        failure_type="",
+        preferred_action="accept",
+        source_dependency="required",
+        source_decision_basis="artifact_source",
+        source_context_available=True,
+    )
+
+    decisions = build_dry_run_decisions(
+        [train, accepted],
+        eval_split="test",
+        train_split="train",
+    )
+
+    assert len(decisions) == 1
+    decision = decisions[0]
+    assert decision["action_router"]["recommended_action"] == "accept"
+    assert decision["action_router"]["confidence"] < 0.5
+    assert decision["dispatch"]["fallback_agent"] is False
+    assert decision["dispatch"]["fallback_reasons"] == []
+    assert decision["dispatch"]["data_gap_tags"] == []
+    assert decision["dispatch"]["confidence_calibration"] == "accept_with_source_context"
+
+
 def test_dry_run_router_report_summarizes_counts_and_evaluation():
     from vulca.learning.dry_run_decision_router import build_dry_run_router_report
 

--- a/tests/test_fallback_residual_audit.py
+++ b/tests/test_fallback_residual_audit.py
@@ -77,7 +77,15 @@ def _fixture_decisions() -> list[dict]:
             failure_hint="",
             fallback_reasons=["low_action_confidence"],
             data_gap_tags=["low_action_confidence"],
-        ),
+        )
+        | {
+            "dispatch": {
+                "fallback_agent": False,
+                "fallback_reasons": [],
+                "data_gap_tags": [],
+                "confidence_calibration": "accept_with_source_context",
+            }
+        },
         _decision(
             "redraw_under_split",
             case_type="redraw_case",
@@ -140,31 +148,25 @@ def test_fallback_residual_audit_classifies_remaining_agent_work(tmp_path):
     assert report["status"] == "needs_agent_or_router_boundary_work"
     assert report["summary"] == {
         "decision_count": 6,
-        "fallback_agent_count": 5,
+        "fallback_agent_count": 4,
         "agent_required_count": 4,
-        "tiny_router_candidate_count": 1,
+        "tiny_router_candidate_count": 0,
         "source_context_gap_count": 0,
     }
     assert report["counts_by_residual_kind"] == {
         "agent_boundary_complex_visual_ownership": 2,
         "provider_runtime_fallback": 2,
-        "tiny_router_confidence_gap": 1,
     }
     assert report["counts_by_recommended_next_step"] == {
         "keep_agent_boundary": 2,
         "route_provider_failure_to_runtime_handler": 2,
-        "add_confidence_calibration_or_label": 1,
     }
     assert [item["case_id"] for item in report["residual_cases"]] == [
         "decompose_occlusion",
         "redraw_under_split",
         "layer_provider_failure",
         "manual_provider_failure",
-        "seed_low_confidence",
     ]
-    seed = next(item for item in report["residual_cases"] if item["case_id"] == "seed_low_confidence")
-    assert seed["residual_kind"] == "tiny_router_confidence_gap"
-    assert seed["recommended_next_step"] == "add_confidence_calibration_or_label"
     assert report_path.exists()
 
 
@@ -192,8 +194,8 @@ def test_fallback_residual_audit_cli_writes_summary(tmp_path):
 
     assert result.returncode == 0, result.stderr
     assert "Fallback residual audit:" in result.stdout
-    assert "Fallback agent decisions: 5" in result.stdout
-    assert "Tiny router candidates: 1" in result.stdout
+    assert "Fallback agent decisions: 4" in result.stdout
+    assert "Tiny router candidates: 0" in result.stdout
     assert "Agent-required residuals: 4" in result.stdout
     report = json.loads(report_path.read_text(encoding="utf-8"))
-    assert report["summary"]["fallback_agent_count"] == 5
+    assert report["summary"]["fallback_agent_count"] == 4

--- a/tests/test_training_effectiveness_report.py
+++ b/tests/test_training_effectiveness_report.py
@@ -154,14 +154,14 @@ def test_training_effectiveness_report_compares_source_context_router_improvemen
         "skipped_count": 19,
     }
     assert router["baseline_without_source_context_signals"]["fallback_agent_count"] == 21
-    assert router["with_source_context_signals"]["fallback_agent_count"] == 7
+    assert router["with_source_context_signals"]["fallback_agent_count"] == 6
     assert router["delta"] == {
-        "fallback_agent_count": -14,
-        "fallback_agent_count_reduction": 14,
+        "fallback_agent_count": -15,
+        "fallback_agent_count_reduction": 15,
         "no_source_context_for_required_source": -17,
         "no_source_context_for_required_source_reduction": 17,
     }
-    assert router["improved_case_count"] == 14
+    assert router["improved_case_count"] == 15
     assert router["remaining_no_source_context_gap_count"] == 2
     assert {item["case_type"] for item in router["improved_cases"]} == {
         "redraw_case",
@@ -176,7 +176,7 @@ def test_training_effectiveness_report_compares_source_context_router_improvemen
         "best_policy": "tiny_model_with_source_context_signals",
         "baseline_policy": "tiny_model_without_source_context_signals",
         "primary_metric": "fallback_agent_count_reduction",
-        "primary_accuracy": 14,
+        "primary_accuracy": 15,
         "secondary_metric": "no_source_context_gap_reduction",
         "secondary_accuracy": 17,
         "mismatch_count": 0,
@@ -223,9 +223,9 @@ def test_training_effectiveness_report_script_writes_report_and_prints_summary(t
     ) in result.stdout
     assert "Ablation hardest drop:" in result.stdout
     assert "Source context signals: 31/50" in result.stdout
-    assert "Dry-run fallback_agent_count: 21 -> 7 (reduction 14)" in result.stdout
+    assert "Dry-run fallback_agent_count: 21 -> 6 (reduction 15)" in result.stdout
     assert "Dry-run no_source_context_for_required_source: 19 -> 2 (reduction 17)" in result.stdout
-    assert "Dry-run improved cases: 14" in result.stdout
+    assert "Dry-run improved cases: 15" in result.stdout
     assert "Dry-run remaining source-context gaps: 2" in result.stdout
     assert "tiny_agent_v0 action_accuracy:" in result.stdout
     assert "Data gaps: 0" in result.stdout


### PR DESCRIPTION
## Summary
- allow low-confidence accepted decisions to stay with tiny_model when required source context is available
- keep explicit fallback_to_agent and missing-source fallbacks unchanged
- update training-effectiveness and residual-audit expectations after the tiny-router confidence gap is removed

## Verified effect
- public source-context dry-run fallback: 21 -> 6 (reduction 15)
- private recovery dry-run fallback: 6 -> 4
- recovered no_source_context_for_required_source: 2 -> 0
- residual audit tiny_router_candidate_count: 0
- residual fallback_agent_count: 4

## Verification
- PYTHONPATH=src python3 -m pytest tests/test_dry_run_decision_router.py::test_dry_run_decisions_do_not_fallback_accepted_cases_with_source_context tests/test_training_effectiveness_report.py::test_training_effectiveness_report_compares_source_context_router_improvement tests/test_fallback_residual_audit.py::test_fallback_residual_audit_classifies_remaining_agent_work -q
- PYTHONPATH=src python3 scripts/real_source_context_recovery_eval.py --repo-root . --case-source-manifest docs/benchmarks/learning/combined_case_source_manifest_v1.json --artifact-search-root /Users/yhryzy/dev/vulca/.scratch/p2b-live-shipgate --image-search-root /Users/yhryzy/dev/vulca/.scratch/p2b-live-shipgate --source-dependency-manifest docs/benchmarks/learning/real_source_dependency_label_manifest_v1.json --output-dir build/tiny_confidence_calibration_v1/real_recovery_eval --report build/tiny_confidence_calibration_v1/real_recovery_eval/report.json --max-recovered-source-context-gaps 0 --min-fallback-agent-reduction 2 --min-recovered-eval-cases 2
- PYTHONPATH=src python3 scripts/training_effectiveness_report.py --repo-root . --output-dir build/tiny_confidence_calibration_v1/training_effectiveness --report build/tiny_confidence_calibration_v1/training_effectiveness/report.json
- PYTHONPATH=src python3 scripts/fallback_residual_audit.py --decision-path build/tiny_confidence_calibration_v1/real_recovery_eval/recovered/dry_run/dry_run_decisions.jsonl --report build/tiny_confidence_calibration_v1/residual_audit/report.json
- PYTHONPATH=src python3 -m pytest tests/test_dry_run_decision_router.py tests/test_training_effectiveness_report.py tests/test_real_source_context_recovery_eval.py tests/test_fallback_residual_audit.py tests/test_source_context_gap_pack.py -q
- ruff check src/vulca/learning/dry_run_decision_router.py tests/test_dry_run_decision_router.py tests/test_training_effectiveness_report.py tests/test_fallback_residual_audit.py
- python3 -m py_compile src/vulca/learning/dry_run_decision_router.py
- git diff --check
