### PR TITLE
Add visual ownership planner plans

### DIFF
--- a/scripts/visual_ownership_planner.py
+++ b/scripts/visual_ownership_planner.py
@@ -1,0 +1,79 @@
+"""Build provider-free visual ownership planner records."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Sequence
+
+
+ROOT = Path(__file__).resolve().parent.parent
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from vulca.learning.visual_ownership_planner import (  # noqa: E402
+    DEFAULT_PLAN_NAME,
+    DEFAULT_REPORT_NAME,
+    run_visual_ownership_planner,
+)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Create structured plans for visual ownership dry-run decisions.",
+    )
+    parser.add_argument(
+        "--decision-path",
+        required=True,
+        help="Dry-run decision JSONL path.",
+    )
+    parser.add_argument(
+        "--plans",
+        default="",
+        help=f"Plan JSONL path (default: alongside decision path as {DEFAULT_PLAN_NAME}).",
+    )
+    parser.add_argument(
+        "--report",
+        default="",
+        help=f"Report JSON path (default: alongside decision path as {DEFAULT_REPORT_NAME}).",
+    )
+    parser.add_argument(
+        "--pretty",
+        action="store_true",
+        help="Print full JSON report after writing it.",
+    )
+    args = parser.parse_args(argv)
+
+    decision_path = Path(args.decision_path)
+    plan_path = Path(args.plans) if args.plans else decision_path.parent / DEFAULT_PLAN_NAME
+    report_path = (
+        Path(args.report) if args.report else decision_path.parent / DEFAULT_REPORT_NAME
+    )
+    try:
+        report = run_visual_ownership_planner(
+            decision_path=decision_path,
+            plan_path=plan_path,
+            report_path=report_path,
+        )
+    except (FileNotFoundError, json.JSONDecodeError, OSError, ValueError) as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 2
+
+    if args.pretty:
+        print(json.dumps(report, indent=2, sort_keys=True))
+
+    summary = report["summary"]
+    print(f"Visual ownership planner report: {report_path}")
+    print(f"Visual ownership plans: {plan_path}")
+    print(f"Decisions: {summary['decision_count']}")
+    print(f"Visual ownership decisions: {summary['visual_ownership_decision_count']}")
+    print(f"Plans: {summary['plan_count']}")
+    print(f"Source-context gaps: {summary['source_context_gap_count']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/vulca/learning/visual_ownership_planner.py
+++ b/src/vulca/learning/visual_ownership_planner.py
@@ -1,0 +1,227 @@
+"""Provider-free planning for visual ownership boundary decisions."""
+
+from __future__ import annotations
+
+import json
+from collections import Counter
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+
+SCHEMA_VERSION = 1
+PLAN_CASE_TYPE = "learning_visual_ownership_plan"
+REPORT_CASE_TYPE = "learning_visual_ownership_planner_report"
+DEFAULT_PLAN_NAME = "visual_ownership_plans.jsonl"
+DEFAULT_REPORT_NAME = "visual_ownership_planner_report.json"
+
+PLANNER_NAME = "visual_ownership_planner_v1"
+NEXT_OWNER = "visual_ownership_agent"
+
+
+def run_visual_ownership_planner(
+    *,
+    decision_path: str | Path,
+    plan_path: str | Path | None = None,
+    report_path: str | Path | None = None,
+) -> dict[str, Any]:
+    """Create structured visual ownership plans from dry-run decisions."""
+    decisions = _load_jsonl(decision_path)
+    visual_decisions = [
+        decision
+        for decision in decisions
+        if bool(_mapping(decision.get("dispatch")).get("visual_ownership_planner"))
+    ]
+    plans = sorted(
+        (_plan_for_decision(decision) for decision in visual_decisions),
+        key=lambda item: (item["source_case_type"], item["case_id"]),
+    )
+
+    resolved_plan_path = (
+        Path(plan_path) if plan_path else Path(decision_path).parent / DEFAULT_PLAN_NAME
+    )
+    _write_jsonl(resolved_plan_path, plans)
+
+    report = {
+        "schema_version": SCHEMA_VERSION,
+        "case_type": REPORT_CASE_TYPE,
+        "status": (
+            "planned_visual_ownership_work"
+            if plans
+            else "no_visual_ownership_decisions"
+        ),
+        "inputs": {
+            "decision_path": Path(decision_path).name,
+        },
+        "artifacts": {
+            "plan_path": str(resolved_plan_path),
+            "report_path": str(report_path or ""),
+        },
+        "summary": _summary(decisions, plans),
+        "counts_by_case_type": _counter_by(plans, "source_case_type"),
+        "counts_by_visual_ownership_kind": _counter_by(
+            plans,
+            "visual_ownership_kind",
+        ),
+        "counts_by_recommended_workflow": _counter_by(
+            plans,
+            "recommended_workflow",
+        ),
+        "plans": plans,
+        "safe_handling": {
+            "copies_local_paths": False,
+            "copies_private_refs": False,
+            "copies_raw_source_text": False,
+            "calls_model_provider": False,
+        },
+    }
+    if report_path:
+        output = Path(report_path)
+        output.parent.mkdir(parents=True, exist_ok=True)
+        report["artifacts"]["report_path"] = str(output)
+        output.write_text(
+            json.dumps(report, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+    return report
+
+
+def _summary(
+    decisions: Sequence[Mapping[str, Any]],
+    plans: Sequence[Mapping[str, Any]],
+) -> dict[str, int]:
+    source_context_gap_count = sum(
+        1 for plan in plans if not bool(plan.get("source_context_available"))
+    )
+    return {
+        "decision_count": len(decisions),
+        "visual_ownership_decision_count": len(plans),
+        "plan_count": len(plans),
+        "source_context_gap_count": source_context_gap_count,
+    }
+
+
+def _plan_for_decision(decision: Mapping[str, Any]) -> dict[str, Any]:
+    action_router = _mapping(decision.get("action_router"))
+    dispatch = _mapping(decision.get("dispatch"))
+    source_dependency = _mapping(decision.get("source_dependency_router"))
+    source_context = _mapping(decision.get("source_context"))
+    case_type = str(decision.get("source_case_type") or "")
+    failure_hint = str(action_router.get("failure_hint") or "")
+    ownership_kind = str(dispatch.get("visual_ownership_kind") or failure_hint)
+    workflow, required_inputs, planner_steps = _workflow_contract(
+        case_type=case_type,
+        visual_ownership_kind=ownership_kind,
+    )
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "case_type": PLAN_CASE_TYPE,
+        "planner_name": PLANNER_NAME,
+        "example_id": str(decision.get("example_id") or ""),
+        "case_id": str(decision.get("case_id") or ""),
+        "source_case_type": case_type,
+        "recommended_action": str(action_router.get("recommended_action") or ""),
+        "failure_hint": failure_hint,
+        "visual_ownership_kind": ownership_kind,
+        "recommended_workflow": workflow,
+        "required_inputs": required_inputs,
+        "planner_steps": planner_steps,
+        "source_context_available": bool(source_context.get("available")),
+        "source_context_signal_count": int(source_context.get("signal_count") or 0),
+        "source_dependency": str(
+            source_dependency.get("recommended_source_dependency") or ""
+        ),
+        "decision_basis": str(
+            source_dependency.get("recommended_decision_basis") or ""
+        ),
+        "routing": {
+            "next_owner": NEXT_OWNER,
+            "production_runtime_ready": False,
+            "requires_visual_agent_judgement": True,
+        },
+    }
+
+
+def _workflow_contract(
+    *,
+    case_type: str,
+    visual_ownership_kind: str,
+) -> tuple[str, list[str], list[str]]:
+    if visual_ownership_kind == "occlusion":
+        return (
+            "decompose_occlusion_replan",
+            [
+                "source_image",
+                "current_layer_manifest",
+                "layer_order_or_occlusion_notes",
+            ],
+            [
+                "inspect_source_occlusion_relationships",
+                "separate_occluder_and_occluded_regions",
+                "verify_layer_order_and_mask_edges",
+            ],
+        )
+    if visual_ownership_kind == "under_split":
+        workflow = (
+            "redraw_under_split_boundary_replan"
+            if case_type == "redraw_case"
+            else "decompose_under_split_boundary_replan"
+        )
+        return (
+            workflow,
+            [
+                "source_image",
+                "current_mask_or_layer_bounds",
+                "target_region_description",
+            ],
+            [
+                "inspect_under_split_boundaries",
+                "propose_additional_layer_or_mask_splits",
+                "verify_target_region_isolation",
+            ],
+        )
+    return (
+        "visual_ownership_manual_replan",
+        [
+            "source_image",
+            "current_visual_artifact",
+            "target_region_description",
+        ],
+        [
+            "inspect_visual_ownership_boundary",
+            "choose_redraw_decompose_or_manual_review_route",
+            "verify_target_region_ownership",
+        ],
+    )
+
+
+def _counter_by(items: Sequence[Mapping[str, Any]], key: str) -> dict[str, int]:
+    counts: Counter[str] = Counter()
+    for item in items:
+        counts[str(item.get(key) or "unknown")] += 1
+    return dict(sorted(counts.items()))
+
+
+def _load_jsonl(path: str | Path) -> list[dict[str, Any]]:
+    records: list[dict[str, Any]] = []
+    for line in Path(path).read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        value = json.loads(line)
+        if isinstance(value, Mapping):
+            records.append(dict(value))
+    return records
+
+
+def _write_jsonl(path: str | Path, records: Sequence[Mapping[str, Any]]) -> None:
+    output = Path(path)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    with output.open("w", encoding="utf-8") as fh:
+        for record in records:
+            fh.write(json.dumps(dict(record), sort_keys=True, separators=(",", ":")))
+            fh.write("\n")
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    if isinstance(value, Mapping):
+        return value
+    return {}

--- a/tests/test_visual_ownership_planner.py
+++ b/tests/test_visual_ownership_planner.py
@@ -1,0 +1,219 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+CLI_ENV = dict(
+    os.environ,
+    PYTHONPATH=str(ROOT / "src") + os.pathsep + os.environ.get("PYTHONPATH", ""),
+)
+SCRIPT = ROOT / "scripts" / "visual_ownership_planner.py"
+
+
+def _decision(
+    case_id: str,
+    *,
+    case_type: str,
+    failure_hint: str,
+    visual_ownership_kind: str,
+) -> dict:
+    return {
+        "schema_version": 1,
+        "case_type": "learning_dry_run_decision",
+        "example_id": f"tiny_{case_id}",
+        "case_id": case_id,
+        "source_case_type": case_type,
+        "split": "test",
+        "action_router": {
+            "policy_name": "tiny_action_model_v1",
+            "recommended_action": "fallback_to_agent",
+            "confidence": 0.86,
+            "failure_hint": failure_hint,
+            "rule_reason": "fixture",
+            "target_action": "fallback_to_agent",
+        },
+        "source_dependency_router": {
+            "policy_name": "source_dependency_rule_v1",
+            "recommended_source_dependency": "required",
+            "recommended_decision_basis": "image_source",
+            "confidence": 0.8,
+            "rule_reason": "fixture",
+            "target_source_dependency": "required",
+            "target_decision_basis": "image_source",
+        },
+        "source_context": {
+            "available": True,
+            "source": "auxiliary_signal",
+            "signal_count": 1,
+        },
+        "dispatch": {
+            "decision_owner": "visual_ownership_planner",
+            "execution_owner": "visual_ownership_planner",
+            "fallback_agent": False,
+            "runtime_recovery": False,
+            "runtime_recovery_kind": "",
+            "visual_ownership_planner": True,
+            "visual_ownership_kind": visual_ownership_kind,
+            "fallback_reasons": [],
+            "data_gap_tags": [],
+            "confidence_calibration": "",
+        },
+    }
+
+
+def _write_jsonl(path: Path, records: list[dict]) -> None:
+    path.write_text(
+        "\n".join(json.dumps(record, sort_keys=True) for record in records) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _fixture_decisions() -> list[dict]:
+    return [
+        _decision(
+            "taxonomy_v1_decompose_occlusion_holdout",
+            case_type="decompose_case",
+            failure_hint="occlusion",
+            visual_ownership_kind="occlusion",
+        ),
+        _decision(
+            "taxonomy_v1_redraw_under_split_holdout",
+            case_type="redraw_case",
+            failure_hint="under_split",
+            visual_ownership_kind="under_split",
+        ),
+        _decision(
+            "resolved_mask_leak",
+            case_type="redraw_case",
+            failure_hint="mask_leak",
+            visual_ownership_kind="",
+        )
+        | {
+            "dispatch": {
+                "decision_owner": "tiny_model",
+                "execution_owner": "tiny_model",
+                "fallback_agent": False,
+                "visual_ownership_planner": False,
+            }
+        },
+    ]
+
+
+def test_visual_ownership_planner_builds_structured_plans(tmp_path):
+    from vulca.learning.visual_ownership_planner import run_visual_ownership_planner
+
+    decision_path = tmp_path / "dry_run_decisions.jsonl"
+    plan_path = tmp_path / "visual_ownership_plans.jsonl"
+    report_path = tmp_path / "visual_ownership_planner_report.json"
+    _write_jsonl(decision_path, _fixture_decisions())
+
+    report = run_visual_ownership_planner(
+        decision_path=decision_path,
+        plan_path=plan_path,
+        report_path=report_path,
+    )
+
+    assert report["case_type"] == "learning_visual_ownership_planner_report"
+    assert report["status"] == "planned_visual_ownership_work"
+    assert report["summary"] == {
+        "decision_count": 3,
+        "visual_ownership_decision_count": 2,
+        "plan_count": 2,
+        "source_context_gap_count": 0,
+    }
+    assert report["counts_by_visual_ownership_kind"] == {
+        "occlusion": 1,
+        "under_split": 1,
+    }
+    assert report["counts_by_recommended_workflow"] == {
+        "decompose_occlusion_replan": 1,
+        "redraw_under_split_boundary_replan": 1,
+    }
+    assert report["safe_handling"] == {
+        "copies_local_paths": False,
+        "copies_private_refs": False,
+        "copies_raw_source_text": False,
+        "calls_model_provider": False,
+    }
+
+    plans = [
+        json.loads(line)
+        for line in plan_path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+    assert [plan["case_id"] for plan in plans] == [
+        "taxonomy_v1_decompose_occlusion_holdout",
+        "taxonomy_v1_redraw_under_split_holdout",
+    ]
+    by_case = {plan["case_id"]: plan for plan in plans}
+
+    occlusion = by_case["taxonomy_v1_decompose_occlusion_holdout"]
+    assert occlusion["case_type"] == "learning_visual_ownership_plan"
+    assert occlusion["recommended_workflow"] == "decompose_occlusion_replan"
+    assert occlusion["required_inputs"] == [
+        "source_image",
+        "current_layer_manifest",
+        "layer_order_or_occlusion_notes",
+    ]
+    assert occlusion["planner_steps"] == [
+        "inspect_source_occlusion_relationships",
+        "separate_occluder_and_occluded_regions",
+        "verify_layer_order_and_mask_edges",
+    ]
+    assert occlusion["routing"]["next_owner"] == "visual_ownership_agent"
+    assert occlusion["routing"]["production_runtime_ready"] is False
+
+    under_split = by_case["taxonomy_v1_redraw_under_split_holdout"]
+    assert under_split["recommended_workflow"] == "redraw_under_split_boundary_replan"
+    assert under_split["required_inputs"] == [
+        "source_image",
+        "current_mask_or_layer_bounds",
+        "target_region_description",
+    ]
+    assert under_split["planner_steps"] == [
+        "inspect_under_split_boundaries",
+        "propose_additional_layer_or_mask_splits",
+        "verify_target_region_isolation",
+    ]
+    assert under_split["routing"]["next_owner"] == "visual_ownership_agent"
+    assert report_path.exists()
+
+
+def test_visual_ownership_planner_cli_writes_plan_and_summary(tmp_path):
+    decision_path = tmp_path / "dry_run_decisions.jsonl"
+    plan_path = tmp_path / "visual_ownership_plans.jsonl"
+    report_path = tmp_path / "visual_ownership_planner_report.json"
+    _write_jsonl(decision_path, _fixture_decisions())
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--decision-path",
+            str(decision_path),
+            "--plans",
+            str(plan_path),
+            "--report",
+            str(report_path),
+        ],
+        cwd=ROOT,
+        env=CLI_ENV,
+        text=True,
+        capture_output=True,
+        timeout=30,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "Visual ownership planner report:" in result.stdout
+    assert "Visual ownership decisions: 2" in result.stdout
+    assert "Plans: 2" in result.stdout
+    assert "Source-context gaps: 0" in result.stdout
+    assert plan_path.exists()
+    report = json.loads(report_path.read_text(encoding="utf-8"))
+    assert report["summary"]["plan_count"] == 2


### PR DESCRIPTION
## Summary
- add provider-free visual ownership planner that consumes dry-run decisions
- write structured plan JSONL records for occlusion and under_split ownership boundaries
- add CLI summary/report output for planner runs

## Real-case smoke
- recovered dry-run decisions: 21
- visual ownership decisions: 2
- plans: 2
- source-context gaps: 0
- workflows: decompose_occlusion_replan=1, redraw_under_split_boundary_replan=1

## Verification
- PYTHONPATH=src python3 -m pytest tests/test_visual_ownership_planner.py -q
- PYTHONPATH=src python3 scripts/real_source_context_recovery_eval.py --repo-root . --case-source-manifest docs/benchmarks/learning/combined_case_source_manifest_v1.json --artifact-search-root /Users/yhryzy/dev/vulca/.scratch/p2b-live-shipgate --image-search-root /Users/yhryzy/dev/vulca/.scratch/p2b-live-shipgate --source-dependency-manifest docs/benchmarks/learning/real_source_dependency_label_manifest_v1.json --output-dir build/visual_ownership_planner_plan_v1/real_recovery_eval --report build/visual_ownership_planner_plan_v1/real_recovery_eval/report.json --max-recovered-source-context-gaps 0 --min-fallback-agent-reduction 2 --min-recovered-eval-cases 2
- PYTHONPATH=src python3 scripts/visual_ownership_planner.py --decision-path build/visual_ownership_planner_plan_v1/real_recovery_eval/recovered/dry_run/dry_run_decisions.jsonl --plans build/visual_ownership_planner_plan_v1/planner/visual_ownership_plans.jsonl --report build/visual_ownership_planner_plan_v1/planner/report.json
- PYTHONPATH=src python3 -m pytest tests/test_visual_ownership_planner.py tests/test_dry_run_decision_router.py tests/test_training_effectiveness_report.py tests/test_real_source_context_recovery_eval.py -q
- ruff check src/vulca/learning/visual_ownership_planner.py scripts/visual_ownership_planner.py tests/test_visual_ownership_planner.py
- python3 -m py_compile src/vulca/learning/visual_ownership_planner.py scripts/visual_ownership_planner.py
- git diff --check