### PR TITLE
feat(learning): add visual ownership runtime entrypoint dry run

### DIFF
--- a/scripts/visual_ownership_runtime_entrypoint_dry_run.py
+++ b/scripts/visual_ownership_runtime_entrypoint_dry_run.py
@@ -1,0 +1,89 @@
+"""Build provider-free visual ownership runtime entrypoint dry-runs."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Sequence
+
+
+ROOT = Path(__file__).resolve().parent.parent
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from vulca.learning.visual_ownership_runtime_entrypoint_dry_run import (  # noqa: E402
+    DEFAULT_INVOCATION_NAME,
+    DEFAULT_REPORT_NAME,
+    run_visual_ownership_runtime_entrypoint_dry_run,
+)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Convert visual ownership runtime replay records into provider-free "
+            "entrypoint invocation contracts."
+        )
+    )
+    parser.add_argument(
+        "--replay",
+        required=True,
+        help="Visual ownership runtime replay JSONL path.",
+    )
+    parser.add_argument(
+        "--invocations",
+        default="",
+        help=(
+            "Dry-run invocation JSONL path "
+            f"(default: alongside replay as {DEFAULT_INVOCATION_NAME})."
+        ),
+    )
+    parser.add_argument(
+        "--report",
+        default="",
+        help=f"Report JSON path (default: alongside replay as {DEFAULT_REPORT_NAME}).",
+    )
+    parser.add_argument(
+        "--pretty",
+        action="store_true",
+        help="Print full JSON report after writing it.",
+    )
+    args = parser.parse_args(argv)
+
+    replay_path = Path(args.replay)
+    invocation_path = (
+        Path(args.invocations)
+        if args.invocations
+        else replay_path.parent / DEFAULT_INVOCATION_NAME
+    )
+    report_path = (
+        Path(args.report) if args.report else replay_path.parent / DEFAULT_REPORT_NAME
+    )
+    try:
+        report = run_visual_ownership_runtime_entrypoint_dry_run(
+            replay_path=replay_path,
+            invocation_path=invocation_path,
+            report_path=report_path,
+        )
+    except (FileNotFoundError, json.JSONDecodeError, OSError, ValueError) as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 2
+
+    if args.pretty:
+        print(json.dumps(report, indent=2, sort_keys=True))
+
+    summary = report["summary"]
+    print(f"Visual ownership runtime entrypoint dry-run report: {report_path}")
+    print(f"Visual ownership runtime entrypoint dry-runs: {invocation_path}")
+    print(f"Replay records: {summary['replay_record_count']}")
+    print(f"Ready: {summary['ready_count']}")
+    print(f"Blocked: {summary['blocked_count']}")
+    print(f"Provider calls: {summary['provider_call_count']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/vulca/learning/visual_ownership_runtime_entrypoint_dry_run.py
+++ b/src/vulca/learning/visual_ownership_runtime_entrypoint_dry_run.py
@@ -1,0 +1,267 @@
+"""Provider-free runtime entrypoint dry-run contracts for visual ownership."""
+
+from __future__ import annotations
+
+import json
+from collections import Counter
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+
+SCHEMA_VERSION = 1
+REPLAY_CASE_TYPE = "learning_visual_ownership_runtime_replay"
+ENTRYPOINT_CASE_TYPE = "learning_visual_ownership_runtime_entrypoint_dry_run"
+REPORT_CASE_TYPE = "learning_visual_ownership_runtime_entrypoint_dry_run_report"
+DEFAULT_INVOCATION_NAME = "visual_ownership_runtime_entrypoint_dry_run.jsonl"
+DEFAULT_REPORT_NAME = "visual_ownership_runtime_entrypoint_dry_run_report.json"
+
+DRY_RUN_NAME = "visual_ownership_runtime_entrypoint_dry_run_v1"
+READY_REPLAY_STATUS = "dry_run_replayable"
+
+
+def run_visual_ownership_runtime_entrypoint_dry_run(
+    *,
+    replay_path: str | Path,
+    invocation_path: str | Path | None = None,
+    report_path: str | Path | None = None,
+) -> dict[str, Any]:
+    """Convert runtime replay records into provider-free entrypoint contracts."""
+    replay_records = _load_jsonl(replay_path)
+    invocations = sorted(
+        (_invocation_for_replay(record) for record in replay_records),
+        key=lambda item: (item["runtime_tool"], item["case_id"]),
+    )
+
+    resolved_invocation_path = (
+        Path(invocation_path)
+        if invocation_path
+        else Path(replay_path).parent / DEFAULT_INVOCATION_NAME
+    )
+    _write_jsonl(resolved_invocation_path, invocations)
+
+    blocked_records = [
+        record
+        for record in invocations
+        if str(record.get("dry_run_status") or "") != "dry_run_invocation_ready"
+    ]
+    report = {
+        "schema_version": SCHEMA_VERSION,
+        "case_type": REPORT_CASE_TYPE,
+        "status": _report_status(replay_records, blocked_records),
+        "inputs": {
+            "replay_path": Path(replay_path).name,
+        },
+        "artifacts": {
+            "invocation_path": str(resolved_invocation_path),
+            "report_path": str(report_path or ""),
+        },
+        "summary": _summary(replay_records, invocations, blocked_records),
+        "counts_by_runtime_tool": _counter_by(invocations, "runtime_tool"),
+        "counts_by_dry_run_status": _counter_by(invocations, "dry_run_status"),
+        "blocked_invocations": [
+            _blocked_invocation_summary(record) for record in blocked_records
+        ],
+        "runtime_entrypoint_dry_runs": invocations,
+        "safe_handling": {
+            "copies_local_paths": False,
+            "copies_private_refs": False,
+            "copies_raw_source_text": False,
+            "calls_model_provider": False,
+        },
+    }
+    if report_path:
+        output = Path(report_path)
+        output.parent.mkdir(parents=True, exist_ok=True)
+        report["artifacts"]["report_path"] = str(output)
+        output.write_text(
+            json.dumps(report, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+    return report
+
+
+def _report_status(
+    replay_records: Sequence[Mapping[str, Any]],
+    blocked_records: Sequence[Mapping[str, Any]],
+) -> str:
+    if not replay_records:
+        return "no_runtime_replays"
+    if blocked_records:
+        return "blocked_runtime_entrypoint_dry_run"
+    return "runtime_entrypoint_dry_run_ready"
+
+
+def _summary(
+    replay_records: Sequence[Mapping[str, Any]],
+    invocations: Sequence[Mapping[str, Any]],
+    blocked_records: Sequence[Mapping[str, Any]],
+) -> dict[str, int]:
+    return {
+        "replay_record_count": len(replay_records),
+        "dry_run_invocation_count": len(invocations),
+        "ready_count": len(invocations) - len(blocked_records),
+        "blocked_count": len(blocked_records),
+        "provider_call_count": 0,
+    }
+
+
+def _invocation_for_replay(replay: Mapping[str, Any]) -> dict[str, Any]:
+    runtime_entrypoint = str(replay.get("runtime_entrypoint") or "")
+    runtime_contract = _mapping(replay.get("runtime_contract"))
+    runtime_tool, contract, mapping_reasons = _entrypoint_contract(runtime_entrypoint)
+
+    dry_run_reasons: list[str] = []
+    dry_run_reasons.extend(mapping_reasons)
+    if str(replay.get("replay_status") or "") != READY_REPLAY_STATUS:
+        dry_run_reasons.append("previous_replay_not_replayable")
+    if bool(runtime_contract.get("provider_calls_enabled")):
+        dry_run_reasons.append("provider_calls_enabled")
+
+    dry_run_status = _dry_run_status(dry_run_reasons)
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "case_type": ENTRYPOINT_CASE_TYPE,
+        "dry_run_name": DRY_RUN_NAME,
+        "replay_name": str(replay.get("replay_name") or ""),
+        "adapter_name": str(replay.get("adapter_name") or ""),
+        "example_id": str(replay.get("example_id") or ""),
+        "case_id": str(replay.get("case_id") or ""),
+        "source_case_type": str(replay.get("source_case_type") or ""),
+        "visual_ownership_kind": str(replay.get("visual_ownership_kind") or ""),
+        "recommended_workflow": str(replay.get("recommended_workflow") or ""),
+        "runtime_target": str(replay.get("runtime_target") or ""),
+        "runtime_action": str(replay.get("runtime_action") or ""),
+        "runtime_entrypoint": runtime_entrypoint,
+        "runtime_tool": runtime_tool,
+        "runtime_interface": contract.get("runtime_interface", "unknown"),
+        "dry_run_status": dry_run_status,
+        "dry_run_reasons": dry_run_reasons,
+        "entrypoint_contract": contract,
+        "readiness": {
+            "dry_run_invocation_ready": (
+                dry_run_status == "dry_run_invocation_ready"
+            ),
+            "provider_call_count": 0,
+        },
+    }
+
+
+def _entrypoint_contract(runtime_entrypoint: str) -> tuple[str, dict[str, Any], list[str]]:
+    if runtime_entrypoint == "layers_split_dry_run":
+        return (
+            "layers_split",
+            {
+                "runtime_interface": "mcp",
+                "runtime_tool": "layers_split",
+                "argument_contract": {
+                    "image_path": "{source_image}",
+                    "output_dir": "{runtime_output_dir}",
+                    "mode": "orchestrated",
+                    "provider": "dry_run",
+                    "tradition": "{tradition}",
+                    "plan": "{visual_ownership_replan_json}",
+                    "case_log_path": "{optional_case_log_path}",
+                },
+                "expected_outputs": [
+                    "layers",
+                    "manifest_path",
+                    "split_mode",
+                ],
+            },
+            [],
+        )
+    if runtime_entrypoint == "layers_redraw_dry_run":
+        return (
+            "layers_redraw",
+            {
+                "runtime_interface": "mcp",
+                "runtime_tool": "layers_redraw",
+                "argument_contract": {
+                    "artwork_dir": "{current_layer_manifest_dir}",
+                    "layer": "{target_layer_name}",
+                    "instruction": "{visual_ownership_redraw_instruction}",
+                    "provider": "dry_run",
+                    "tradition": "{tradition}",
+                    "route": "auto",
+                    "case_log_path": "{optional_case_log_path}",
+                },
+                "expected_outputs": [
+                    "name",
+                    "file",
+                    "source_pasteback_path",
+                ],
+            },
+            [],
+        )
+    return (
+        "unknown",
+        {
+            "runtime_interface": "unknown",
+            "runtime_tool": "unknown",
+            "argument_contract": {},
+            "expected_outputs": [],
+        },
+        ["unsupported_runtime_entrypoint"],
+    )
+
+
+def _dry_run_status(dry_run_reasons: Sequence[str]) -> str:
+    if not dry_run_reasons:
+        return "dry_run_invocation_ready"
+    if "unsupported_runtime_entrypoint" in dry_run_reasons:
+        return "blocked_unknown_runtime_entrypoint"
+    if "previous_replay_not_replayable" in dry_run_reasons:
+        return "blocked_previous_replay_status"
+    if "provider_calls_enabled" in dry_run_reasons:
+        return "blocked_provider_call_policy"
+    return "blocked_runtime_entrypoint_dry_run"
+
+
+def _blocked_invocation_summary(record: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        "example_id": str(record.get("example_id") or ""),
+        "case_id": str(record.get("case_id") or ""),
+        "runtime_entrypoint": str(record.get("runtime_entrypoint") or ""),
+        "runtime_tool": str(record.get("runtime_tool") or ""),
+        "dry_run_status": str(record.get("dry_run_status") or ""),
+        "dry_run_reasons": _string_list(record.get("dry_run_reasons")),
+    }
+
+
+def _counter_by(items: Sequence[Mapping[str, Any]], key: str) -> dict[str, int]:
+    counts: Counter[str] = Counter()
+    for item in items:
+        counts[str(item.get(key) or "unknown")] += 1
+    return dict(sorted(counts.items()))
+
+
+def _load_jsonl(path: str | Path) -> list[dict[str, Any]]:
+    records: list[dict[str, Any]] = []
+    for line in Path(path).read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        value = json.loads(line)
+        if isinstance(value, Mapping):
+            records.append(dict(value))
+    return records
+
+
+def _write_jsonl(path: str | Path, records: Sequence[Mapping[str, Any]]) -> None:
+    output = Path(path)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    with output.open("w", encoding="utf-8") as fh:
+        for record in records:
+            fh.write(json.dumps(dict(record), sort_keys=True, separators=(",", ":")))
+            fh.write("\n")
+
+
+def _string_list(value: Any) -> list[str]:
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes)):
+        return []
+    return [str(item) for item in value]
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    if isinstance(value, Mapping):
+        return value
+    return {}

--- a/tests/test_visual_ownership_runtime_entrypoint_dry_run.py
+++ b/tests/test_visual_ownership_runtime_entrypoint_dry_run.py
@@ -1,0 +1,267 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+CLI_ENV = dict(
+    os.environ,
+    PYTHONPATH=str(ROOT / "src") + os.pathsep + os.environ.get("PYTHONPATH", ""),
+)
+SCRIPT = ROOT / "scripts" / "visual_ownership_runtime_entrypoint_dry_run.py"
+
+
+def _replay(
+    case_id: str,
+    *,
+    runtime_target: str,
+    runtime_action: str,
+    runtime_entrypoint: str,
+    replay_status: str = "dry_run_replayable",
+    required_runtime_inputs: list[str] | None = None,
+    provider_calls_enabled: bool = False,
+) -> dict:
+    inputs = required_runtime_inputs or ["source_image"]
+    return {
+        "schema_version": 1,
+        "case_type": "learning_visual_ownership_runtime_replay",
+        "replay_name": "visual_ownership_runtime_replay_v1",
+        "adapter_name": "visual_ownership_runtime_adapter_v1",
+        "example_id": f"tiny_{case_id}",
+        "case_id": case_id,
+        "source_case_type": "decompose_case"
+        if runtime_target == "layers_decompose"
+        else "redraw_case",
+        "visual_ownership_kind": "occlusion"
+        if runtime_target == "layers_decompose"
+        else "under_split",
+        "recommended_workflow": "decompose_occlusion_replan"
+        if runtime_target == "layers_decompose"
+        else "redraw_under_split_boundary_replan",
+        "runtime_target": runtime_target,
+        "runtime_action": runtime_action,
+        "runtime_entrypoint": runtime_entrypoint,
+        "replay_status": replay_status,
+        "replay_reasons": []
+        if replay_status == "dry_run_replayable"
+        else ["fixture_blocked"],
+        "runtime_contract": {
+            "runtime_target": runtime_target,
+            "runtime_action": runtime_action,
+            "required_runtime_inputs": inputs,
+            "provider_calls_enabled": provider_calls_enabled,
+        },
+        "readiness": {
+            "dry_run_replayable": replay_status == "dry_run_replayable",
+            "required_runtime_input_count": len(inputs),
+            "provider_call_count": 0,
+        },
+    }
+
+
+def _fixture_replays() -> list[dict]:
+    return [
+        _replay(
+            "taxonomy_v1_decompose_occlusion_holdout",
+            runtime_target="layers_decompose",
+            runtime_action="replan_decompose_layers",
+            runtime_entrypoint="layers_split_dry_run",
+            required_runtime_inputs=[
+                "source_image",
+                "current_layer_manifest",
+                "layer_order_or_occlusion_notes",
+            ],
+        ),
+        _replay(
+            "taxonomy_v1_redraw_under_split_holdout",
+            runtime_target="layers_redraw",
+            runtime_action="replan_redraw_boundary",
+            runtime_entrypoint="layers_redraw_dry_run",
+            required_runtime_inputs=[
+                "source_image",
+                "current_mask_or_layer_bounds",
+                "target_region_description",
+            ],
+        ),
+        _replay(
+            "blocked_previous_replay",
+            runtime_target="layers_redraw",
+            runtime_action="replan_redraw_boundary",
+            runtime_entrypoint="layers_redraw_dry_run",
+            replay_status="blocked_missing_runtime_inputs",
+            required_runtime_inputs=[],
+        ),
+    ]
+
+
+def _write_jsonl(path: Path, records: list[dict]) -> None:
+    path.write_text(
+        "\n".join(json.dumps(record, sort_keys=True) for record in records) + "\n",
+        encoding="utf-8",
+    )
+
+
+def test_visual_ownership_runtime_entrypoint_dry_run_builds_invocations(tmp_path):
+    from vulca.learning.visual_ownership_runtime_entrypoint_dry_run import (
+        run_visual_ownership_runtime_entrypoint_dry_run,
+    )
+
+    replay_path = tmp_path / "visual_ownership_runtime_replay.jsonl"
+    invocation_path = (
+        tmp_path / "visual_ownership_runtime_entrypoint_dry_run.jsonl"
+    )
+    report_path = tmp_path / "visual_ownership_runtime_entrypoint_dry_run_report.json"
+    _write_jsonl(replay_path, _fixture_replays())
+
+    report = run_visual_ownership_runtime_entrypoint_dry_run(
+        replay_path=replay_path,
+        invocation_path=invocation_path,
+        report_path=report_path,
+    )
+
+    assert (
+        report["case_type"]
+        == "learning_visual_ownership_runtime_entrypoint_dry_run_report"
+    )
+    assert report["status"] == "blocked_runtime_entrypoint_dry_run"
+    assert report["summary"] == {
+        "replay_record_count": 3,
+        "dry_run_invocation_count": 3,
+        "ready_count": 2,
+        "blocked_count": 1,
+        "provider_call_count": 0,
+    }
+    assert report["counts_by_runtime_tool"] == {
+        "layers_redraw": 2,
+        "layers_split": 1,
+    }
+    assert report["counts_by_dry_run_status"] == {
+        "blocked_previous_replay_status": 1,
+        "dry_run_invocation_ready": 2,
+    }
+    assert report["safe_handling"] == {
+        "copies_local_paths": False,
+        "copies_private_refs": False,
+        "copies_raw_source_text": False,
+        "calls_model_provider": False,
+    }
+
+    invocations = [
+        json.loads(line)
+        for line in invocation_path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+    by_case = {record["case_id"]: record for record in invocations}
+
+    decompose = by_case["taxonomy_v1_decompose_occlusion_holdout"]
+    assert (
+        decompose["case_type"]
+        == "learning_visual_ownership_runtime_entrypoint_dry_run"
+    )
+    assert decompose["runtime_tool"] == "layers_split"
+    assert decompose["runtime_interface"] == "mcp"
+    assert decompose["dry_run_status"] == "dry_run_invocation_ready"
+    assert decompose["entrypoint_contract"]["argument_contract"] == {
+        "case_log_path": "{optional_case_log_path}",
+        "image_path": "{source_image}",
+        "mode": "orchestrated",
+        "output_dir": "{runtime_output_dir}",
+        "plan": "{visual_ownership_replan_json}",
+        "provider": "dry_run",
+        "tradition": "{tradition}",
+    }
+    assert decompose["readiness"]["provider_call_count"] == 0
+
+    redraw = by_case["taxonomy_v1_redraw_under_split_holdout"]
+    assert redraw["runtime_tool"] == "layers_redraw"
+    assert redraw["runtime_interface"] == "mcp"
+    assert redraw["dry_run_status"] == "dry_run_invocation_ready"
+    assert redraw["entrypoint_contract"]["argument_contract"] == {
+        "artwork_dir": "{current_layer_manifest_dir}",
+        "case_log_path": "{optional_case_log_path}",
+        "instruction": "{visual_ownership_redraw_instruction}",
+        "layer": "{target_layer_name}",
+        "provider": "dry_run",
+        "route": "auto",
+        "tradition": "{tradition}",
+    }
+
+    blocked = by_case["blocked_previous_replay"]
+    assert blocked["runtime_tool"] == "layers_redraw"
+    assert blocked["dry_run_status"] == "blocked_previous_replay_status"
+    assert blocked["dry_run_reasons"] == ["previous_replay_not_replayable"]
+    assert report_path.exists()
+
+
+def test_visual_ownership_runtime_entrypoint_dry_run_blocks_provider_contract(
+    tmp_path,
+):
+    from vulca.learning.visual_ownership_runtime_entrypoint_dry_run import (
+        run_visual_ownership_runtime_entrypoint_dry_run,
+    )
+
+    replay_path = tmp_path / "visual_ownership_runtime_replay.jsonl"
+    _write_jsonl(
+        replay_path,
+        [
+            _replay(
+                "provider_enabled_contract",
+                runtime_target="layers_redraw",
+                runtime_action="replan_redraw_boundary",
+                runtime_entrypoint="layers_redraw_dry_run",
+                provider_calls_enabled=True,
+            )
+        ],
+    )
+
+    report = run_visual_ownership_runtime_entrypoint_dry_run(
+        replay_path=replay_path,
+    )
+
+    record = report["runtime_entrypoint_dry_runs"][0]
+    assert record["dry_run_status"] == "blocked_provider_call_policy"
+    assert record["dry_run_reasons"] == ["provider_calls_enabled"]
+    assert record["readiness"]["provider_call_count"] == 0
+    assert report["summary"]["provider_call_count"] == 0
+
+
+def test_visual_ownership_runtime_entrypoint_dry_run_cli_writes_summary(tmp_path):
+    replay_path = tmp_path / "visual_ownership_runtime_replay.jsonl"
+    invocation_path = (
+        tmp_path / "visual_ownership_runtime_entrypoint_dry_run.jsonl"
+    )
+    report_path = tmp_path / "visual_ownership_runtime_entrypoint_dry_run_report.json"
+    _write_jsonl(replay_path, _fixture_replays())
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--replay",
+            str(replay_path),
+            "--invocations",
+            str(invocation_path),
+            "--report",
+            str(report_path),
+        ],
+        cwd=ROOT,
+        env=CLI_ENV,
+        text=True,
+        capture_output=True,
+        timeout=30,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "Visual ownership runtime entrypoint dry-run report:" in result.stdout
+    assert "Visual ownership runtime entrypoint dry-runs:" in result.stdout
+    assert "Replay records: 3" in result.stdout
+    assert "Ready: 2" in result.stdout
+    assert "Blocked: 1" in result.stdout
+    assert "Provider calls: 0" in result.stdout
+    report = json.loads(report_path.read_text(encoding="utf-8"))
+    assert report["summary"]["ready_count"] == 2


### PR DESCRIPTION
## Summary
- add provider-free visual ownership runtime entrypoint dry-run records and report
- translate replayable runtime records into MCP argument contracts for layers_split and layers_redraw
- block previous replay failures and provider-enabled contracts without executing runtime/provider calls

## Verification
- PYTHONPATH=src python3 -m pytest tests/test_visual_ownership_runtime_entrypoint_dry_run.py -q
- PYTHONPATH=src python3 scripts/real_source_context_recovery_eval.py --repo-root . --case-source-manifest docs/benchmarks/learning/combined_case_source_manifest_v1.json --artifact-search-root /Users/yhryzy/dev/vulca/.scratch/p2b-live-shipgate --image-search-root /Users/yhryzy/dev/vulca/.scratch/p2b-live-shipgate --source-dependency-manifest docs/benchmarks/learning/real_source_dependency_label_manifest_v1.json --output-dir build/visual_ownership_runtime_entrypoint_dry_run_v1/real_recovery_eval --report build/visual_ownership_runtime_entrypoint_dry_run_v1/real_recovery_eval/report.json --max-recovered-source-context-gaps 0 --min-fallback-agent-reduction 2 --min-recovered-eval-cases 2
- PYTHONPATH=src python3 scripts/visual_ownership_planner.py --decision-path build/visual_ownership_runtime_entrypoint_dry_run_v1/real_recovery_eval/recovered/dry_run/dry_run_decisions.jsonl --plans build/visual_ownership_runtime_entrypoint_dry_run_v1/planner/visual_ownership_plans.jsonl --report build/visual_ownership_runtime_entrypoint_dry_run_v1/planner/report.json
- PYTHONPATH=src python3 scripts/visual_ownership_execution_gate.py --plans build/visual_ownership_runtime_entrypoint_dry_run_v1/planner/visual_ownership_plans.jsonl --gates build/visual_ownership_runtime_entrypoint_dry_run_v1/gate/visual_ownership_execution_gate.jsonl --report build/visual_ownership_runtime_entrypoint_dry_run_v1/gate/report.json
- PYTHONPATH=src python3 scripts/visual_ownership_runtime_adapter.py --gates build/visual_ownership_runtime_entrypoint_dry_run_v1/gate/visual_ownership_execution_gate.jsonl --requests build/visual_ownership_runtime_entrypoint_dry_run_v1/runtime/visual_ownership_runtime_requests.jsonl --report build/visual_ownership_runtime_entrypoint_dry_run_v1/runtime/report.json
- PYTHONPATH=src python3 scripts/visual_ownership_runtime_replay.py --requests build/visual_ownership_runtime_entrypoint_dry_run_v1/runtime/visual_ownership_runtime_requests.jsonl --replay build/visual_ownership_runtime_entrypoint_dry_run_v1/replay/visual_ownership_runtime_replay.jsonl --report build/visual_ownership_runtime_entrypoint_dry_run_v1/replay/report.json
- PYTHONPATH=src python3 scripts/visual_ownership_runtime_entrypoint_dry_run.py --replay build/visual_ownership_runtime_entrypoint_dry_run_v1/replay/visual_ownership_runtime_replay.jsonl --invocations build/visual_ownership_runtime_entrypoint_dry_run_v1/entrypoint/visual_ownership_runtime_entrypoint_dry_run.jsonl --report build/visual_ownership_runtime_entrypoint_dry_run_v1/entrypoint/report.json
- PYTHONPATH=src python3 -m pytest tests/test_visual_ownership_runtime_entrypoint_dry_run.py tests/test_visual_ownership_runtime_replay.py tests/test_visual_ownership_runtime_adapter.py tests/test_visual_ownership_execution_gate.py tests/test_visual_ownership_planner.py tests/test_dry_run_decision_router.py tests/test_training_effectiveness_report.py tests/test_real_source_context_recovery_eval.py -q
- python3 -m py_compile src/vulca/learning/visual_ownership_runtime_entrypoint_dry_run.py scripts/visual_ownership_runtime_entrypoint_dry_run.py
- ruff check src/vulca/learning/visual_ownership_runtime_entrypoint_dry_run.py scripts/visual_ownership_runtime_entrypoint_dry_run.py tests/test_visual_ownership_runtime_entrypoint_dry_run.py
- git diff --check