### PR TITLE
Route provider failures to runtime recovery

### DIFF
--- a/scripts/dry_run_decision_router.py
+++ b/scripts/dry_run_decision_router.py
@@ -119,6 +119,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     print(f"Dataset: {report['artifacts']['dataset_path']}")
     print(f"Decisions: {summary['decision_count']}")
     print(f"Fallback agent decisions: {summary['fallback_agent_count']}")
+    print(f"Runtime recovery decisions: {summary['runtime_recovery_count']}")
     print(
         "tiny_action_model_v1 action_accuracy: "
         f"{evaluation['action_accuracy']}"

--- a/scripts/training_effectiveness_report.py
+++ b/scripts/training_effectiveness_report.py
@@ -183,6 +183,11 @@ def main(argv: Sequence[str] | None = None) -> int:
         f"{current_router['fallback_agent_count']} "
         f"(reduction {router_delta['fallback_agent_count_reduction']})"
     )
+    print(
+        "Dry-run runtime_recovery_count: "
+        f"{baseline_router['runtime_recovery_count']} -> "
+        f"{current_router['runtime_recovery_count']}"
+    )
     baseline_gap_count = baseline_router["data_gap_counts"].get(
         "no_source_context_for_required_source",
         0,

--- a/src/vulca/learning/dry_run_decision_router.py
+++ b/src/vulca/learning/dry_run_decision_router.py
@@ -188,6 +188,7 @@ def _decision_record(
     targets = _mapping(example.get("targets"))
     confidence = _float(action_prediction.get("confidence"), default=0.0)
     recommended_action = str(action_prediction.get("recommended_action") or "")
+    failure_hint = str(action_prediction.get("failure_hint") or "")
     source_dependency = str(source_prediction.source_dependency or "")
     decision_basis = str(source_prediction.decision_basis or "")
     target_dependency = str(targets.get("source_dependency") or "")
@@ -195,6 +196,7 @@ def _decision_record(
     source_context = _source_context_summary(example)
     dispatch = _dispatch_record(
         recommended_action=recommended_action,
+        failure_hint=failure_hint,
         action_confidence=confidence,
         min_action_confidence=min_action_confidence,
         source_dependency=source_dependency,
@@ -213,7 +215,7 @@ def _decision_record(
             "policy_name": POLICY_TINY_ACTION_MODEL,
             "recommended_action": recommended_action,
             "confidence": confidence,
-            "failure_hint": str(action_prediction.get("failure_hint") or ""),
+            "failure_hint": failure_hint,
             "rule_reason": _action_rule_reason(action_prediction),
             "target_action": str(targets.get("preferred_action") or ""),
         },
@@ -234,6 +236,7 @@ def _decision_record(
 def _dispatch_record(
     *,
     recommended_action: str,
+    failure_hint: str,
     action_confidence: float,
     min_action_confidence: float,
     source_dependency: str,
@@ -243,8 +246,13 @@ def _dispatch_record(
     fallback_reasons: list[str] = []
     data_gap_tags: list[str] = []
     confidence_calibration = ""
+    runtime_recovery = (
+        recommended_action == "fallback_to_agent" and failure_hint == "provider_failure"
+    )
+    runtime_recovery_kind = "provider_failure" if runtime_recovery else ""
     if recommended_action == "fallback_to_agent":
-        fallback_reasons.append("action_fallback_to_agent")
+        if not runtime_recovery:
+            fallback_reasons.append("action_fallback_to_agent")
     low_confidence = action_confidence < min_action_confidence
     accept_with_source_context = (
         recommended_action == "accept"
@@ -263,14 +271,26 @@ def _dispatch_record(
         data_gap_tags.append("no_source_dependency_label")
 
     fallback_agent = bool(fallback_reasons)
+    decision_owner = (
+        "runtime_provider_recovery"
+        if runtime_recovery
+        else "fallback_agent"
+        if "low_action_confidence" in fallback_reasons
+        else "tiny_model"
+    )
+    execution_owner = (
+        "runtime_provider_recovery"
+        if runtime_recovery
+        else "fallback_agent"
+        if fallback_agent
+        else "tiny_model"
+    )
     return {
-        "decision_owner": (
-            "fallback_agent"
-            if "low_action_confidence" in fallback_reasons
-            else "tiny_model"
-        ),
-        "execution_owner": "fallback_agent" if fallback_agent else "tiny_model",
+        "decision_owner": decision_owner,
+        "execution_owner": execution_owner,
         "fallback_agent": fallback_agent,
+        "runtime_recovery": runtime_recovery,
+        "runtime_recovery_kind": runtime_recovery_kind,
         "fallback_reasons": fallback_reasons,
         "data_gap_tags": data_gap_tags,
         "confidence_calibration": confidence_calibration,
@@ -313,6 +333,11 @@ def _build_summary(decisions: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
         "counts_by_execution_owner": _counter_by(
             decisions,
             lambda item: _mapping(item.get("dispatch")).get("execution_owner"),
+        ),
+        "runtime_recovery_count": sum(
+            1
+            for decision in decisions
+            if bool(_mapping(decision.get("dispatch")).get("runtime_recovery"))
         ),
         "fallback_reason_counts": dict(sorted(fallback_reason_counts.items())),
         "data_gap_counts": dict(sorted(data_gap_counts.items())),

--- a/src/vulca/learning/training_effectiveness.py
+++ b/src/vulca/learning/training_effectiveness.py
@@ -401,6 +401,7 @@ def _compact_dry_run_report(report: Mapping[str, Any]) -> dict[str, Any]:
     return {
         "decision_count": int(summary.get("decision_count") or 0),
         "fallback_agent_count": int(summary.get("fallback_agent_count") or 0),
+        "runtime_recovery_count": int(summary.get("runtime_recovery_count") or 0),
         "data_gap_counts": dict(_mapping(summary.get("data_gap_counts"))),
         "fallback_reason_counts": dict(_mapping(summary.get("fallback_reason_counts"))),
         "counts_by_execution_owner": dict(

--- a/tests/test_dry_run_decision_router.py
+++ b/tests/test_dry_run_decision_router.py
@@ -169,7 +169,12 @@ def test_dry_run_decisions_combine_action_source_dependency_and_dispatch():
     assert provider["source_dependency_router"]["recommended_decision_basis"] == (
         "metadata_only"
     )
-    assert provider["dispatch"]["fallback_reasons"] == ["action_fallback_to_agent"]
+    assert provider["dispatch"]["decision_owner"] == "runtime_provider_recovery"
+    assert provider["dispatch"]["execution_owner"] == "runtime_provider_recovery"
+    assert provider["dispatch"]["fallback_agent"] is False
+    assert provider["dispatch"]["runtime_recovery"] is True
+    assert provider["dispatch"]["runtime_recovery_kind"] == "provider_failure"
+    assert provider["dispatch"]["fallback_reasons"] == []
     assert provider["dispatch"]["data_gap_tags"] == []
 
     decompose = by_case["test_decompose_source_available"]
@@ -320,6 +325,7 @@ def test_dry_run_decision_router_cli_writes_real_dataset_report(tmp_path):
     assert result.returncode == 0, result.stderr
     assert "Dry-run decision router report:" in result.stdout
     assert "Decisions: 21" in result.stdout
+    assert "Runtime recovery decisions: 2" in result.stdout
     assert "tiny_action_model_v1 action_accuracy: 1.0" in result.stdout
     assert "source_dependency_rule_v1 source_dependency_accuracy:" in result.stdout
     assert (output_dir / "dry_run_decisions.jsonl").exists()
@@ -328,6 +334,8 @@ def test_dry_run_decision_router_cli_writes_real_dataset_report(tmp_path):
     report = json.loads(report_path.read_text(encoding="utf-8"))
     assert report["summary"]["decision_count"] == 21
     assert report["summary"]["counts_by_source_dependency"]["required"] > 0
+    assert report["summary"]["counts_by_execution_owner"]["runtime_provider_recovery"] == 2
+    assert report["summary"]["runtime_recovery_count"] == 2
     assert report["evaluation"]["action_accuracy"] == 1.0
     assert report["artifacts"]["decision_path"] == str(
         output_dir / "dry_run_decisions.jsonl"

--- a/tests/test_training_effectiveness_report.py
+++ b/tests/test_training_effectiveness_report.py
@@ -153,8 +153,13 @@ def test_training_effectiveness_report_compares_source_context_router_improvemen
         "promoted_signal_count": 31,
         "skipped_count": 19,
     }
-    assert router["baseline_without_source_context_signals"]["fallback_agent_count"] == 21
-    assert router["with_source_context_signals"]["fallback_agent_count"] == 6
+    assert router["baseline_without_source_context_signals"]["fallback_agent_count"] == 19
+    assert router["with_source_context_signals"]["fallback_agent_count"] == 4
+    assert (
+        router["baseline_without_source_context_signals"]["runtime_recovery_count"]
+        == 2
+    )
+    assert router["with_source_context_signals"]["runtime_recovery_count"] == 2
     assert router["delta"] == {
         "fallback_agent_count": -15,
         "fallback_agent_count_reduction": 15,
@@ -223,7 +228,8 @@ def test_training_effectiveness_report_script_writes_report_and_prints_summary(t
     ) in result.stdout
     assert "Ablation hardest drop:" in result.stdout
     assert "Source context signals: 31/50" in result.stdout
-    assert "Dry-run fallback_agent_count: 21 -> 6 (reduction 15)" in result.stdout
+    assert "Dry-run fallback_agent_count: 19 -> 4 (reduction 15)" in result.stdout
+    assert "Dry-run runtime_recovery_count: 2 -> 2" in result.stdout
     assert "Dry-run no_source_context_for_required_source: 19 -> 2 (reduction 17)" in result.stdout
     assert "Dry-run improved cases: 15" in result.stdout
     assert "Dry-run remaining source-context gaps: 2" in result.stdout


### PR DESCRIPTION
## Summary
- route provider_failure fallback_to_agent dry-run decisions to runtime_provider_recovery instead of fallback_agent
- add runtime_recovery fields and counts to dry-run summaries
- surface runtime recovery counts in dry-run and training-effectiveness CLI output

## Real-case effect
- recovered dry-run fallback_agent_count: 4 -> 2 after provider failures move to runtime recovery
- runtime_provider_recovery decisions: 2
- residual audit expected boundaries: 2, unexpected fallbacks: 0
- remaining fallback residuals are visual ownership only: occlusion and under_split

## Verification
- PYTHONPATH=src python3 -m pytest tests/test_dry_run_decision_router.py tests/test_fallback_residual_audit.py tests/test_real_source_context_recovery_eval.py tests/test_training_effectiveness_report.py tests/test_source_context_gap_pack.py -q
- PYTHONPATH=src python3 scripts/real_source_context_recovery_eval.py --repo-root . --case-source-manifest docs/benchmarks/learning/combined_case_source_manifest_v1.json --artifact-search-root /Users/yhryzy/dev/vulca/.scratch/p2b-live-shipgate --image-search-root /Users/yhryzy/dev/vulca/.scratch/p2b-live-shipgate --source-dependency-manifest docs/benchmarks/learning/real_source_dependency_label_manifest_v1.json --output-dir build/runtime_provider_recovery_v1/real_recovery_eval --report build/runtime_provider_recovery_v1/real_recovery_eval/report.json --max-recovered-source-context-gaps 0 --min-fallback-agent-reduction 2 --min-recovered-eval-cases 2
- PYTHONPATH=src python3 scripts/fallback_residual_audit.py --decision-path build/runtime_provider_recovery_v1/real_recovery_eval/recovered/dry_run/dry_run_decisions.jsonl --report build/runtime_provider_recovery_v1/residual_audit/report.json
- ruff check src/vulca/learning/dry_run_decision_router.py src/vulca/learning/training_effectiveness.py scripts/dry_run_decision_router.py scripts/training_effectiveness_report.py tests/test_dry_run_decision_router.py tests/test_training_effectiveness_report.py
- python3 -m py_compile src/vulca/learning/dry_run_decision_router.py src/vulca/learning/training_effectiveness.py scripts/dry_run_decision_router.py scripts/training_effectiveness_report.py
- git diff --check