### PR TITLE
Add visual ownership execution gate

### DIFF
--- a/scripts/visual_ownership_execution_gate.py
+++ b/scripts/visual_ownership_execution_gate.py
@@ -1,0 +1,81 @@
+"""Run the provider-free visual ownership execution gate."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Sequence
+
+
+ROOT = Path(__file__).resolve().parent.parent
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from vulca.learning.visual_ownership_execution_gate import (  # noqa: E402
+    DEFAULT_GATE_NAME,
+    DEFAULT_REPORT_NAME,
+    run_visual_ownership_execution_gate,
+)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Validate visual ownership plans before agent/runtime execution.",
+    )
+    parser.add_argument(
+        "--plans",
+        required=True,
+        help="Visual ownership plan JSONL path.",
+    )
+    parser.add_argument(
+        "--gates",
+        default="",
+        help=f"Gate JSONL path (default: alongside plans as {DEFAULT_GATE_NAME}).",
+    )
+    parser.add_argument(
+        "--report",
+        default="",
+        help=f"Report JSON path (default: alongside plans as {DEFAULT_REPORT_NAME}).",
+    )
+    parser.add_argument(
+        "--pretty",
+        action="store_true",
+        help="Print full JSON report after writing it.",
+    )
+    args = parser.parse_args(argv)
+
+    plan_path = Path(args.plans)
+    gate_path = Path(args.gates) if args.gates else plan_path.parent / DEFAULT_GATE_NAME
+    report_path = (
+        Path(args.report) if args.report else plan_path.parent / DEFAULT_REPORT_NAME
+    )
+    try:
+        report = run_visual_ownership_execution_gate(
+            plan_path=plan_path,
+            gate_path=gate_path,
+            report_path=report_path,
+        )
+    except (FileNotFoundError, json.JSONDecodeError, OSError, ValueError) as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 2
+
+    if args.pretty:
+        print(json.dumps(report, indent=2, sort_keys=True))
+
+    summary = report["summary"]
+    print(f"Visual ownership execution gate report: {report_path}")
+    print(f"Visual ownership execution gates: {gate_path}")
+    print(f"Plans: {summary['plan_count']}")
+    print(f"Agent execution ready: {summary['agent_execution_ready_count']}")
+    print(f"Blocked: {summary['blocked_count']}")
+    print(f"Production runtime ready: {summary['production_runtime_ready_count']}")
+    print(f"Source-context gaps: {summary['source_context_gap_count']}")
+    print(f"Incomplete plans: {summary['incomplete_plan_count']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/vulca/learning/visual_ownership_execution_gate.py
+++ b/src/vulca/learning/visual_ownership_execution_gate.py
@@ -1,0 +1,201 @@
+"""Provider-free execution gate for visual ownership plans."""
+
+from __future__ import annotations
+
+import json
+from collections import Counter
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+
+SCHEMA_VERSION = 1
+GATE_CASE_TYPE = "learning_visual_ownership_execution_gate"
+REPORT_CASE_TYPE = "learning_visual_ownership_execution_gate_report"
+DEFAULT_GATE_NAME = "visual_ownership_execution_gate.jsonl"
+DEFAULT_REPORT_NAME = "visual_ownership_execution_gate_report.json"
+
+STATUS_READY = "ready_for_agent_execution"
+STATUS_MISSING_SOURCE = "blocked_missing_source_context"
+STATUS_INCOMPLETE = "blocked_incomplete_plan"
+
+
+def run_visual_ownership_execution_gate(
+    *,
+    plan_path: str | Path,
+    gate_path: str | Path | None = None,
+    report_path: str | Path | None = None,
+) -> dict[str, Any]:
+    """Validate visual ownership plans before agent/runtime execution."""
+    plans = _load_jsonl(plan_path)
+    gate_records = [_gate_record(plan) for plan in plans]
+    resolved_gate_path = (
+        Path(gate_path) if gate_path else Path(plan_path).parent / DEFAULT_GATE_NAME
+    )
+    _write_jsonl(resolved_gate_path, gate_records)
+
+    report = {
+        "schema_version": SCHEMA_VERSION,
+        "case_type": REPORT_CASE_TYPE,
+        "status": (
+            "ready_for_visual_ownership_agent_execution"
+            if gate_records
+            and all(record["gate_status"] == STATUS_READY for record in gate_records)
+            else "blocked_visual_ownership_execution"
+            if gate_records
+            else "no_visual_ownership_plans"
+        ),
+        "inputs": {
+            "plan_path": Path(plan_path).name,
+        },
+        "artifacts": {
+            "gate_path": str(resolved_gate_path),
+            "report_path": str(report_path or ""),
+        },
+        "summary": _summary(gate_records),
+        "counts_by_gate_status": _counter_by(gate_records, "gate_status"),
+        "counts_by_recommended_workflow": _counter_by(
+            gate_records,
+            "recommended_workflow",
+        ),
+        "gate_records": gate_records,
+        "safe_handling": {
+            "copies_local_paths": False,
+            "copies_private_refs": False,
+            "copies_raw_source_text": False,
+            "calls_model_provider": False,
+        },
+    }
+    if report_path:
+        output = Path(report_path)
+        output.parent.mkdir(parents=True, exist_ok=True)
+        report["artifacts"]["report_path"] = str(output)
+        output.write_text(
+            json.dumps(report, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+    return report
+
+
+def _summary(gate_records: Sequence[Mapping[str, Any]]) -> dict[str, int]:
+    return {
+        "plan_count": len(gate_records),
+        "agent_execution_ready_count": sum(
+            1
+            for record in gate_records
+            if bool(_mapping(record.get("readiness")).get("agent_execution_ready"))
+        ),
+        "blocked_count": sum(
+            1 for record in gate_records if record.get("gate_status") != STATUS_READY
+        ),
+        "production_runtime_ready_count": sum(
+            1
+            for record in gate_records
+            if bool(_mapping(record.get("readiness")).get("production_runtime_ready"))
+        ),
+        "source_context_gap_count": sum(
+            1 for record in gate_records if "source_context_unavailable" in record.get("gate_reasons", [])
+        ),
+        "incomplete_plan_count": sum(
+            1
+            for record in gate_records
+            if record.get("gate_status") == STATUS_INCOMPLETE
+        ),
+    }
+
+
+def _gate_record(plan: Mapping[str, Any]) -> dict[str, Any]:
+    required_inputs = _string_list(plan.get("required_inputs"))
+    planner_steps = _string_list(plan.get("planner_steps"))
+    routing = _mapping(plan.get("routing"))
+    source_context_available = bool(plan.get("source_context_available"))
+    production_runtime_ready = bool(routing.get("production_runtime_ready"))
+    gate_status, gate_reasons, next_owner = _gate_decision(
+        source_context_available=source_context_available,
+        required_inputs=required_inputs,
+        planner_steps=planner_steps,
+        routing=routing,
+    )
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "case_type": GATE_CASE_TYPE,
+        "example_id": str(plan.get("example_id") or ""),
+        "case_id": str(plan.get("case_id") or ""),
+        "source_case_type": str(plan.get("source_case_type") or ""),
+        "visual_ownership_kind": str(plan.get("visual_ownership_kind") or ""),
+        "recommended_workflow": str(plan.get("recommended_workflow") or ""),
+        "gate_status": gate_status,
+        "gate_reasons": gate_reasons,
+        "readiness": {
+            "agent_execution_ready": gate_status == STATUS_READY,
+            "production_runtime_ready": production_runtime_ready,
+            "required_input_count": len(required_inputs),
+            "planner_step_count": len(planner_steps),
+            "source_context_available": source_context_available,
+        },
+        "routing": {
+            "next_owner": next_owner,
+            "requires_runtime_adapter": not production_runtime_ready,
+        },
+    }
+
+
+def _gate_decision(
+    *,
+    source_context_available: bool,
+    required_inputs: Sequence[str],
+    planner_steps: Sequence[str],
+    routing: Mapping[str, Any],
+) -> tuple[str, list[str], str]:
+    if not source_context_available:
+        return STATUS_MISSING_SOURCE, ["source_context_unavailable"], "source_context_recovery"
+
+    reasons: list[str] = []
+    if not required_inputs:
+        reasons.append("required_inputs_missing")
+    if not planner_steps:
+        reasons.append("planner_steps_missing")
+    if str(routing.get("next_owner") or "") != "visual_ownership_agent":
+        reasons.append("visual_ownership_agent_route_missing")
+    if reasons:
+        return STATUS_INCOMPLETE, reasons, "visual_ownership_planner"
+
+    return STATUS_READY, [], "visual_ownership_agent"
+
+
+def _counter_by(items: Sequence[Mapping[str, Any]], key: str) -> dict[str, int]:
+    counts: Counter[str] = Counter()
+    for item in items:
+        counts[str(item.get(key) or "unknown")] += 1
+    return dict(sorted(counts.items()))
+
+
+def _load_jsonl(path: str | Path) -> list[dict[str, Any]]:
+    records: list[dict[str, Any]] = []
+    for line in Path(path).read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        value = json.loads(line)
+        if isinstance(value, Mapping):
+            records.append(dict(value))
+    return records
+
+
+def _write_jsonl(path: str | Path, records: Sequence[Mapping[str, Any]]) -> None:
+    output = Path(path)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    with output.open("w", encoding="utf-8") as fh:
+        for record in records:
+            fh.write(json.dumps(dict(record), sort_keys=True, separators=(",", ":")))
+            fh.write("\n")
+
+
+def _string_list(value: Any) -> list[str]:
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes)):
+        return []
+    return [str(item) for item in value]
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    if isinstance(value, Mapping):
+        return value
+    return {}

--- a/tests/test_visual_ownership_execution_gate.py
+++ b/tests/test_visual_ownership_execution_gate.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+CLI_ENV = dict(
+    os.environ,
+    PYTHONPATH=str(ROOT / "src") + os.pathsep + os.environ.get("PYTHONPATH", ""),
+)
+SCRIPT = ROOT / "scripts" / "visual_ownership_execution_gate.py"
+
+
+def _plan(
+    case_id: str,
+    *,
+    source_context_available: bool = True,
+    planner_steps: list[str] | None = None,
+    required_inputs: list[str] | None = None,
+) -> dict:
+    return {
+        "schema_version": 1,
+        "case_type": "learning_visual_ownership_plan",
+        "planner_name": "visual_ownership_planner_v1",
+        "example_id": f"tiny_{case_id}",
+        "case_id": case_id,
+        "source_case_type": "redraw_case",
+        "recommended_action": "fallback_to_agent",
+        "failure_hint": "under_split",
+        "visual_ownership_kind": "under_split",
+        "recommended_workflow": "redraw_under_split_boundary_replan",
+        "required_inputs": required_inputs
+        if required_inputs is not None
+        else [
+            "source_image",
+            "current_mask_or_layer_bounds",
+            "target_region_description",
+        ],
+        "planner_steps": planner_steps
+        if planner_steps is not None
+        else [
+            "inspect_under_split_boundaries",
+            "propose_additional_layer_or_mask_splits",
+            "verify_target_region_isolation",
+        ],
+        "source_context_available": source_context_available,
+        "source_context_signal_count": 1 if source_context_available else 0,
+        "source_dependency": "required",
+        "decision_basis": "image_source",
+        "routing": {
+            "next_owner": "visual_ownership_agent",
+            "production_runtime_ready": False,
+            "requires_visual_agent_judgement": True,
+        },
+    }
+
+
+def _write_jsonl(path: Path, records: list[dict]) -> None:
+    path.write_text(
+        "\n".join(json.dumps(record, sort_keys=True) for record in records) + "\n",
+        encoding="utf-8",
+    )
+
+
+def test_visual_ownership_execution_gate_marks_ready_and_blocked_plans(tmp_path):
+    from vulca.learning.visual_ownership_execution_gate import (
+        run_visual_ownership_execution_gate,
+    )
+
+    plan_path = tmp_path / "visual_ownership_plans.jsonl"
+    gate_path = tmp_path / "visual_ownership_execution_gate.jsonl"
+    report_path = tmp_path / "visual_ownership_execution_gate_report.json"
+    _write_jsonl(
+        plan_path,
+        [
+            _plan("ready_under_split"),
+            _plan("missing_source_context", source_context_available=False),
+            _plan("incomplete_steps", planner_steps=[]),
+        ],
+    )
+
+    report = run_visual_ownership_execution_gate(
+        plan_path=plan_path,
+        gate_path=gate_path,
+        report_path=report_path,
+    )
+
+    assert report["case_type"] == "learning_visual_ownership_execution_gate_report"
+    assert report["status"] == "blocked_visual_ownership_execution"
+    assert report["summary"] == {
+        "plan_count": 3,
+        "agent_execution_ready_count": 1,
+        "blocked_count": 2,
+        "production_runtime_ready_count": 0,
+        "source_context_gap_count": 1,
+        "incomplete_plan_count": 1,
+    }
+    assert report["counts_by_gate_status"] == {
+        "blocked_incomplete_plan": 1,
+        "blocked_missing_source_context": 1,
+        "ready_for_agent_execution": 1,
+    }
+    assert report["safe_handling"] == {
+        "copies_local_paths": False,
+        "copies_private_refs": False,
+        "copies_raw_source_text": False,
+        "calls_model_provider": False,
+    }
+
+    gate_records = [
+        json.loads(line)
+        for line in gate_path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+    by_case = {record["case_id"]: record for record in gate_records}
+
+    ready = by_case["ready_under_split"]
+    assert ready["case_type"] == "learning_visual_ownership_execution_gate"
+    assert ready["gate_status"] == "ready_for_agent_execution"
+    assert ready["gate_reasons"] == []
+    assert ready["readiness"] == {
+        "agent_execution_ready": True,
+        "production_runtime_ready": False,
+        "required_input_count": 3,
+        "planner_step_count": 3,
+        "source_context_available": True,
+    }
+    assert ready["routing"] == {
+        "next_owner": "visual_ownership_agent",
+        "requires_runtime_adapter": True,
+    }
+
+    missing_source = by_case["missing_source_context"]
+    assert missing_source["gate_status"] == "blocked_missing_source_context"
+    assert missing_source["gate_reasons"] == ["source_context_unavailable"]
+    assert missing_source["routing"]["next_owner"] == "source_context_recovery"
+
+    incomplete = by_case["incomplete_steps"]
+    assert incomplete["gate_status"] == "blocked_incomplete_plan"
+    assert incomplete["gate_reasons"] == ["planner_steps_missing"]
+    assert incomplete["routing"]["next_owner"] == "visual_ownership_planner"
+    assert report_path.exists()
+
+
+def test_visual_ownership_execution_gate_cli_writes_summary(tmp_path):
+    plan_path = tmp_path / "visual_ownership_plans.jsonl"
+    gate_path = tmp_path / "visual_ownership_execution_gate.jsonl"
+    report_path = tmp_path / "visual_ownership_execution_gate_report.json"
+    _write_jsonl(plan_path, [_plan("ready_under_split")])
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--plans",
+            str(plan_path),
+            "--gates",
+            str(gate_path),
+            "--report",
+            str(report_path),
+        ],
+        cwd=ROOT,
+        env=CLI_ENV,
+        text=True,
+        capture_output=True,
+        timeout=30,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "Visual ownership execution gate report:" in result.stdout
+    assert "Plans: 1" in result.stdout
+    assert "Agent execution ready: 1" in result.stdout
+    assert "Blocked: 0" in result.stdout
+    assert "Production runtime ready: 0" in result.stdout
+    assert gate_path.exists()
+    report = json.loads(report_path.read_text(encoding="utf-8"))
+    assert report["summary"]["agent_execution_ready_count"] == 1


### PR DESCRIPTION
## Summary
- add provider-free execution gate for visual ownership plans
- emit gate JSONL records and a summary report
- separate agent-execution readiness from production-runtime readiness

## Real-case smoke
- recovered dry-run decisions: 21
- visual ownership plans: 2
- agent execution ready: 2
- blocked: 0
- production runtime ready: 0
- source-context gaps: 0

## Verification
- PYTHONPATH=src python3 -m pytest tests/test_visual_ownership_execution_gate.py -q
- PYTHONPATH=src python3 scripts/real_source_context_recovery_eval.py --repo-root . --case-source-manifest docs/benchmarks/learning/combined_case_source_manifest_v1.json --artifact-search-root /Users/yhryzy/dev/vulca/.scratch/p2b-live-shipgate --image-search-root /Users/yhryzy/dev/vulca/.scratch/p2b-live-shipgate --source-dependency-manifest docs/benchmarks/learning/real_source_dependency_label_manifest_v1.json --output-dir build/visual_ownership_execution_gate_v1/real_recovery_eval --report build/visual_ownership_execution_gate_v1/real_recovery_eval/report.json --max-recovered-source-context-gaps 0 --min-fallback-agent-reduction 2 --min-recovered-eval-cases 2
- PYTHONPATH=src python3 scripts/visual_ownership_planner.py --decision-path build/visual_ownership_execution_gate_v1/real_recovery_eval/recovered/dry_run/dry_run_decisions.jsonl --plans build/visual_ownership_execution_gate_v1/planner/visual_ownership_plans.jsonl --report build/visual_ownership_execution_gate_v1/planner/report.json
- PYTHONPATH=src python3 scripts/visual_ownership_execution_gate.py --plans build/visual_ownership_execution_gate_v1/planner/visual_ownership_plans.jsonl --gates build/visual_ownership_execution_gate_v1/gate/visual_ownership_execution_gate.jsonl --report build/visual_ownership_execution_gate_v1/gate/report.json
- PYTHONPATH=src python3 -m pytest tests/test_visual_ownership_execution_gate.py tests/test_visual_ownership_planner.py tests/test_dry_run_decision_router.py tests/test_training_effectiveness_report.py tests/test_real_source_context_recovery_eval.py -q
- ruff check src/vulca/learning/visual_ownership_execution_gate.py scripts/visual_ownership_execution_gate.py tests/test_visual_ownership_execution_gate.py
- python3 -m py_compile src/vulca/learning/visual_ownership_execution_gate.py scripts/visual_ownership_execution_gate.py
- git diff --check