### PR TITLE
feat(learning): add visual ownership runtime replay

### DIFF
--- a/scripts/visual_ownership_runtime_replay.py
+++ b/scripts/visual_ownership_runtime_replay.py
@@ -1,0 +1,84 @@
+"""Dry-run visual ownership runtime adapter requests."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Sequence
+
+
+ROOT = Path(__file__).resolve().parent.parent
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from vulca.learning.visual_ownership_runtime_replay import (  # noqa: E402
+    DEFAULT_REPLAY_NAME,
+    DEFAULT_REPORT_NAME,
+    run_visual_ownership_runtime_replay,
+)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Dry-run visual ownership runtime adapter requests into replay "
+            "records without provider calls."
+        )
+    )
+    parser.add_argument(
+        "--requests",
+        required=True,
+        help="Visual ownership runtime request JSONL path.",
+    )
+    parser.add_argument(
+        "--replay",
+        default="",
+        help=f"Replay JSONL path (default: alongside requests as {DEFAULT_REPLAY_NAME}).",
+    )
+    parser.add_argument(
+        "--report",
+        default="",
+        help=f"Report JSON path (default: alongside requests as {DEFAULT_REPORT_NAME}).",
+    )
+    parser.add_argument(
+        "--pretty",
+        action="store_true",
+        help="Print full JSON report after writing it.",
+    )
+    args = parser.parse_args(argv)
+
+    request_path = Path(args.requests)
+    replay_path = (
+        Path(args.replay) if args.replay else request_path.parent / DEFAULT_REPLAY_NAME
+    )
+    report_path = (
+        Path(args.report) if args.report else request_path.parent / DEFAULT_REPORT_NAME
+    )
+    try:
+        report = run_visual_ownership_runtime_replay(
+            request_path=request_path,
+            replay_path=replay_path,
+            report_path=report_path,
+        )
+    except (FileNotFoundError, json.JSONDecodeError, OSError, ValueError) as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 2
+
+    if args.pretty:
+        print(json.dumps(report, indent=2, sort_keys=True))
+
+    summary = report["summary"]
+    print(f"Visual ownership runtime replay report: {report_path}")
+    print(f"Visual ownership runtime replay: {replay_path}")
+    print(f"Requests: {summary['request_count']}")
+    print(f"Replayable: {summary['replayable_count']}")
+    print(f"Blocked: {summary['blocked_count']}")
+    print(f"Provider calls: {summary['provider_call_count']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/vulca/learning/visual_ownership_runtime_replay.py
+++ b/src/vulca/learning/visual_ownership_runtime_replay.py
@@ -1,0 +1,234 @@
+"""Provider-free dry-run replay for visual ownership runtime requests."""
+
+from __future__ import annotations
+
+import json
+from collections import Counter
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+
+SCHEMA_VERSION = 1
+REQUEST_CASE_TYPE = "learning_visual_ownership_runtime_request"
+REPLAY_CASE_TYPE = "learning_visual_ownership_runtime_replay"
+REPORT_CASE_TYPE = "learning_visual_ownership_runtime_replay_report"
+DEFAULT_REPLAY_NAME = "visual_ownership_runtime_replay.jsonl"
+DEFAULT_REPORT_NAME = "visual_ownership_runtime_replay_report.json"
+
+REPLAY_NAME = "visual_ownership_runtime_replay_v1"
+
+
+def run_visual_ownership_runtime_replay(
+    *,
+    request_path: str | Path,
+    replay_path: str | Path | None = None,
+    report_path: str | Path | None = None,
+) -> dict[str, Any]:
+    """Dry-run runtime requests into replay records without provider calls."""
+    requests = _load_jsonl(request_path)
+    replay_records = sorted(
+        (_replay_for_request(request) for request in requests),
+        key=lambda item: (item["runtime_target"], item["case_id"]),
+    )
+
+    resolved_replay_path = (
+        Path(replay_path)
+        if replay_path
+        else Path(request_path).parent / DEFAULT_REPLAY_NAME
+    )
+    _write_jsonl(resolved_replay_path, replay_records)
+
+    blocked_records = [
+        record
+        for record in replay_records
+        if str(record.get("replay_status") or "") != "dry_run_replayable"
+    ]
+    report = {
+        "schema_version": SCHEMA_VERSION,
+        "case_type": REPORT_CASE_TYPE,
+        "status": _report_status(requests, blocked_records),
+        "inputs": {
+            "request_path": Path(request_path).name,
+        },
+        "artifacts": {
+            "replay_path": str(resolved_replay_path),
+            "report_path": str(report_path or ""),
+        },
+        "summary": _summary(requests, replay_records, blocked_records),
+        "counts_by_runtime_target": _counter_by(replay_records, "runtime_target"),
+        "counts_by_runtime_entrypoint": _counter_by(
+            replay_records,
+            "runtime_entrypoint",
+        ),
+        "counts_by_replay_status": _counter_by(replay_records, "replay_status"),
+        "blocked_requests": [
+            _blocked_request_summary(record) for record in blocked_records
+        ],
+        "runtime_replays": replay_records,
+        "safe_handling": {
+            "copies_local_paths": False,
+            "copies_private_refs": False,
+            "copies_raw_source_text": False,
+            "calls_model_provider": False,
+        },
+    }
+    if report_path:
+        output = Path(report_path)
+        output.parent.mkdir(parents=True, exist_ok=True)
+        report["artifacts"]["report_path"] = str(output)
+        output.write_text(
+            json.dumps(report, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+    return report
+
+
+def _report_status(
+    requests: Sequence[Mapping[str, Any]],
+    blocked_records: Sequence[Mapping[str, Any]],
+) -> str:
+    if not requests:
+        return "no_runtime_requests"
+    if blocked_records:
+        return "blocked_runtime_replay"
+    return "runtime_replay_ready"
+
+
+def _summary(
+    requests: Sequence[Mapping[str, Any]],
+    replay_records: Sequence[Mapping[str, Any]],
+    blocked_records: Sequence[Mapping[str, Any]],
+) -> dict[str, int]:
+    return {
+        "request_count": len(requests),
+        "replay_record_count": len(replay_records),
+        "replayable_count": len(replay_records) - len(blocked_records),
+        "blocked_count": len(blocked_records),
+        "provider_call_count": 0,
+    }
+
+
+def _replay_for_request(request: Mapping[str, Any]) -> dict[str, Any]:
+    runtime_target = str(request.get("runtime_target") or "")
+    runtime_action = str(request.get("runtime_action") or "")
+    runtime_entrypoint, mapping_reasons = _runtime_entrypoint(
+        runtime_target,
+        runtime_action,
+    )
+    runtime_inputs = _string_list(request.get("required_runtime_inputs"))
+    execution_policy = _mapping(request.get("execution_policy"))
+
+    replay_reasons: list[str] = []
+    replay_reasons.extend(mapping_reasons)
+    if bool(execution_policy.get("provider_calls_enabled")):
+        replay_reasons.append("provider_calls_enabled")
+    if not runtime_inputs:
+        replay_reasons.append("required_runtime_inputs_missing")
+
+    replay_status = _replay_status(replay_reasons)
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "case_type": REPLAY_CASE_TYPE,
+        "replay_name": REPLAY_NAME,
+        "adapter_name": str(request.get("adapter_name") or ""),
+        "example_id": str(request.get("example_id") or ""),
+        "case_id": str(request.get("case_id") or ""),
+        "source_case_type": str(request.get("source_case_type") or ""),
+        "visual_ownership_kind": str(request.get("visual_ownership_kind") or ""),
+        "recommended_workflow": str(request.get("recommended_workflow") or ""),
+        "runtime_target": runtime_target,
+        "runtime_action": runtime_action,
+        "runtime_entrypoint": runtime_entrypoint or "unknown",
+        "replay_status": replay_status,
+        "replay_reasons": replay_reasons,
+        "runtime_contract": {
+            "runtime_target": runtime_target,
+            "runtime_action": runtime_action,
+            "required_runtime_inputs": runtime_inputs,
+            "provider_calls_enabled": False,
+        },
+        "readiness": {
+            "dry_run_replayable": replay_status == "dry_run_replayable",
+            "required_runtime_input_count": len(runtime_inputs),
+            "provider_call_count": 0,
+        },
+    }
+
+
+def _runtime_entrypoint(runtime_target: str, runtime_action: str) -> tuple[str, list[str]]:
+    if runtime_target == "layers_decompose":
+        if runtime_action in {
+            "replan_decompose_layers",
+            "replan_decompose_boundaries",
+        }:
+            return "layers_split_dry_run", []
+        return "unknown", ["unsupported_runtime_action"]
+    if runtime_target == "layers_redraw":
+        if runtime_action == "replan_redraw_boundary":
+            return "layers_redraw_dry_run", []
+        return "unknown", ["unsupported_runtime_action"]
+    return "unknown", ["unsupported_runtime_target"]
+
+
+def _replay_status(replay_reasons: Sequence[str]) -> str:
+    if not replay_reasons:
+        return "dry_run_replayable"
+    if "unsupported_runtime_target" in replay_reasons:
+        return "blocked_unknown_runtime_target"
+    if "unsupported_runtime_action" in replay_reasons:
+        return "blocked_unknown_runtime_action"
+    if "provider_calls_enabled" in replay_reasons:
+        return "blocked_provider_call_policy"
+    if "required_runtime_inputs_missing" in replay_reasons:
+        return "blocked_missing_runtime_inputs"
+    return "blocked_runtime_replay"
+
+
+def _blocked_request_summary(record: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        "example_id": str(record.get("example_id") or ""),
+        "case_id": str(record.get("case_id") or ""),
+        "runtime_target": str(record.get("runtime_target") or ""),
+        "runtime_action": str(record.get("runtime_action") or ""),
+        "replay_status": str(record.get("replay_status") or ""),
+        "replay_reasons": _string_list(record.get("replay_reasons")),
+    }
+
+
+def _counter_by(items: Sequence[Mapping[str, Any]], key: str) -> dict[str, int]:
+    counts: Counter[str] = Counter()
+    for item in items:
+        counts[str(item.get(key) or "unknown")] += 1
+    return dict(sorted(counts.items()))
+
+
+def _load_jsonl(path: str | Path) -> list[dict[str, Any]]:
+    records: list[dict[str, Any]] = []
+    for line in Path(path).read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        value = json.loads(line)
+        if isinstance(value, Mapping):
+            records.append(dict(value))
+    return records
+
+
+def _write_jsonl(path: str | Path, records: Sequence[Mapping[str, Any]]) -> None:
+    output = Path(path)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    with output.open("w", encoding="utf-8") as fh:
+        for record in records:
+            fh.write(json.dumps(dict(record), sort_keys=True, separators=(",", ":")))
+            fh.write("\n")
+
+
+def _string_list(value: Any) -> list[str]:
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes)):
+        return []
+    return [str(item) for item in value]
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    if isinstance(value, Mapping):
+        return value
+    return {}

--- a/tests/test_visual_ownership_runtime_replay.py
+++ b/tests/test_visual_ownership_runtime_replay.py
@@ -1,0 +1,241 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+CLI_ENV = dict(
+    os.environ,
+    PYTHONPATH=str(ROOT / "src") + os.pathsep + os.environ.get("PYTHONPATH", ""),
+)
+SCRIPT = ROOT / "scripts" / "visual_ownership_runtime_replay.py"
+
+
+def _request(
+    case_id: str,
+    *,
+    runtime_target: str,
+    runtime_action: str,
+    required_runtime_inputs: list[str],
+    provider_calls_enabled: bool = False,
+) -> dict:
+    return {
+        "schema_version": 1,
+        "case_type": "learning_visual_ownership_runtime_request",
+        "adapter_name": "visual_ownership_runtime_adapter_v1",
+        "example_id": f"tiny_{case_id}",
+        "case_id": case_id,
+        "source_case_type": "decompose_case"
+        if runtime_target == "layers_decompose"
+        else "redraw_case",
+        "visual_ownership_kind": "occlusion"
+        if runtime_target == "layers_decompose"
+        else "under_split",
+        "recommended_workflow": "decompose_occlusion_replan"
+        if runtime_target == "layers_decompose"
+        else "redraw_under_split_boundary_replan",
+        "runtime_target": runtime_target,
+        "runtime_action": runtime_action,
+        "required_runtime_inputs": required_runtime_inputs,
+        "gate_status": "ready_for_agent_execution",
+        "source_context_available": True,
+        "handoff": {
+            "from_owner": "visual_ownership_agent",
+            "to_runtime_target": runtime_target,
+            "requires_runtime_adapter": True,
+        },
+        "execution_policy": {
+            "provider_calls_enabled": provider_calls_enabled,
+            "requires_visual_agent_judgement": True,
+            "requires_runtime_adapter_review": True,
+        },
+    }
+
+
+def _fixture_requests() -> list[dict]:
+    return [
+        _request(
+            "taxonomy_v1_decompose_occlusion_holdout",
+            runtime_target="layers_decompose",
+            runtime_action="replan_decompose_layers",
+            required_runtime_inputs=[
+                "source_image",
+                "current_layer_manifest",
+                "layer_order_or_occlusion_notes",
+            ],
+        ),
+        _request(
+            "taxonomy_v1_redraw_under_split_holdout",
+            runtime_target="layers_redraw",
+            runtime_action="replan_redraw_boundary",
+            required_runtime_inputs=[
+                "source_image",
+                "current_mask_or_layer_bounds",
+                "target_region_description",
+            ],
+        ),
+        _request(
+            "blocked_unknown_runtime",
+            runtime_target="unsupported_runtime",
+            runtime_action="manual_visual_review",
+            required_runtime_inputs=["source_image"],
+        ),
+    ]
+
+
+def _write_jsonl(path: Path, records: list[dict]) -> None:
+    path.write_text(
+        "\n".join(json.dumps(record, sort_keys=True) for record in records) + "\n",
+        encoding="utf-8",
+    )
+
+
+def test_visual_ownership_runtime_replay_records_dry_run_readiness(tmp_path):
+    from vulca.learning.visual_ownership_runtime_replay import (
+        run_visual_ownership_runtime_replay,
+    )
+
+    request_path = tmp_path / "visual_ownership_runtime_requests.jsonl"
+    replay_path = tmp_path / "visual_ownership_runtime_replay.jsonl"
+    report_path = tmp_path / "visual_ownership_runtime_replay_report.json"
+    _write_jsonl(request_path, _fixture_requests())
+
+    report = run_visual_ownership_runtime_replay(
+        request_path=request_path,
+        replay_path=replay_path,
+        report_path=report_path,
+    )
+
+    assert report["case_type"] == "learning_visual_ownership_runtime_replay_report"
+    assert report["status"] == "blocked_runtime_replay"
+    assert report["summary"] == {
+        "request_count": 3,
+        "replay_record_count": 3,
+        "replayable_count": 2,
+        "blocked_count": 1,
+        "provider_call_count": 0,
+    }
+    assert report["counts_by_runtime_target"] == {
+        "layers_decompose": 1,
+        "layers_redraw": 1,
+        "unsupported_runtime": 1,
+    }
+    assert report["counts_by_runtime_entrypoint"] == {
+        "layers_redraw_dry_run": 1,
+        "layers_split_dry_run": 1,
+        "unknown": 1,
+    }
+    assert report["counts_by_replay_status"] == {
+        "blocked_unknown_runtime_target": 1,
+        "dry_run_replayable": 2,
+    }
+    assert report["safe_handling"] == {
+        "copies_local_paths": False,
+        "copies_private_refs": False,
+        "copies_raw_source_text": False,
+        "calls_model_provider": False,
+    }
+
+    records = [
+        json.loads(line)
+        for line in replay_path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+    by_case = {record["case_id"]: record for record in records}
+
+    decompose = by_case["taxonomy_v1_decompose_occlusion_holdout"]
+    assert decompose["case_type"] == "learning_visual_ownership_runtime_replay"
+    assert decompose["runtime_target"] == "layers_decompose"
+    assert decompose["runtime_action"] == "replan_decompose_layers"
+    assert decompose["runtime_entrypoint"] == "layers_split_dry_run"
+    assert decompose["replay_status"] == "dry_run_replayable"
+    assert decompose["runtime_contract"] == {
+        "runtime_target": "layers_decompose",
+        "runtime_action": "replan_decompose_layers",
+        "required_runtime_inputs": [
+            "source_image",
+            "current_layer_manifest",
+            "layer_order_or_occlusion_notes",
+        ],
+        "provider_calls_enabled": False,
+    }
+
+    redraw = by_case["taxonomy_v1_redraw_under_split_holdout"]
+    assert redraw["runtime_target"] == "layers_redraw"
+    assert redraw["runtime_action"] == "replan_redraw_boundary"
+    assert redraw["runtime_entrypoint"] == "layers_redraw_dry_run"
+    assert redraw["replay_status"] == "dry_run_replayable"
+
+    blocked = by_case["blocked_unknown_runtime"]
+    assert blocked["runtime_entrypoint"] == "unknown"
+    assert blocked["replay_status"] == "blocked_unknown_runtime_target"
+    assert blocked["replay_reasons"] == ["unsupported_runtime_target"]
+    assert report_path.exists()
+
+
+def test_visual_ownership_runtime_replay_blocks_provider_enabled_requests(tmp_path):
+    from vulca.learning.visual_ownership_runtime_replay import (
+        run_visual_ownership_runtime_replay,
+    )
+
+    request_path = tmp_path / "visual_ownership_runtime_requests.jsonl"
+    _write_jsonl(
+        request_path,
+        [
+            _request(
+                "provider_enabled_request",
+                runtime_target="layers_redraw",
+                runtime_action="replan_redraw_boundary",
+                required_runtime_inputs=["source_image"],
+                provider_calls_enabled=True,
+            )
+        ],
+    )
+
+    report = run_visual_ownership_runtime_replay(request_path=request_path)
+
+    record = report["runtime_replays"][0]
+    assert record["replay_status"] == "blocked_provider_call_policy"
+    assert record["replay_reasons"] == ["provider_calls_enabled"]
+    assert record["readiness"]["provider_call_count"] == 0
+    assert report["summary"]["provider_call_count"] == 0
+
+
+def test_visual_ownership_runtime_replay_cli_writes_summary(tmp_path):
+    request_path = tmp_path / "visual_ownership_runtime_requests.jsonl"
+    replay_path = tmp_path / "visual_ownership_runtime_replay.jsonl"
+    report_path = tmp_path / "visual_ownership_runtime_replay_report.json"
+    _write_jsonl(request_path, _fixture_requests())
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--requests",
+            str(request_path),
+            "--replay",
+            str(replay_path),
+            "--report",
+            str(report_path),
+        ],
+        cwd=ROOT,
+        env=CLI_ENV,
+        text=True,
+        capture_output=True,
+        timeout=30,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "Visual ownership runtime replay report:" in result.stdout
+    assert "Visual ownership runtime replay:" in result.stdout
+    assert "Requests: 3" in result.stdout
+    assert "Replayable: 2" in result.stdout
+    assert "Blocked: 1" in result.stdout
+    assert "Provider calls: 0" in result.stdout
+    report = json.loads(report_path.read_text(encoding="utf-8"))
+    assert report["summary"]["replayable_count"] == 2


### PR DESCRIPTION
## Summary
- add provider-free visual ownership runtime replay records and report
- add CLI to replay runtime adapter requests into dry-run runtime entrypoints
- cover replayable decompose/redraw requests plus blocked runtime/provider-policy cases

## Verification
- PYTHONPATH=src python3 -m pytest tests/test_visual_ownership_runtime_replay.py -q
- PYTHONPATH=src python3 scripts/real_source_context_recovery_eval.py --repo-root . --case-source-manifest docs/benchmarks/learning/combined_case_source_manifest_v1.json --artifact-search-root /Users/yhryzy/dev/vulca/.scratch/p2b-live-shipgate --image-search-root /Users/yhryzy/dev/vulca/.scratch/p2b-live-shipgate --source-dependency-manifest docs/benchmarks/learning/real_source_dependency_label_manifest_v1.json --output-dir build/visual_ownership_runtime_replay_v1/real_recovery_eval --report build/visual_ownership_runtime_replay_v1/real_recovery_eval/report.json --max-recovered-source-context-gaps 0 --min-fallback-agent-reduction 2 --min-recovered-eval-cases 2
- PYTHONPATH=src python3 scripts/visual_ownership_planner.py --decision-path build/visual_ownership_runtime_replay_v1/real_recovery_eval/recovered/dry_run/dry_run_decisions.jsonl --plans build/visual_ownership_runtime_replay_v1/planner/visual_ownership_plans.jsonl --report build/visual_ownership_runtime_replay_v1/planner/report.json
- PYTHONPATH=src python3 scripts/visual_ownership_execution_gate.py --plans build/visual_ownership_runtime_replay_v1/planner/visual_ownership_plans.jsonl --gates build/visual_ownership_runtime_replay_v1/gate/visual_ownership_execution_gate.jsonl --report build/visual_ownership_runtime_replay_v1/gate/report.json
- PYTHONPATH=src python3 scripts/visual_ownership_runtime_adapter.py --gates build/visual_ownership_runtime_replay_v1/gate/visual_ownership_execution_gate.jsonl --requests build/visual_ownership_runtime_replay_v1/runtime/visual_ownership_runtime_requests.jsonl --report build/visual_ownership_runtime_replay_v1/runtime/report.json
- PYTHONPATH=src python3 scripts/visual_ownership_runtime_replay.py --requests build/visual_ownership_runtime_replay_v1/runtime/visual_ownership_runtime_requests.jsonl --replay build/visual_ownership_runtime_replay_v1/replay/visual_ownership_runtime_replay.jsonl --report build/visual_ownership_runtime_replay_v1/replay/report.json
- PYTHONPATH=src python3 -m pytest tests/test_visual_ownership_runtime_replay.py tests/test_visual_ownership_runtime_adapter.py tests/test_visual_ownership_execution_gate.py tests/test_visual_ownership_planner.py tests/test_dry_run_decision_router.py tests/test_training_effectiveness_report.py tests/test_real_source_context_recovery_eval.py -q
- python3 -m py_compile src/vulca/learning/visual_ownership_runtime_replay.py scripts/visual_ownership_runtime_replay.py
- ruff check src/vulca/learning/visual_ownership_runtime_replay.py scripts/visual_ownership_runtime_replay.py tests/test_visual_ownership_runtime_replay.py
- git diff --check