### PR TITLE
[codex] Record Hugging Face MCP endpoint

### DIFF
--- a/docs/platform/chatgpt-app-resubmission-checklist.md
+++ b/docs/platform/chatgpt-app-resubmission-checklist.md
@@ -50,12 +50,15 @@ Relevant OpenAI requirements:
   PYTHONPATH=src python scripts/chatgpt_app_preflight.py \
     --submission chatgpt-app-submission.json \
     --privacy-url https://github.com/vulca-org/vulca/blob/master/docs/platform/chatgpt-app-privacy-policy.md \
-    --mcp-url https://<cloud-run-service-url>/mcp
+    --mcp-url https://harryhurry-vulca-openai-mcp.hf.space/mcp
   ```
-- Deploy the review-safe MCP profile using `deploy/chatgpt-mcp/` to a direct
-  Cloud Run service URL. The Docker image installs `vulca[mcp]==0.23.1` from
-  PyPI and the deployed command must run `vulca-mcp-remote`, not the full local
-  `vulca-mcp` server.
+- Deploy the review-safe MCP profile to a public HTTPS host. The current
+  resubmission endpoint is the Hugging Face Docker Space
+  `https://harryhurry-vulca-openai-mcp.hf.space/mcp`, running
+  `vulca[mcp]==0.23.1` from PyPI.
+- If using Cloud Run instead, deploy `deploy/chatgpt-mcp/` to a direct Cloud Run
+  service URL. The deployed command must run `vulca-mcp-remote`, not the full
+  local `vulca-mcp` server.
 - Do not use `https://vulcaart.art/mcp` for this resubmission unless Firebase
   Hosting has first been explicitly rewired to the deployed Cloud Run service
   and the production preflight command passes against that domain.

--- a/docs/platform/chatgpt-app-resubmission-evidence.md
+++ b/docs/platform/chatgpt-app-resubmission-evidence.md
@@ -29,7 +29,7 @@ Run before submission:
 PYTHONPATH=src python scripts/chatgpt_app_preflight.py \
   --submission chatgpt-app-submission.json \
   --privacy-url https://github.com/vulca-org/vulca/blob/master/docs/platform/chatgpt-app-privacy-policy.md \
-  --mcp-url https://<production-service-url>/mcp
+  --mcp-url https://harryhurry-vulca-openai-mcp.hf.space/mcp
 ```
 
 ## Deployment Evidence
@@ -37,16 +37,17 @@ PYTHONPATH=src python scripts/chatgpt_app_preflight.py \
 Production MCP URL:
 
 ```text
-TODO: https://<cloud-run-service-url>/mcp
+https://harryhurry-vulca-openai-mcp.hf.space/mcp
 ```
 
 Deployment command or workflow:
 
 ```text
-Use deploy/chatgpt-mcp/Dockerfile with deploy/chatgpt-mcp/cloudbuild.yaml.
-The image installs vulca[mcp]==0.23.1 from PyPI and runs vulca-mcp-remote.
-Deploy the built image directly to Cloud Run with VULCA_REMOTE_MCP_* environment
-values and submit the Cloud Run service URL plus /mcp.
+Hugging Face Space: harryHURRY/vulca-openai-mcp
+SDK: docker
+Hardware: cpu-basic
+Runtime package: vulca[mcp]==0.23.1 from PyPI
+MCP path: /mcp
 ```
 
 Expected deployed profile:
@@ -91,7 +92,7 @@ Use these values unless the dashboard form has a stricter current constraint:
 - Category: `DESIGN`
 - Privacy policy URL:
   `https://github.com/vulca-org/vulca/blob/master/docs/platform/chatgpt-app-privacy-policy.md`
-- MCP server URL: `TODO: https://<cloud-run-service-url>/mcp`
+- MCP server URL: `https://harryhurry-vulca-openai-mcp.hf.space/mcp`
 - Tools: exactly the five allowlisted tools above.
 
 Release note:


### PR DESCRIPTION
## What changed

- Updated the ChatGPT app resubmission checklist to use the live Hugging Face Space MCP endpoint.
- Updated the evidence file with the production MCP URL and deployment details.

## Endpoint

`https://harryhurry-vulca-openai-mcp.hf.space/mcp`

The Space is a Docker Space on CPU Basic and now runs `vulca[mcp]==0.23.1` from PyPI.

## Validation

- `git diff --check`
- `PYTHONPATH=src /opt/homebrew/bin/python3 scripts/chatgpt_app_preflight.py --submission chatgpt-app-submission.json --privacy-url https://github.com/vulca-org/vulca/blob/master/docs/platform/chatgpt-app-privacy-policy.md --mcp-url https://harryhurry-vulca-openai-mcp.hf.space/mcp`
- Remote FastMCP client listed exactly the five submitted tools and successfully called `list_traditions`.
