### PR TITLE
docs: sync staged GitHub protection rollout

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,13 +2,13 @@
 # GitHub uses this to auto-request reviews on PRs and to gate branch-protection
 # rules when enabled.
 #
-# Solo maintainer: @yhryzy owns everything by default.
+# Solo maintainer: @yha9806 owns everything by default.
 
-* @yhryzy
+* @yha9806
 
 # Protected context vault. Reader sessions may cite it, but direct edits require
 # owner review and the review-context gate.
-/docs/review-context/ @yhryzy
+/docs/review-context/ @yha9806
 
 # When future contributors emerge, add per-path ownership here, e.g.:
 #   /src/vulca/cultural/  @culture-team

--- a/docs/superpowers/plans/2026-06-15-github-main-context-vault-protection.md
+++ b/docs/superpowers/plans/2026-06-15-github-main-context-vault-protection.md
@@ -2,9 +2,9 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Enforce GitHub repository-side protection for `master` and `codex/vulca-context-vault` so both branches require PR review and checks before updates.
+**Goal:** Enforce GitHub repository-side protection for `master` and `codex/vulca-context-vault` so both branches require PR workflow and checks before updates.
 
-**Architecture:** Use three GitHub repository rulesets: one shared base ruleset for PR/review/no-force-push/no-delete behavior, one master-only status-check ruleset, and one context-vault-only status-check ruleset. Make the lightweight review-context workflow run on every protected branch PR/push so it can be safely required as a status check.
+**Architecture:** Use three GitHub repository rulesets: one shared base ruleset for PR-required/no-force-push/no-delete behavior, one master-only status-check ruleset, and one context-vault-only status-check ruleset. Keep master checks to existing CI until `review-context.yml` lands on `master`; keep context-vault gated by the lightweight `validate` job.
 
 **Tech Stack:** Git, GitHub CLI (`gh`), GitHub REST repository rulesets API, GitHub Actions, Python 3.
 
@@ -13,7 +13,7 @@
 ## File Structure
 
 - Modify: `.github/workflows/review-context.yml`
-  - Remove path filters so the `Review Context Vault / validate` check appears on every protected branch PR/push.
+  - Remove path filters so the `validate` check appears on every context-vault PR/push and can later be required on `master` after the workflow lands there.
 - Read: `.github/workflows/ci.yml`
   - Confirm CI matrix job names before binding required checks for `master`.
 - Read: `docs/superpowers/specs/2026-06-15-github-main-context-vault-protection-design.md`
@@ -306,9 +306,9 @@ base = {
             "parameters": {
                 "allowed_merge_methods": ["merge", "squash", "rebase"],
                 "dismiss_stale_reviews_on_push": True,
-                "require_code_owner_review": True,
+                "require_code_owner_review": False,
                 "require_last_push_approval": False,
-                "required_approving_review_count": 1,
+                "required_approving_review_count": 0,
                 "required_review_thread_resolution": True,
             },
         },
@@ -336,7 +336,6 @@ master_checks = {
                 "required_status_checks": [
                     {"context": master_check_311},
                     {"context": master_check_312},
-                    {"context": review_context_check},
                 ],
             },
         },
@@ -407,6 +406,14 @@ master-checks.json protected-master-required-checks ['refs/heads/master']
 ```
 
 The printed check names must match the values from Task 3 exactly.
+
+In the initial solo-maintainer rollout, expected checks are:
+
+- `master-checks.json`: `test (3.11)`, `test (3.12)`
+- `context-checks.json`: `validate`
+
+Do not put `validate` in `master-checks.json` until `review-context.yml` has
+landed on `master` and a successful `validate` check exists on that branch.
 
 ## Task 5: Create Repository Rulesets
 
@@ -542,11 +549,11 @@ CONTEXT_RULE_CHECKS="$(gh api repos/vulca-org/vulca/rules/branches/codex%2Fvulca
 printf 'master:\n%s\ncontext vault:\n%s\n' "$MASTER_RULE_CHECKS" "$CONTEXT_RULE_CHECKS"
 printf '%s\n' "$MASTER_RULE_CHECKS" | grep -Fx "$MASTER_CHECK_311"
 printf '%s\n' "$MASTER_RULE_CHECKS" | grep -Fx "$MASTER_CHECK_312"
-printf '%s\n' "$MASTER_RULE_CHECKS" | grep -Fx "$REVIEW_CONTEXT_CHECK"
 printf '%s\n' "$CONTEXT_RULE_CHECKS" | grep -Fx "$REVIEW_CONTEXT_CHECK"
 ```
 
-Expected: all four `grep -Fx` commands echo the matching check name and exit 0.
+Expected: all three `grep -Fx` commands echo the matching check name and exit 0.
+`master` should not require `validate` in the initial rollout.
 
 ## Task 7: Final Local Verification And Handoff
 

--- a/docs/superpowers/specs/2026-06-15-github-main-context-vault-protection-design.md
+++ b/docs/superpowers/specs/2026-06-15-github-main-context-vault-protection-design.md
@@ -14,7 +14,7 @@ Current remote protection state checked on 2026-06-15:
 - repository rulesets are empty.
 - local branch `codex/vulca-context-vault` contains the protected review-context
   vault initialization commit and is ahead of `origin/master` by one commit.
-- `.github/CODEOWNERS` now assigns `/docs/review-context/` to `@yhryzy`.
+- `.github/CODEOWNERS` now assigns `/docs/review-context/` to `@yha9806`.
 - `.github/workflows/review-context.yml` now validates review-context vault
   changes.
 
@@ -38,8 +38,10 @@ through pull requests, review, and required checks.
   remain cheap to create, update, and discard.
 - Do not make PPT, website, or SDK experiment branches immutable.
 - Do not add signed-commit enforcement in this pass.
-- Do not require two-person review while the repository is operated by a solo
-  maintainer; one owner approval is enough for the first protection layer.
+- Do not require approval while the repository is operated by a solo maintainer.
+  The first protection layer blocks direct branch mutation through PR-required,
+  no-delete, no-force-push, and required-check rules. Approval and code-owner
+  review can be re-enabled after a second valid reviewer or team exists.
 
 ## Recommended Mechanism
 
@@ -80,8 +82,8 @@ actors.
 The base ruleset should enforce:
 
 - Require pull request before merging.
-- Require at least one approving review.
-- Require review from Code Owners.
+- Require zero approving reviews while the repository has only one collaborator.
+- Do not require Code Owner review while the repository has only one collaborator.
 - Dismiss stale approvals when new commits are pushed.
 - Require conversation resolution before merge.
 - Block force pushes.
@@ -107,7 +109,10 @@ Required checks:
 
 - CI Python 3.11 job.
 - CI Python 3.12 job.
-- Review Context Vault validation job.
+
+Do not require the review-context validation job on `master` until
+`.github/workflows/review-context.yml` has landed on `master` and a successful
+`validate` check has been observed on that branch.
 
 Ruleset name:
 
@@ -121,7 +126,9 @@ Required checks:
 
 - Review Context Vault validation job.
 
-`Review Context Vault / validate` must run on every protected-branch PR and push.
+The `validate` check from `Review Context Vault` must run on every
+context-vault PR and push, and can later be required on `master` after the
+workflow exists there.
 The implementation should remove path filters from `.github/workflows/review-context.yml`
 before the rulesets require that check. The validator is lightweight and safe to
 run on all protected branch changes.
@@ -136,6 +143,41 @@ names are derived from:
 
 Implementation must inspect recent check runs and use the exact context names
 reported by GitHub.
+
+## Current Applied State
+
+Applied on 2026-06-15:
+
+- `protected-main-and-context-vault-base` id `17697353`
+  - active branch ruleset
+  - targets `refs/heads/master` and `refs/heads/codex/vulca-context-vault`
+  - requires pull requests but currently uses `required_approving_review_count: 0`
+  - uses `require_code_owner_review: false`
+  - blocks deletion and non-fast-forward updates
+  - has no bypass actors
+- `protected-master-required-checks` id `17697361`
+  - active branch ruleset
+  - targets `refs/heads/master`
+  - requires `test (3.11)` and `test (3.12)`
+  - does not yet require `validate`
+- `protected-context-vault-required-checks` id `17697367`
+  - active branch ruleset
+  - targets `refs/heads/codex/vulca-context-vault`
+  - requires `validate`
+
+Reason for staged review settings:
+
+- The repository currently has one collaborator, `yha9806`.
+- A one-approval plus code-owner review rule would lock out a solo maintainer.
+- `review-context.yml` is not yet on `master`, so requiring `validate` on
+  `master` would risk blocking the first PR that lands the workflow.
+
+Follow-up after `review-context.yml` lands on `master` and a valid second
+reviewer or team exists:
+
+1. Add `validate` to `protected-master-required-checks`.
+2. Re-enable `required_approving_review_count: 1`.
+3. Re-enable `require_code_owner_review: true`.
 
 ## Bootstrap Sequence
 
@@ -166,7 +208,9 @@ The GitHub ruleset complements, but does not replace, the vault rules:
 
 - `docs/review-context/LOCK.md` defines who may modify vault context.
 - `docs/review-context/GOVERNANCE.md` defines request and curator behavior.
-- CODEOWNERS makes owner review visible and enforceable.
+- CODEOWNERS makes ownership visible. Code-owner review becomes enforceable only
+  after `require_code_owner_review` is re-enabled and a non-author reviewer or
+  team exists.
 - the review-context workflow makes the local validator enforceable on PRs and
   pushes to protected branches.
 
@@ -180,8 +224,8 @@ If required checks are misnamed and block all merges:
 
 1. Use admin access to edit the ruleset check list.
 2. Replace guessed contexts with the exact contexts from recent check runs.
-3. Keep PR review, code owner review, force-push block, and deletion block
-   enabled while fixing check names.
+3. Keep PR workflow, force-push block, and deletion block enabled while fixing
+   check names.
 
 If the review-context workflow itself fails:
 


### PR DESCRIPTION
## Summary
- update CODEOWNERS to valid GitHub user @yha9806
- document the applied solo-safe ruleset state
- update the rollout plan so master initially requires CI only, while context-vault requires validate

## Verification
- python3 docs/review-context/gates/validate_review_context.py
- git diff --check HEAD~1..HEAD

## Notes
- master does not require validate until review-context.yml lands on master and a successful validate check is observed there
- approval/code-owner review should be re-enabled after a valid second reviewer or team exists