### PR TITLE
[codex] Complete OpenAI app resubmission packet

### DIFF
--- a/docs/platform/chatgpt-app-privacy-policy.md
+++ b/docs/platform/chatgpt-app-privacy-policy.md
@@ -1,6 +1,6 @@
 # Vulca ChatGPT App Privacy Policy
 
-**Effective date:** 2026-05-07
+**Effective date:** 2026-05-11
 
 This policy describes the data practices for the submitted Vulca ChatGPT App
 remote profile. Vulca is an agent-native visual workflow tool for tradition
@@ -30,6 +30,20 @@ filesystem-writing tools.
 profile. It returns an L1-L5 rubric payload and does not read image pixels or
 call a vision model by default.
 
+All submitted tools are read-only from the ChatGPT App perspective. They do not
+create, modify, delete, publish, send messages, start paid provider jobs, or
+write files.
+
+## Tool Inputs And Outputs
+
+| Tool | Inputs Vulca Receives | Outputs Vulca Returns |
+| --- | --- | --- |
+| `list_traditions` | No required user input. | Public tradition identifiers, display names, categories, and L1-L5 weights. |
+| `get_tradition_guide` | A tradition identifier or name selected or supplied by the user. | Public guide content for that tradition, including terminology, taboos, weight definitions, and layer guidance. |
+| `search_traditions` | User-supplied visual keywords, cultural terms, or tags, plus an optional result limit. | Ranked public tradition matches and matched terms relevant to the request. |
+| `compose_prompt_from_design` | A workspace-relative `design.md` path inside the configured remote workspace root. The tool reads that approved design document only for the requested prompt-composition task. | A composed prompt, negative prompt, tradition tokens, color tokens, and style treatment derived from the approved design document. The submitted profile removes the source file path from the response. |
+| `evaluate_artwork` | An image reference string, selected tradition, and user-supplied evaluation intent. In the submitted profile, the image reference is not opened, uploaded, inspected, or returned. | A rubric-only L1-L5 evaluation payload for the selected tradition and intent. The submitted profile removes image path and timing diagnostics from the response. |
+
 ## Data We Receive
 
 Vulca receives only the tool arguments that ChatGPT sends to the selected MCP
@@ -52,6 +66,9 @@ tool. Depending on the tool, this can include:
 The submitted profile does not intentionally request or collect precise
 location, payment card data, government identifiers, health information,
 passwords, API keys, MFA codes, OAuth tokens, raw full chat history, or images.
+It also does not reconstruct the user's full ChatGPT conversation. It operates
+only on the specific tool arguments or approved resource references that
+ChatGPT sends for a selected tool call.
 
 ## Data We Return To ChatGPT
 

--- a/docs/platform/chatgpt-app-resubmission-checklist.md
+++ b/docs/platform/chatgpt-app-resubmission-checklist.md
@@ -1,14 +1,18 @@
 # ChatGPT App Resubmission Checklist
 
-**Status:** Privacy-remediation checklist
+**Status:** Privacy and screenshot remediation checklist
 **Created:** 2026-05-07
+**Last updated:** 2026-05-11
 
-## Rejection Reason
+## Rejection Reasons
 
-OpenAI review rejected Vulca because the submitted privacy policy did not
-clearly disclose all data uses. The requested remediation is a complete policy
-covering data collected, purposes, recipients, retention, and user controls, and
-alignment with current tool inputs and outputs.
+OpenAI review rejected Vulca for two issues:
+
+1. The submitted privacy policy did not clearly disclose all data uses. The
+   requested remediation is a complete policy covering data collected, purposes,
+   recipients, retention, user controls, and alignment with current tool inputs
+   and outputs.
+2. The included screenshots did not meet OpenAI publishing requirements.
 
 Relevant OpenAI requirements:
 
@@ -19,6 +23,13 @@ Relevant OpenAI requirements:
   avoid diagnostic, telemetry, or internal identifiers unless required.
 - MCP tool responses should be audited for nested fields, debug payloads, PII,
   telemetry, internal IDs, and secrets.
+- The dashboard submission form requires app name, logo, description, company
+  and privacy policy URLs, MCP and tool information, screenshots, test prompts
+  and responses, and localization information.
+- MCP server submissions must use a publicly accessible hosted domain, not a
+  local or testing endpoint.
+- Test cases should produce correct, relevant results on ChatGPT web and mobile
+  apps, with no UI or image-loading errors.
 
 ## Code/Docs Remediation
 
@@ -34,6 +45,8 @@ Relevant OpenAI requirements:
 - Confirm `compose_prompt_from_design` does not echo `source_design_path`.
 - Confirm remote `evaluate_artwork` does not echo `image_path` or `latency_ms`.
 - Re-run remote-profile tests before resubmission.
+- Capture new app screenshots and test evidence using
+  `docs/platform/chatgpt-app-screenshot-and-test-evidence.md`.
 
 ## Tool Response Audit
 
@@ -60,12 +73,36 @@ Expected allowed response categories:
 - composed prompt fields derived from a user-approved design document;
 - rubric-only L1-L5 evaluation payload.
 
+## Screenshot Remediation
+
+The previous screenshot set should be discarded and replaced. Use fresh
+screenshots captured from the production public MCP endpoint and the actual
+ChatGPT app experience.
+
+Required checks before upload:
+
+- The app name, icon, and relevant ChatGPT app UI are visible.
+- Screenshots show real Vulca tool use, not terminal-only captures, source code,
+  local docs, placeholders, or unrelated screens.
+- No API keys, OAuth tokens, PyPI tokens, support emails, private user files,
+  local filesystem paths, private images, trace IDs, or internal debug data are
+  visible.
+- The MCP URL is public HTTPS, not `localhost`, a LAN address, or a temporary
+  testing endpoint.
+- Text is readable after the dashboard upload preview.
+- At least one test pass is recorded for ChatGPT web and one for mobile before
+  resubmission.
+
+If the dashboard displays stricter dimensions, aspect ratio, file size, or file
+type constraints during upload, treat the dashboard validation as the source of
+truth and update the screenshot evidence notes.
+
 ## Dashboard Resubmission Notes
 
 Use a concise release note:
 
 ```text
-Privacy remediation after review feedback. Published a complete Vulca ChatGPT App privacy policy covering collected data, purposes, recipient categories, retention, and user controls. Audited remote MCP tool responses and removed unnecessary local path and diagnostic metadata from the submitted remote profile.
+Remediation after OpenAI review feedback. Published a complete Vulca ChatGPT App privacy policy covering collected data, tool inputs and outputs, purposes, recipient categories, retention, and user controls. Audited remote MCP tool responses and removed unnecessary local path and diagnostic metadata from the submitted remote profile. Replaced the prior screenshot set with fresh screenshots of the actual ChatGPT app experience, using the production public MCP endpoint and matching test prompts/responses.
 ```
 
 ## Optional Email Reply
@@ -73,16 +110,21 @@ Privacy remediation after review feedback. Published a complete Vulca ChatGPT Ap
 ```text
 Hello OpenAI review team,
 
-Thank you for the review. We have remediated the privacy-policy issue for Vulca.
+Thank you for the review. We have remediated the privacy-policy and screenshot issues for Vulca.
 
 Changes made:
-- Published a complete privacy policy covering data collected, purposes of use, recipient categories, retention timelines, and user controls.
+- Published a complete privacy policy covering data collected, current tool inputs and outputs, purposes of use, recipient categories, retention timelines, and user controls.
 - Audited the submitted ChatGPT App remote MCP profile and confirmed it exposes only the five review-safe tools: list_traditions, get_tradition_guide, search_traditions, compose_prompt_from_design, and evaluate_artwork.
 - Removed unnecessary local path and diagnostic metadata from remote tool responses.
 - Confirmed the submitted profile does not expose generation, image upload, pixel reading, redraw, inpaint, archive, sync, admin, or filesystem-writing tools.
+- Replaced the previous screenshot set with screenshots captured from the actual ChatGPT app experience against the production public MCP endpoint.
+- Re-ran the representative test prompts/responses on ChatGPT web and mobile before resubmission.
 
 Privacy policy URL:
 <insert published URL>
+
+Screenshot/test evidence:
+<insert dashboard evidence or internal capture notes if useful>
 
 We will resubmit the app from the OpenAI Platform dashboard.
 

--- a/docs/platform/chatgpt-app-screenshot-and-test-evidence.md
+++ b/docs/platform/chatgpt-app-screenshot-and-test-evidence.md
@@ -1,0 +1,119 @@
+# ChatGPT App Screenshot And Test Evidence Plan
+
+**Status:** Capture plan for OpenAI App resubmission
+**Created:** 2026-05-11
+
+Use this plan after the privacy policy URL is live and before resubmitting Vulca
+from the OpenAI Platform dashboard.
+
+## Source Requirements
+
+OpenAI's submission guide says the dashboard submission form requires app name,
+logo, description, company and privacy policy URLs, MCP and tool information,
+screenshots, test prompts and responses, and localization information.
+
+OpenAI's review guidance also says common rejection reasons include test cases
+that do not produce correct results, UI or image-loading errors, undisclosed
+user-related fields in tool responses, and inaccurate tool hint annotations.
+
+The rejection email for Vulca specifically says the included screenshots did
+not meet publishing requirements. The public docs do not currently list exact
+pixel dimensions for screenshots, so any dashboard upload validation for file
+type, dimensions, aspect ratio, or file size is the source of truth.
+
+Official references:
+
+- `https://developers.openai.com/apps-sdk/deploy/submission`
+- `https://developers.openai.com/apps-sdk/app-submission-guidelines`
+
+## Capture Principles
+
+- Capture from the production public MCP endpoint, not `localhost`, a LAN
+  address, a tunnel, or a temporary test endpoint.
+- Capture the actual ChatGPT app experience. Do not upload terminal-only
+  screenshots, source code, local docs, dashboards, or placeholder mockups.
+- Keep the app name, icon, prompt, tool result, and relevant ChatGPT UI visible.
+- Use realistic but non-private prompts and sample content.
+- Do not show API keys, OAuth tokens, PyPI tokens, support inbox content,
+  private user images, local filesystem paths, request IDs, trace IDs, session
+  IDs, internal account IDs, raw logs, or debug payloads.
+- Preserve raw full-size PNG captures before creating upload-ready versions.
+- If cropping is needed for the dashboard preview, crop only to remove browser
+  chrome or irrelevant margins; do not stretch, blur, or obscure the UI.
+
+## Required Screenshot Set
+
+| File | Scenario | Prompt Or Screen | Acceptance Criteria |
+| --- | --- | --- | --- |
+| `01-vulca-app-connected.png` | App identity and connection state | Vulca app listing, enabled app screen, or direct app selection in ChatGPT | Shows Vulca name, icon, and connected or available state. No private account details are visible. |
+| `02-list-traditions.png` | Discovery | `@Vulca list the supported visual traditions and summarize the L1-L5 rubric families.` | Output shows public tradition names or identifiers and L1-L5 rubric framing. |
+| `03-get-tradition-guide.png` | Tradition guide | `@Vulca show the guide for chinese_xieyi and keep it concise.` | Output shows terminology, weights, taboos, or layer guidance for one tradition. |
+| `04-search-traditions.png` | Search | `@Vulca find traditions related to ink wash, negative space, and restrained color.` | Output shows ranked public matches and matched terms. |
+| `05-compose-prompt.png` | Prompt composition | `@Vulca compose a provider prompt from the approved design.md in the review workspace.` | Output shows composed prompt fields and does not reveal `source_design_path` or any local absolute path. |
+| `06-evaluate-rubric.png` | Rubric-only evaluation | `@Vulca evaluate this artwork reference for chinese_xieyi using rubric-only mode: misty mountain ink study.` | Output shows an L1-L5 rubric payload or summary and does not reveal `image_path`, `latency_ms`, raw image bytes, or provider metadata. |
+| `07-mobile-smoke.png` | Mobile smoke test | Repeat one discovery or guide prompt in ChatGPT mobile | Confirms the app produces correct, readable output on mobile. Use as evidence even if the dashboard only asks for desktop screenshots. |
+
+If the dashboard allows only a smaller number of screenshots, upload the best
+set in this order: `01`, `02`, `03`, `05`, `06`. Keep the remaining captures as
+review evidence.
+
+## Test Prompts And Expected Responses
+
+Use these prompts in the dashboard test prompt/response fields or as reviewer
+evidence.
+
+| Prompt | Expected Tool | Expected Response Boundary |
+| --- | --- | --- |
+| `@Vulca list the supported visual traditions and summarize the L1-L5 rubric families.` | `list_traditions` | Public tradition identifiers, display names, categories, and L1-L5 weights only. |
+| `@Vulca show the guide for chinese_xieyi and keep it concise.` | `get_tradition_guide` | Public guide content for `chinese_xieyi`; no user-related data. |
+| `@Vulca find traditions related to ink wash, negative space, and restrained color.` | `search_traditions` | Ranked public matches and matched terms; may echo the supplied tags as `query_tags`. |
+| `@Vulca compose a provider prompt from the approved design.md in the review workspace.` | `compose_prompt_from_design` | Prompt fields derived from approved design content; no `source_design_path` or absolute filesystem paths. |
+| `@Vulca evaluate this artwork reference for chinese_xieyi using rubric-only mode: misty mountain ink study.` | `evaluate_artwork` | Rubric-only L1-L5 evaluation payload; no `image_path`, `latency_ms`, image bytes, VLM provider response, or trace metadata. |
+
+## Pre-Upload QA
+
+- Privacy policy URL opens without login and matches
+  `docs/platform/chatgpt-app-privacy-policy.md`.
+- Tool list in the dashboard matches the submitted remote profile exactly:
+  `list_traditions`, `get_tradition_guide`, `search_traditions`,
+  `compose_prompt_from_design`, and `evaluate_artwork`.
+- Tool annotations are read-only, non-destructive, and not open-world.
+- Raw tool responses were inspected for nested debug payloads and internal
+  identifiers.
+- Screenshots are captured after any metadata or server changes, not from an
+  older rejected build.
+- Uploaded screenshots remain readable in the dashboard preview.
+- ChatGPT web and mobile test prompts both pass before clicking submit.
+
+## Evidence Log Template
+
+```text
+Capture date:
+Reviewer:
+Production MCP URL:
+Privacy policy URL:
+Dashboard screenshot constraints observed:
+
+Uploaded screenshots:
+- 01-vulca-app-connected.png:
+- 02-list-traditions.png:
+- 03-get-tradition-guide.png:
+- 05-compose-prompt.png:
+- 06-evaluate-rubric.png:
+
+Additional evidence retained:
+- 04-search-traditions.png:
+- 07-mobile-smoke.png:
+
+Web test pass:
+- Prompt:
+- Tool selected:
+- Result summary:
+- Unexpected fields checked:
+
+Mobile test pass:
+- Prompt:
+- Tool selected:
+- Result summary:
+- Unexpected fields checked:
+```

--- a/docs/platform/openai-codex-mcp-guide.md
+++ b/docs/platform/openai-codex-mcp-guide.md
@@ -102,6 +102,7 @@ Before public install instructions:
 - verify `vulca-mcp-remote` starts with `VULCA_REMOTE_WORKSPACE_ROOT` set before ChatGPT remote MCP experiments;
 - publish and submit the privacy policy in `docs/platform/chatgpt-app-privacy-policy.md`;
 - audit the raw remote MCP responses against `docs/platform/chatgpt-app-resubmission-checklist.md`;
+- recapture OpenAI App screenshots and test evidence with `docs/platform/chatgpt-app-screenshot-and-test-evidence.md`;
 - run one no-cost `/visual-discovery` or prompt-composition workflow;
 - confirm generated artifacts stay in the workspace;
 - confirm public copy says official Codex public publishing is still pending unless OpenAI has opened it.


### PR DESCRIPTION
## Summary

- Expands the ChatGPT App privacy policy with a per-tool input/output map and clearer data-boundary language.
- Updates the resubmission checklist to cover both OpenAI rejection reasons: privacy policy disclosure and screenshots.
- Adds a screenshot and test-evidence capture plan, then links it from the OpenAI/Codex release gate.

## Validation

- `PYTHONPATH=src /opt/homebrew/bin/python3.11 -m pytest tests/test_mcp_remote_profile.py -q` (16 passed)
- `/opt/homebrew/bin/ruff check src/vulca/mcp_remote.py tests/test_mcp_remote_profile.py` (passed)
- `git diff --check` (passed)

## Notes

- Keeping this PR as draft until the real production ChatGPT screenshots are captured and uploaded in the OpenAI Platform dashboard.
- Official docs checked: `https://developers.openai.com/apps-sdk/deploy/submission` and `https://developers.openai.com/apps-sdk/app-submission-guidelines`.