### PR TITLE
Route complex visual ownership to planner

### DIFF
--- a/scripts/dry_run_decision_router.py
+++ b/scripts/dry_run_decision_router.py
@@ -121,6 +121,10 @@ def main(argv: Sequence[str] | None = None) -> int:
     print(f"Fallback agent decisions: {summary['fallback_agent_count']}")
     print(f"Runtime recovery decisions: {summary['runtime_recovery_count']}")
     print(
+        "Visual ownership planner decisions: "
+        f"{summary['visual_ownership_planner_count']}"
+    )
+    print(
         "tiny_action_model_v1 action_accuracy: "
         f"{evaluation['action_accuracy']}"
     )

--- a/scripts/training_effectiveness_report.py
+++ b/scripts/training_effectiveness_report.py
@@ -188,6 +188,11 @@ def main(argv: Sequence[str] | None = None) -> int:
         f"{baseline_router['runtime_recovery_count']} -> "
         f"{current_router['runtime_recovery_count']}"
     )
+    print(
+        "Dry-run visual_ownership_planner_count: "
+        f"{baseline_router['visual_ownership_planner_count']} -> "
+        f"{current_router['visual_ownership_planner_count']}"
+    )
     baseline_gap_count = baseline_router["data_gap_counts"].get(
         "no_source_context_for_required_source",
         0,

--- a/src/vulca/learning/dry_run_decision_router.py
+++ b/src/vulca/learning/dry_run_decision_router.py
@@ -250,8 +250,13 @@ def _dispatch_record(
         recommended_action == "fallback_to_agent" and failure_hint == "provider_failure"
     )
     runtime_recovery_kind = "provider_failure" if runtime_recovery else ""
+    visual_ownership_planner = (
+        recommended_action == "fallback_to_agent"
+        and failure_hint in {"occlusion", "under_split"}
+    )
+    visual_ownership_kind = failure_hint if visual_ownership_planner else ""
     if recommended_action == "fallback_to_agent":
-        if not runtime_recovery:
+        if not runtime_recovery and not visual_ownership_planner:
             fallback_reasons.append("action_fallback_to_agent")
     low_confidence = action_confidence < min_action_confidence
     accept_with_source_context = (
@@ -274,6 +279,8 @@ def _dispatch_record(
     decision_owner = (
         "runtime_provider_recovery"
         if runtime_recovery
+        else "visual_ownership_planner"
+        if visual_ownership_planner
         else "fallback_agent"
         if "low_action_confidence" in fallback_reasons
         else "tiny_model"
@@ -281,6 +288,8 @@ def _dispatch_record(
     execution_owner = (
         "runtime_provider_recovery"
         if runtime_recovery
+        else "visual_ownership_planner"
+        if visual_ownership_planner
         else "fallback_agent"
         if fallback_agent
         else "tiny_model"
@@ -291,6 +300,8 @@ def _dispatch_record(
         "fallback_agent": fallback_agent,
         "runtime_recovery": runtime_recovery,
         "runtime_recovery_kind": runtime_recovery_kind,
+        "visual_ownership_planner": visual_ownership_planner,
+        "visual_ownership_kind": visual_ownership_kind,
         "fallback_reasons": fallback_reasons,
         "data_gap_tags": data_gap_tags,
         "confidence_calibration": confidence_calibration,
@@ -338,6 +349,13 @@ def _build_summary(decisions: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
             1
             for decision in decisions
             if bool(_mapping(decision.get("dispatch")).get("runtime_recovery"))
+        ),
+        "visual_ownership_planner_count": sum(
+            1
+            for decision in decisions
+            if bool(
+                _mapping(decision.get("dispatch")).get("visual_ownership_planner")
+            )
         ),
         "fallback_reason_counts": dict(sorted(fallback_reason_counts.items())),
         "data_gap_counts": dict(sorted(data_gap_counts.items())),

--- a/src/vulca/learning/training_effectiveness.py
+++ b/src/vulca/learning/training_effectiveness.py
@@ -402,6 +402,9 @@ def _compact_dry_run_report(report: Mapping[str, Any]) -> dict[str, Any]:
         "decision_count": int(summary.get("decision_count") or 0),
         "fallback_agent_count": int(summary.get("fallback_agent_count") or 0),
         "runtime_recovery_count": int(summary.get("runtime_recovery_count") or 0),
+        "visual_ownership_planner_count": int(
+            summary.get("visual_ownership_planner_count") or 0
+        ),
         "data_gap_counts": dict(_mapping(summary.get("data_gap_counts"))),
         "fallback_reason_counts": dict(_mapping(summary.get("fallback_reason_counts"))),
         "counts_by_execution_owner": dict(

--- a/tests/test_dry_run_decision_router.py
+++ b/tests/test_dry_run_decision_router.py
@@ -118,11 +118,12 @@ def test_dry_run_decisions_combine_action_source_dependency_and_dispatch():
             "test_decompose_source_available",
             split="test",
             case_type="decompose_case",
-            failure_type="under_segmentation",
-            preferred_action="split_layer_further",
+            failure_type="occlusion",
+            preferred_action="fallback_to_agent",
             source_dependency="required",
             source_decision_basis="image_source",
             source_context_available=True,
+            action_hint="fallback_to_agent",
         ),
     ]
 
@@ -178,12 +179,16 @@ def test_dry_run_decisions_combine_action_source_dependency_and_dispatch():
     assert provider["dispatch"]["data_gap_tags"] == []
 
     decompose = by_case["test_decompose_source_available"]
-    assert decompose["action_router"]["recommended_action"] == "split_layer_further"
+    assert decompose["action_router"]["recommended_action"] == "fallback_to_agent"
     assert decompose["source_dependency_router"]["recommended_decision_basis"] == (
         "image_source"
     )
     assert decompose["dispatch"]["fallback_agent"] is False
-    assert decompose["dispatch"]["execution_owner"] == "tiny_model"
+    assert decompose["dispatch"]["decision_owner"] == "visual_ownership_planner"
+    assert decompose["dispatch"]["execution_owner"] == "visual_ownership_planner"
+    assert decompose["dispatch"]["visual_ownership_planner"] is True
+    assert decompose["dispatch"]["visual_ownership_kind"] == "occlusion"
+    assert decompose["dispatch"]["fallback_reasons"] == []
 
 
 def test_dry_run_decisions_treat_auxiliary_source_context_signal_as_available():
@@ -326,6 +331,7 @@ def test_dry_run_decision_router_cli_writes_real_dataset_report(tmp_path):
     assert "Dry-run decision router report:" in result.stdout
     assert "Decisions: 21" in result.stdout
     assert "Runtime recovery decisions: 2" in result.stdout
+    assert "Visual ownership planner decisions: 2" in result.stdout
     assert "tiny_action_model_v1 action_accuracy: 1.0" in result.stdout
     assert "source_dependency_rule_v1 source_dependency_accuracy:" in result.stdout
     assert (output_dir / "dry_run_decisions.jsonl").exists()
@@ -336,6 +342,8 @@ def test_dry_run_decision_router_cli_writes_real_dataset_report(tmp_path):
     assert report["summary"]["counts_by_source_dependency"]["required"] > 0
     assert report["summary"]["counts_by_execution_owner"]["runtime_provider_recovery"] == 2
     assert report["summary"]["runtime_recovery_count"] == 2
+    assert report["summary"]["counts_by_execution_owner"]["visual_ownership_planner"] == 2
+    assert report["summary"]["visual_ownership_planner_count"] == 2
     assert report["evaluation"]["action_accuracy"] == 1.0
     assert report["artifacts"]["decision_path"] == str(
         output_dir / "dry_run_decisions.jsonl"

--- a/tests/test_training_effectiveness_report.py
+++ b/tests/test_training_effectiveness_report.py
@@ -154,19 +154,26 @@ def test_training_effectiveness_report_compares_source_context_router_improvemen
         "skipped_count": 19,
     }
     assert router["baseline_without_source_context_signals"]["fallback_agent_count"] == 19
-    assert router["with_source_context_signals"]["fallback_agent_count"] == 4
+    assert router["with_source_context_signals"]["fallback_agent_count"] == 2
     assert (
         router["baseline_without_source_context_signals"]["runtime_recovery_count"]
         == 2
     )
     assert router["with_source_context_signals"]["runtime_recovery_count"] == 2
+    assert (
+        router["baseline_without_source_context_signals"][
+            "visual_ownership_planner_count"
+        ]
+        == 2
+    )
+    assert router["with_source_context_signals"]["visual_ownership_planner_count"] == 2
     assert router["delta"] == {
-        "fallback_agent_count": -15,
-        "fallback_agent_count_reduction": 15,
+        "fallback_agent_count": -17,
+        "fallback_agent_count_reduction": 17,
         "no_source_context_for_required_source": -17,
         "no_source_context_for_required_source_reduction": 17,
     }
-    assert router["improved_case_count"] == 15
+    assert router["improved_case_count"] == 17
     assert router["remaining_no_source_context_gap_count"] == 2
     assert {item["case_type"] for item in router["improved_cases"]} == {
         "redraw_case",
@@ -181,7 +188,7 @@ def test_training_effectiveness_report_compares_source_context_router_improvemen
         "best_policy": "tiny_model_with_source_context_signals",
         "baseline_policy": "tiny_model_without_source_context_signals",
         "primary_metric": "fallback_agent_count_reduction",
-        "primary_accuracy": 15,
+        "primary_accuracy": 17,
         "secondary_metric": "no_source_context_gap_reduction",
         "secondary_accuracy": 17,
         "mismatch_count": 0,
@@ -228,10 +235,11 @@ def test_training_effectiveness_report_script_writes_report_and_prints_summary(t
     ) in result.stdout
     assert "Ablation hardest drop:" in result.stdout
     assert "Source context signals: 31/50" in result.stdout
-    assert "Dry-run fallback_agent_count: 19 -> 4 (reduction 15)" in result.stdout
+    assert "Dry-run fallback_agent_count: 19 -> 2 (reduction 17)" in result.stdout
     assert "Dry-run runtime_recovery_count: 2 -> 2" in result.stdout
+    assert "Dry-run visual_ownership_planner_count: 2 -> 2" in result.stdout
     assert "Dry-run no_source_context_for_required_source: 19 -> 2 (reduction 17)" in result.stdout
-    assert "Dry-run improved cases: 15" in result.stdout
+    assert "Dry-run improved cases: 17" in result.stdout
     assert "Dry-run remaining source-context gaps: 2" in result.stdout
     assert "tiny_agent_v0 action_accuracy:" in result.stdout
     assert "Data gaps: 0" in result.stdout


### PR DESCRIPTION
## Summary
- route occlusion / under_split fallback_to_agent dry-run decisions to visual_ownership_planner
- add visual ownership planner fields and counts to dry-run summaries
- surface visual ownership counts in dry-run and training-effectiveness CLI output

## Real-case effect
- recovered dry-run fallback_agent_count: 2 -> 0
- runtime_provider_recovery decisions: 2
- visual_ownership_planner decisions: 2
- residual audit fallback_agent_count: 0, unexpected fallbacks: 0

## Verification
- PYTHONPATH=src python3 -m pytest tests/test_dry_run_decision_router.py tests/test_fallback_residual_audit.py tests/test_real_source_context_recovery_eval.py tests/test_training_effectiveness_report.py tests/test_source_context_gap_pack.py -q
- PYTHONPATH=src python3 scripts/real_source_context_recovery_eval.py --repo-root . --case-source-manifest docs/benchmarks/learning/combined_case_source_manifest_v1.json --artifact-search-root /Users/yhryzy/dev/vulca/.scratch/p2b-live-shipgate --image-search-root /Users/yhryzy/dev/vulca/.scratch/p2b-live-shipgate --source-dependency-manifest docs/benchmarks/learning/real_source_dependency_label_manifest_v1.json --output-dir build/visual_ownership_planner_v1/final_real_recovery_eval --report build/visual_ownership_planner_v1/final_real_recovery_eval/report.json --max-recovered-source-context-gaps 0 --min-fallback-agent-reduction 2 --min-recovered-eval-cases 2
- PYTHONPATH=src python3 scripts/fallback_residual_audit.py --decision-path build/visual_ownership_planner_v1/final_real_recovery_eval/recovered/dry_run/dry_run_decisions.jsonl --report build/visual_ownership_planner_v1/final_residual_audit/report.json
- ruff check src/vulca/learning/dry_run_decision_router.py src/vulca/learning/training_effectiveness.py scripts/dry_run_decision_router.py scripts/training_effectiveness_report.py tests/test_dry_run_decision_router.py tests/test_training_effectiveness_report.py
- python3 -m py_compile src/vulca/learning/dry_run_decision_router.py src/vulca/learning/training_effectiveness.py scripts/dry_run_decision_router.py scripts/training_effectiveness_report.py
- git diff --check