### PR TITLE
Add visual ownership runtime adapter

### DIFF
--- a/scripts/visual_ownership_runtime_adapter.py
+++ b/scripts/visual_ownership_runtime_adapter.py
@@ -1,0 +1,88 @@
+"""Build provider-free visual ownership runtime adapter requests."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Sequence
+
+
+ROOT = Path(__file__).resolve().parent.parent
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from vulca.learning.visual_ownership_runtime_adapter import (  # noqa: E402
+    DEFAULT_REPORT_NAME,
+    DEFAULT_REQUEST_NAME,
+    run_visual_ownership_runtime_adapter,
+)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Convert ready visual ownership execution gates into provider-free "
+            "runtime adapter requests."
+        )
+    )
+    parser.add_argument(
+        "--gates",
+        required=True,
+        help="Visual ownership execution gate JSONL path.",
+    )
+    parser.add_argument(
+        "--requests",
+        default="",
+        help=f"Request JSONL path (default: alongside gates as {DEFAULT_REQUEST_NAME}).",
+    )
+    parser.add_argument(
+        "--report",
+        default="",
+        help=f"Report JSON path (default: alongside gates as {DEFAULT_REPORT_NAME}).",
+    )
+    parser.add_argument(
+        "--pretty",
+        action="store_true",
+        help="Print full JSON report after writing it.",
+    )
+    args = parser.parse_args(argv)
+
+    gate_path = Path(args.gates)
+    request_path = (
+        Path(args.requests) if args.requests else gate_path.parent / DEFAULT_REQUEST_NAME
+    )
+    report_path = (
+        Path(args.report) if args.report else gate_path.parent / DEFAULT_REPORT_NAME
+    )
+    try:
+        report = run_visual_ownership_runtime_adapter(
+            gate_path=gate_path,
+            request_path=request_path,
+            report_path=report_path,
+        )
+    except (FileNotFoundError, json.JSONDecodeError, OSError, ValueError) as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 2
+
+    if args.pretty:
+        print(json.dumps(report, indent=2, sort_keys=True))
+
+    summary = report["summary"]
+    print(f"Visual ownership runtime adapter report: {report_path}")
+    print(f"Visual ownership runtime requests: {request_path}")
+    print(f"Gate records: {summary['gate_record_count']}")
+    print(f"Adapter requests: {summary['adapter_request_count']}")
+    print(f"Blocked gates: {summary['blocked_gate_count']}")
+    print(
+        "Production runtime candidates: "
+        f"{summary['production_runtime_candidate_count']}"
+    )
+    print(f"Provider calls: {summary['provider_call_count']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/vulca/learning/visual_ownership_runtime_adapter.py
+++ b/src/vulca/learning/visual_ownership_runtime_adapter.py
@@ -1,0 +1,226 @@
+"""Provider-free runtime requests for visual ownership execution gates."""
+
+from __future__ import annotations
+
+import json
+from collections import Counter
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+
+SCHEMA_VERSION = 1
+REQUEST_CASE_TYPE = "learning_visual_ownership_runtime_request"
+REPORT_CASE_TYPE = "learning_visual_ownership_runtime_adapter_report"
+DEFAULT_REQUEST_NAME = "visual_ownership_runtime_requests.jsonl"
+DEFAULT_REPORT_NAME = "visual_ownership_runtime_adapter_report.json"
+
+ADAPTER_NAME = "visual_ownership_runtime_adapter_v1"
+READY_GATE_STATUS = "ready_for_agent_execution"
+
+
+def run_visual_ownership_runtime_adapter(
+    *,
+    gate_path: str | Path,
+    request_path: str | Path | None = None,
+    report_path: str | Path | None = None,
+) -> dict[str, Any]:
+    """Convert ready visual ownership gates into runtime request records."""
+    gate_records = _load_jsonl(gate_path)
+    ready_gates = [
+        gate
+        for gate in gate_records
+        if str(gate.get("gate_status") or "") == READY_GATE_STATUS
+    ]
+    requests = sorted(
+        (_request_for_gate(gate) for gate in ready_gates),
+        key=lambda item: (item["runtime_target"], item["case_id"]),
+    )
+
+    resolved_request_path = (
+        Path(request_path)
+        if request_path
+        else Path(gate_path).parent / DEFAULT_REQUEST_NAME
+    )
+    _write_jsonl(resolved_request_path, requests)
+
+    report = {
+        "schema_version": SCHEMA_VERSION,
+        "case_type": REPORT_CASE_TYPE,
+        "status": (
+            "runtime_requests_ready_for_adapter_review"
+            if requests
+            else "no_runtime_requests"
+        ),
+        "inputs": {
+            "gate_path": Path(gate_path).name,
+        },
+        "artifacts": {
+            "request_path": str(resolved_request_path),
+            "report_path": str(report_path or ""),
+        },
+        "summary": _summary(gate_records, requests),
+        "counts_by_runtime_target": _counter_by(requests, "runtime_target"),
+        "counts_by_runtime_action": _counter_by(requests, "runtime_action"),
+        "counts_by_recommended_workflow": _counter_by(
+            requests,
+            "recommended_workflow",
+        ),
+        "blocked_gate_records": [
+            _blocked_gate_summary(gate)
+            for gate in gate_records
+            if str(gate.get("gate_status") or "") != READY_GATE_STATUS
+        ],
+        "runtime_requests": requests,
+        "safe_handling": {
+            "copies_local_paths": False,
+            "copies_private_refs": False,
+            "copies_raw_source_text": False,
+            "calls_model_provider": False,
+        },
+    }
+    if report_path:
+        output = Path(report_path)
+        output.parent.mkdir(parents=True, exist_ok=True)
+        report["artifacts"]["report_path"] = str(output)
+        output.write_text(
+            json.dumps(report, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+    return report
+
+
+def _summary(
+    gate_records: Sequence[Mapping[str, Any]],
+    requests: Sequence[Mapping[str, Any]],
+) -> dict[str, int]:
+    return {
+        "gate_record_count": len(gate_records),
+        "adapter_request_count": len(requests),
+        "blocked_gate_count": len(gate_records) - len(requests),
+        "production_runtime_candidate_count": len(requests),
+        "provider_call_count": 0,
+    }
+
+
+def _request_for_gate(gate: Mapping[str, Any]) -> dict[str, Any]:
+    workflow = str(gate.get("recommended_workflow") or "")
+    target, action, required_inputs = _runtime_contract(workflow)
+    readiness = _mapping(gate.get("readiness"))
+    routing = _mapping(gate.get("routing"))
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "case_type": REQUEST_CASE_TYPE,
+        "adapter_name": ADAPTER_NAME,
+        "example_id": str(gate.get("example_id") or ""),
+        "case_id": str(gate.get("case_id") or ""),
+        "source_case_type": str(gate.get("source_case_type") or ""),
+        "visual_ownership_kind": str(gate.get("visual_ownership_kind") or ""),
+        "recommended_workflow": workflow,
+        "runtime_target": target,
+        "runtime_action": action,
+        "required_runtime_inputs": required_inputs,
+        "gate_status": str(gate.get("gate_status") or ""),
+        "source_context_available": bool(readiness.get("source_context_available")),
+        "handoff": {
+            "from_owner": "visual_ownership_agent",
+            "to_runtime_target": target,
+            "requires_runtime_adapter": bool(routing.get("requires_runtime_adapter")),
+        },
+        "execution_policy": {
+            "provider_calls_enabled": False,
+            "requires_visual_agent_judgement": True,
+            "requires_runtime_adapter_review": True,
+        },
+    }
+
+
+def _runtime_contract(workflow: str) -> tuple[str, str, list[str]]:
+    if workflow == "decompose_occlusion_replan":
+        return (
+            "layers_decompose",
+            "replan_decompose_layers",
+            [
+                "source_image",
+                "current_layer_manifest",
+                "layer_order_or_occlusion_notes",
+            ],
+        )
+    if workflow == "redraw_under_split_boundary_replan":
+        return (
+            "layers_redraw",
+            "replan_redraw_boundary",
+            [
+                "source_image",
+                "current_mask_or_layer_bounds",
+                "target_region_description",
+            ],
+        )
+    if workflow == "decompose_under_split_boundary_replan":
+        return (
+            "layers_decompose",
+            "replan_decompose_boundaries",
+            [
+                "source_image",
+                "current_mask_or_layer_bounds",
+                "target_region_description",
+            ],
+        )
+    return (
+        "visual_ownership_manual_review",
+        "manual_visual_ownership_review",
+        [
+            "source_image",
+            "current_visual_artifact",
+            "target_region_description",
+        ],
+    )
+
+
+def _blocked_gate_summary(gate: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        "example_id": str(gate.get("example_id") or ""),
+        "case_id": str(gate.get("case_id") or ""),
+        "source_case_type": str(gate.get("source_case_type") or ""),
+        "recommended_workflow": str(gate.get("recommended_workflow") or ""),
+        "gate_status": str(gate.get("gate_status") or ""),
+        "gate_reasons": _string_list(gate.get("gate_reasons")),
+    }
+
+
+def _counter_by(items: Sequence[Mapping[str, Any]], key: str) -> dict[str, int]:
+    counts: Counter[str] = Counter()
+    for item in items:
+        counts[str(item.get(key) or "unknown")] += 1
+    return dict(sorted(counts.items()))
+
+
+def _load_jsonl(path: str | Path) -> list[dict[str, Any]]:
+    records: list[dict[str, Any]] = []
+    for line in Path(path).read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        value = json.loads(line)
+        if isinstance(value, Mapping):
+            records.append(dict(value))
+    return records
+
+
+def _write_jsonl(path: str | Path, records: Sequence[Mapping[str, Any]]) -> None:
+    output = Path(path)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    with output.open("w", encoding="utf-8") as fh:
+        for record in records:
+            fh.write(json.dumps(dict(record), sort_keys=True, separators=(",", ":")))
+            fh.write("\n")
+
+
+def _string_list(value: Any) -> list[str]:
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes)):
+        return []
+    return [str(item) for item in value]
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    if isinstance(value, Mapping):
+        return value
+    return {}

--- a/tests/test_visual_ownership_runtime_adapter.py
+++ b/tests/test_visual_ownership_runtime_adapter.py
@@ -1,0 +1,186 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+CLI_ENV = dict(
+    os.environ,
+    PYTHONPATH=str(ROOT / "src") + os.pathsep + os.environ.get("PYTHONPATH", ""),
+)
+SCRIPT = ROOT / "scripts" / "visual_ownership_runtime_adapter.py"
+
+
+def _gate(
+    case_id: str,
+    *,
+    source_case_type: str,
+    visual_ownership_kind: str,
+    recommended_workflow: str,
+    gate_status: str = "ready_for_agent_execution",
+) -> dict:
+    return {
+        "schema_version": 1,
+        "case_type": "learning_visual_ownership_execution_gate",
+        "example_id": f"tiny_{case_id}",
+        "case_id": case_id,
+        "source_case_type": source_case_type,
+        "visual_ownership_kind": visual_ownership_kind,
+        "recommended_workflow": recommended_workflow,
+        "gate_status": gate_status,
+        "gate_reasons": [] if gate_status == "ready_for_agent_execution" else ["fixture_blocked"],
+        "readiness": {
+            "agent_execution_ready": gate_status == "ready_for_agent_execution",
+            "production_runtime_ready": False,
+            "required_input_count": 3,
+            "planner_step_count": 3,
+            "source_context_available": True,
+        },
+        "routing": {
+            "next_owner": "visual_ownership_agent",
+            "requires_runtime_adapter": True,
+        },
+    }
+
+
+def _write_jsonl(path: Path, records: list[dict]) -> None:
+    path.write_text(
+        "\n".join(json.dumps(record, sort_keys=True) for record in records) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _fixture_gates() -> list[dict]:
+    return [
+        _gate(
+            "taxonomy_v1_decompose_occlusion_holdout",
+            source_case_type="decompose_case",
+            visual_ownership_kind="occlusion",
+            recommended_workflow="decompose_occlusion_replan",
+        ),
+        _gate(
+            "taxonomy_v1_redraw_under_split_holdout",
+            source_case_type="redraw_case",
+            visual_ownership_kind="under_split",
+            recommended_workflow="redraw_under_split_boundary_replan",
+        ),
+        _gate(
+            "blocked_missing_source_context",
+            source_case_type="redraw_case",
+            visual_ownership_kind="under_split",
+            recommended_workflow="redraw_under_split_boundary_replan",
+            gate_status="blocked_missing_source_context",
+        ),
+    ]
+
+
+def test_visual_ownership_runtime_adapter_builds_runtime_requests(tmp_path):
+    from vulca.learning.visual_ownership_runtime_adapter import (
+        run_visual_ownership_runtime_adapter,
+    )
+
+    gate_path = tmp_path / "visual_ownership_execution_gate.jsonl"
+    request_path = tmp_path / "visual_ownership_runtime_requests.jsonl"
+    report_path = tmp_path / "visual_ownership_runtime_adapter_report.json"
+    _write_jsonl(gate_path, _fixture_gates())
+
+    report = run_visual_ownership_runtime_adapter(
+        gate_path=gate_path,
+        request_path=request_path,
+        report_path=report_path,
+    )
+
+    assert report["case_type"] == "learning_visual_ownership_runtime_adapter_report"
+    assert report["status"] == "runtime_requests_ready_for_adapter_review"
+    assert report["summary"] == {
+        "gate_record_count": 3,
+        "adapter_request_count": 2,
+        "blocked_gate_count": 1,
+        "production_runtime_candidate_count": 2,
+        "provider_call_count": 0,
+    }
+    assert report["counts_by_runtime_target"] == {
+        "layers_decompose": 1,
+        "layers_redraw": 1,
+    }
+    assert report["safe_handling"] == {
+        "copies_local_paths": False,
+        "copies_private_refs": False,
+        "copies_raw_source_text": False,
+        "calls_model_provider": False,
+    }
+
+    requests = [
+        json.loads(line)
+        for line in request_path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+    assert [request["case_id"] for request in requests] == [
+        "taxonomy_v1_decompose_occlusion_holdout",
+        "taxonomy_v1_redraw_under_split_holdout",
+    ]
+    by_case = {request["case_id"]: request for request in requests}
+
+    decompose = by_case["taxonomy_v1_decompose_occlusion_holdout"]
+    assert decompose["case_type"] == "learning_visual_ownership_runtime_request"
+    assert decompose["runtime_target"] == "layers_decompose"
+    assert decompose["runtime_action"] == "replan_decompose_layers"
+    assert decompose["required_runtime_inputs"] == [
+        "source_image",
+        "current_layer_manifest",
+        "layer_order_or_occlusion_notes",
+    ]
+    assert decompose["execution_policy"] == {
+        "provider_calls_enabled": False,
+        "requires_visual_agent_judgement": True,
+        "requires_runtime_adapter_review": True,
+    }
+
+    redraw = by_case["taxonomy_v1_redraw_under_split_holdout"]
+    assert redraw["runtime_target"] == "layers_redraw"
+    assert redraw["runtime_action"] == "replan_redraw_boundary"
+    assert redraw["required_runtime_inputs"] == [
+        "source_image",
+        "current_mask_or_layer_bounds",
+        "target_region_description",
+    ]
+    assert report_path.exists()
+
+
+def test_visual_ownership_runtime_adapter_cli_writes_summary(tmp_path):
+    gate_path = tmp_path / "visual_ownership_execution_gate.jsonl"
+    request_path = tmp_path / "visual_ownership_runtime_requests.jsonl"
+    report_path = tmp_path / "visual_ownership_runtime_adapter_report.json"
+    _write_jsonl(gate_path, _fixture_gates())
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--gates",
+            str(gate_path),
+            "--requests",
+            str(request_path),
+            "--report",
+            str(report_path),
+        ],
+        cwd=ROOT,
+        env=CLI_ENV,
+        text=True,
+        capture_output=True,
+        timeout=30,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "Visual ownership runtime adapter report:" in result.stdout
+    assert "Gate records: 3" in result.stdout
+    assert "Adapter requests: 2" in result.stdout
+    assert "Blocked gates: 1" in result.stdout
+    assert "Provider calls: 0" in result.stdout
+    report = json.loads(report_path.read_text(encoding="utf-8"))
+    assert report["summary"]["adapter_request_count"] == 2


### PR DESCRIPTION
## Summary
- add provider-free runtime adapter requests for visual ownership execution gates
- map decompose occlusion plans to layers_decompose runtime requests
- map redraw under-split plans to layers_redraw runtime requests
- keep provider calls disabled and expose adapter review policy

## Current training/eval status
- dataset examples: 50
- eval cases: 21
- tiny_action_model_v1 action accuracy: 1.0
- source dependency rule accuracy: 1.0
- fallback-agent residuals after owner routing: 0

## Real-case smoke
- recovered dry-run decisions: 21
- visual ownership plans: 2
- execution gates ready: 2
- adapter requests: 2
- runtime targets: layers_decompose=1, layers_redraw=1
- provider calls: 0

## Verification
- PYTHONPATH=src python3 -m pytest tests/test_visual_ownership_runtime_adapter.py -q
- PYTHONPATH=src python3 scripts/real_source_context_recovery_eval.py --repo-root . --case-source-manifest docs/benchmarks/learning/combined_case_source_manifest_v1.json --artifact-search-root /Users/yhryzy/dev/vulca/.scratch/p2b-live-shipgate --image-search-root /Users/yhryzy/dev/vulca/.scratch/p2b-live-shipgate --source-dependency-manifest docs/benchmarks/learning/real_source_dependency_label_manifest_v1.json --output-dir build/visual_ownership_runtime_adapter_v1/real_recovery_eval --report build/visual_ownership_runtime_adapter_v1/real_recovery_eval/report.json --max-recovered-source-context-gaps 0 --min-fallback-agent-reduction 2 --min-recovered-eval-cases 2
- PYTHONPATH=src python3 scripts/visual_ownership_planner.py --decision-path build/visual_ownership_runtime_adapter_v1/real_recovery_eval/recovered/dry_run/dry_run_decisions.jsonl --plans build/visual_ownership_runtime_adapter_v1/planner/visual_ownership_plans.jsonl --report build/visual_ownership_runtime_adapter_v1/planner/report.json
- PYTHONPATH=src python3 scripts/visual_ownership_execution_gate.py --plans build/visual_ownership_runtime_adapter_v1/planner/visual_ownership_plans.jsonl --gates build/visual_ownership_runtime_adapter_v1/gate/visual_ownership_execution_gate.jsonl --report build/visual_ownership_runtime_adapter_v1/gate/report.json
- PYTHONPATH=src python3 scripts/visual_ownership_runtime_adapter.py --gates build/visual_ownership_runtime_adapter_v1/gate/visual_ownership_execution_gate.jsonl --requests build/visual_ownership_runtime_adapter_v1/runtime/visual_ownership_runtime_requests.jsonl --report build/visual_ownership_runtime_adapter_v1/runtime/report.json
- PYTHONPATH=src python3 -m pytest tests/test_visual_ownership_runtime_adapter.py tests/test_visual_ownership_execution_gate.py tests/test_visual_ownership_planner.py tests/test_dry_run_decision_router.py tests/test_training_effectiveness_report.py tests/test_real_source_context_recovery_eval.py -q
- ruff check src/vulca/learning/visual_ownership_runtime_adapter.py scripts/visual_ownership_runtime_adapter.py tests/test_visual_ownership_runtime_adapter.py
- python3 -m py_compile src/vulca/learning/visual_ownership_runtime_adapter.py scripts/visual_ownership_runtime_adapter.py
- git diff --check