### PR TITLE
docs: lock context vault to dedicated branch

### DIFF
--- a/.github/workflows/review-context.yml
+++ b/.github/workflows/review-context.yml
@@ -2,9 +2,9 @@ name: Review Context Vault
 
 on:
   pull_request:
-    branches: [master, codex/vulca-context-vault]
+    branches: [codex/vulca-context-vault]
   push:
-    branches: [master, codex/vulca-context-vault]
+    branches: [codex/vulca-context-vault]
 
 concurrency:
   group: review-context-${{ github.workflow }}-${{ github.ref }}

--- a/docs/review-context/CHANGELOG.md
+++ b/docs/review-context/CHANGELOG.md
@@ -4,6 +4,22 @@ Vault status: append-only change log.
 
 ## 2026-06-15
 
+### Confirmed Branch-Only Protection
+
+- Recorded the human decision to keep the vault only on
+  `codex/vulca-context-vault`.
+- Added `PROTECTION.md` as the local record for GitHub rulesets, branch
+  boundary, request workflow, and emergency bypass requirements.
+- Scoped `.github/workflows/review-context.yml` to
+  `codex/vulca-context-vault` only.
+- Fixed governance ownership text to use the valid GitHub owner `@yha9806`.
+
+Source basis:
+
+- Human decision in the current session: option B, keep the vault only on
+  `codex/vulca-context-vault`.
+- Live GitHub rulesets verified through the GitHub API on 2026-06-15.
+
 ### Initialized Context Vault
 
 - Created protected `docs/review-context/` structure on branch

--- a/docs/review-context/GOVERNANCE.md
+++ b/docs/review-context/GOVERNANCE.md
@@ -101,14 +101,32 @@ The gate must pass before commit.
 Pull requests that touch the vault also run `.github/workflows/review-context.yml`,
 which executes the gate and its validator tests.
 
+## Branch Boundary
+
+The vault is branch-only by current human decision.
+
+- `codex/vulca-context-vault` is the protected context branch.
+- `master` is the protected product mainline.
+- `master` does not carry the vault as a required context artifact.
+- `master` does not require the `validate` review-context status check.
+- Moving the vault into `master` requires a new explicit human instruction and
+  a governance update in this folder.
+
 ## Repository Guardrails
 
 The vault relies on both local and repository-level controls:
 
-- `.github/CODEOWNERS` assigns `/docs/review-context/` to `@yhryzy`.
-- `.github/workflows/review-context.yml` runs the validator on vault changes.
+- `.github/CODEOWNERS` assigns `/docs/review-context/` to `@yha9806`.
+- `.github/workflows/review-context.yml` runs the validator on
+  `codex/vulca-context-vault` PRs and pushes.
 - `tests/test_review_context_vault.py` checks the validator catches missing files,
   missing request-lock checklist items, and forbidden claim upgrades.
+- GitHub rulesets protect `master` and `codex/vulca-context-vault` from direct
+  branch mutation, deletion, and non-fast-forward updates.
+- `protected-context-vault-required-checks` requires the `validate` status check
+  on `codex/vulca-context-vault`.
+- `protected-master-required-checks` requires only the existing CI checks on
+  `master`: `test (3.11)` and `test (3.12)`.
 
 These controls do not replace curator judgment. They make bypasses visible in
 review and keep future sessions from silently weakening the context lock.

--- a/docs/review-context/LOCK.md
+++ b/docs/review-context/LOCK.md
@@ -38,6 +38,11 @@ Direct vault edits are allowed only when all of these are true:
 
 The vault branch is not a feature branch. It is a protected memory branch.
 
+Current human decision: keep this vault only on `codex/vulca-context-vault`.
+Do not move or mirror it into `master` unless a future explicit instruction
+changes this policy and records that change in `GOVERNANCE.md`,
+`PROTECTION.md`, and `CHANGELOG.md`.
+
 - SDK implementation branches may read it.
 - Platform / Workspace branches may read it.
 - Website branches may read it.

--- a/docs/review-context/MANIFEST.json
+++ b/docs/review-context/MANIFEST.json
@@ -15,6 +15,7 @@
     "README.md",
     "LOCK.md",
     "GOVERNANCE.md",
+    "PROTECTION.md",
     "CHANGELOG.md",
     "MANIFEST.json",
     "source-index.md",

--- a/docs/review-context/PROTECTION.md
+++ b/docs/review-context/PROTECTION.md
@@ -1,0 +1,87 @@
+# Review Context Protection
+
+Vault status: protected branch and repository guardrail record.
+
+## Branch-Only Decision
+
+The review-context vault is intentionally kept on
+`codex/vulca-context-vault`.
+
+`master` is the protected product mainline. It must not become the working copy
+of the vault unless a future human instruction explicitly reverses this
+decision and records the reason in this vault.
+
+Current rule:
+
+- `codex/vulca-context-vault` owns `docs/review-context/` and its validation
+  gate.
+- `master` may link to or read from the vault, but it does not carry the vault
+  as a required context artifact.
+- The `validate` status check is required on `codex/vulca-context-vault`.
+- The `validate` status check is not required on `master`.
+
+## Live Repository Protection
+
+As of 2026-06-15, GitHub repository rulesets protect both long-lived branches:
+
+- `protected-main-and-context-vault-base` targets `master` and
+  `codex/vulca-context-vault`.
+- `protected-master-required-checks` targets `master`.
+- `protected-context-vault-required-checks` targets
+  `codex/vulca-context-vault`.
+
+The shared base ruleset requires pull requests, blocks deletion, blocks
+non-fast-forward updates, and has no bypass actors.
+
+The master status-check ruleset requires:
+
+- `test (3.11)`
+- `test (3.12)`
+
+The context-vault status-check ruleset requires:
+
+- `validate`
+
+While the repository has only one maintainer, the shared pull-request rule uses
+`required_approving_review_count: 0` and
+`require_code_owner_review: false` to avoid a solo-maintainer lockout. Code
+owner review can be re-enabled only after a second valid reviewer or team exists.
+
+## Modification Path
+
+Reader sessions may:
+
+- read this vault;
+- cite this vault;
+- create a request packet using `requests/TEMPLATE.md`;
+- open a normal PR that proposes a request packet.
+
+Reader sessions must not:
+
+- directly edit protected vault files during unrelated SDK, website, PPT,
+  Workspace, release, or copywriting work;
+- merge their own context changes into `codex/vulca-context-vault`;
+- move the vault into `master` as a side effect of another change.
+
+Only a context-curator session may modify the vault. The curator must update the
+relevant vault files, update `CHANGELOG.md` and `MANIFEST.json` when the
+protected context inventory changes, run the local validation gate, and merge
+through the protected branch workflow.
+
+## Emergency Changes
+
+Emergency bypass is not configured by default.
+
+If a critical repair requires temporary bypass:
+
+1. Record the human instruction authorizing the bypass.
+2. Temporarily adjust only the failing ruleset requirement.
+3. Make the smallest repair.
+4. Restore the ruleset immediately.
+5. Record the incident in this vault.
+
+## Sources
+
+- Repository rulesets verified through the GitHub API on 2026-06-15.
+- Context-vault branch: `codex/vulca-context-vault`.
+- GitHub user owner in `.github/CODEOWNERS`: `@yha9806`.

--- a/docs/review-context/README.md
+++ b/docs/review-context/README.md
@@ -16,10 +16,14 @@ Other sessions may read this folder and cite it. They must not directly modify
 it. Proposed edits go through `requests/` and are accepted only by a dedicated
 context-curator session on the `codex/vulca-context-vault` branch.
 
+The vault is intentionally branch-only. `master` remains the protected product
+mainline and does not carry or require the vault validation gate.
+
 ## Current Vault Contents
 
 - `LOCK.md`: non-negotiable access and modification boundary.
 - `GOVERNANCE.md`: request, review, and curator workflow.
+- `PROTECTION.md`: branch-only decision and live GitHub protection record.
 - `MANIFEST.json`: machine-readable vault inventory and gate metadata.
 - `source-index.md`: source references for historical claims.
 - `00-project-overview.md`: current integrated VULCA picture.

--- a/docs/superpowers/plans/2026-06-15-github-main-context-vault-protection.md
+++ b/docs/superpowers/plans/2026-06-15-github-main-context-vault-protection.md
@@ -4,7 +4,7 @@
 
 **Goal:** Enforce GitHub repository-side protection for `master` and `codex/vulca-context-vault` so both branches require PR workflow and checks before updates.
 
-**Architecture:** Use three GitHub repository rulesets: one shared base ruleset for PR-required/no-force-push/no-delete behavior, one master-only status-check ruleset, and one context-vault-only status-check ruleset. Keep master checks to existing CI until `review-context.yml` lands on `master`; keep context-vault gated by the lightweight `validate` job.
+**Architecture:** Use three GitHub repository rulesets: one shared base ruleset for PR-required/no-force-push/no-delete behavior, one master-only status-check ruleset, and one context-vault-only status-check ruleset. Keep master checks to existing CI; under the branch-only vault decision, only `codex/vulca-context-vault` is gated by the lightweight `validate` job.
 
 **Tech Stack:** Git, GitHub CLI (`gh`), GitHub REST repository rulesets API, GitHub Actions, Python 3.
 
@@ -13,7 +13,7 @@
 ## File Structure
 
 - Modify: `.github/workflows/review-context.yml`
-  - Remove path filters so the `validate` check appears on every context-vault PR/push and can later be required on `master` after the workflow lands there.
+  - Scope the workflow to `codex/vulca-context-vault` so the `validate` check appears on every context-vault PR/push without making it a `master` requirement.
 - Read: `.github/workflows/ci.yml`
   - Confirm CI matrix job names before binding required checks for `master`.
 - Read: `docs/superpowers/specs/2026-06-15-github-main-context-vault-protection-design.md`
@@ -38,9 +38,9 @@ name: Review Context Vault
 
 on:
   pull_request:
-    branches: [master, codex/vulca-context-vault]
+    branches: [codex/vulca-context-vault]
   push:
-    branches: [master, codex/vulca-context-vault]
+    branches: [codex/vulca-context-vault]
 
 concurrency:
   group: review-context-${{ github.workflow }}-${{ github.ref }}
@@ -412,8 +412,10 @@ In the initial solo-maintainer rollout, expected checks are:
 - `master-checks.json`: `test (3.11)`, `test (3.12)`
 - `context-checks.json`: `validate`
 
-Do not put `validate` in `master-checks.json` until `review-context.yml` has
-landed on `master` and a successful `validate` check exists on that branch.
+Do not put `validate` in `master-checks.json` under the branch-only vault
+decision. Any future change that makes `master` require `validate` must first
+record an explicit governance decision to move or mirror the vault workflow onto
+`master`.
 
 ## Task 5: Create Repository Rulesets
 

--- a/docs/superpowers/specs/2026-06-15-github-main-context-vault-protection-design.md
+++ b/docs/superpowers/specs/2026-06-15-github-main-context-vault-protection-design.md
@@ -2,13 +2,13 @@
 
 ## Status
 
-Approved design for implementation planning.
+Applied protection design. Branch-only vault policy confirmed on 2026-06-15.
 
 ## Context
 
 The repository is `vulca-org/vulca`. The default branch is `master`.
 
-Current remote protection state checked on 2026-06-15:
+Initial remote protection state checked on 2026-06-15 before rollout:
 
 - `master` has no branch protection rule.
 - repository rulesets are empty.
@@ -111,8 +111,8 @@ Required checks:
 - CI Python 3.12 job.
 
 Do not require the review-context validation job on `master` until
-`.github/workflows/review-context.yml` has landed on `master` and a successful
-`validate` check has been observed on that branch.
+an explicit future human instruction reverses the branch-only vault decision
+and lands the vault workflow on `master`.
 
 Ruleset name:
 
@@ -127,11 +127,8 @@ Required checks:
 - Review Context Vault validation job.
 
 The `validate` check from `Review Context Vault` must run on every
-context-vault PR and push, and can later be required on `master` after the
-workflow exists there.
-The implementation should remove path filters from `.github/workflows/review-context.yml`
-before the rulesets require that check. The validator is lightweight and safe to
-run on all protected branch changes.
+context-vault PR and push. Under the current branch-only policy, the workflow is
+scoped to `codex/vulca-context-vault` and is not a `master` requirement.
 
 The exact GitHub check context names must be bound after the workflows have run
 at least once on GitHub. Implementation must read the names from GitHub's
@@ -159,7 +156,7 @@ Applied on 2026-06-15:
   - active branch ruleset
   - targets `refs/heads/master`
   - requires `test (3.11)` and `test (3.12)`
-  - does not yet require `validate`
+  - does not require `validate` under the branch-only vault policy
 - `protected-context-vault-required-checks` id `17697367`
   - active branch ruleset
   - targets `refs/heads/codex/vulca-context-vault`
@@ -169,15 +166,17 @@ Reason for staged review settings:
 
 - The repository currently has one collaborator, `yha9806`.
 - A one-approval plus code-owner review rule would lock out a solo maintainer.
-- `review-context.yml` is not yet on `master`, so requiring `validate` on
-  `master` would risk blocking the first PR that lands the workflow.
+- The current human decision keeps the vault on `codex/vulca-context-vault`,
+  so `master` must not require the vault-only `validate` check.
 
-Follow-up after `review-context.yml` lands on `master` and a valid second
-reviewer or team exists:
+Future changes require separate decisions:
 
-1. Add `validate` to `protected-master-required-checks`.
-2. Re-enable `required_approving_review_count: 1`.
-3. Re-enable `require_code_owner_review: true`.
+1. Adding `validate` to `protected-master-required-checks` requires an explicit
+   human instruction to move or mirror the vault workflow onto `master`.
+2. Re-enabling `required_approving_review_count: 1` requires a valid second
+   reviewer or team.
+3. Re-enabling `require_code_owner_review: true` requires a valid second
+   reviewer or team that can satisfy CODEOWNERS review.
 
 ## Bootstrap Sequence
 
@@ -187,8 +186,9 @@ future updates and before the review-context workflow can produce a check run.
 
 Sequence:
 
-1. Remove path filters from `.github/workflows/review-context.yml` and commit the
-   workflow change if it has not already been done.
+1. Scope `.github/workflows/review-context.yml` to
+   `codex/vulca-context-vault` and commit the workflow change if it has not
+   already been done.
 2. Push `codex/vulca-context-vault` to `origin`.
 3. Wait for GitHub Actions to run on the pushed branch.
 4. Inspect exact check context names from the completed runs.
@@ -212,7 +212,7 @@ The GitHub ruleset complements, but does not replace, the vault rules:
   after `require_code_owner_review` is re-enabled and a non-author reviewer or
   team exists.
 - the review-context workflow makes the local validator enforceable on PRs and
-  pushes to protected branches.
+  pushes to `codex/vulca-context-vault`.
 
 Other sessions may still read the vault and propose request packets. They should
 not directly edit protected vault files or merge their own changes into the


### PR DESCRIPTION
## Summary
- Records the confirmed branch-only policy for `codex/vulca-context-vault`.
- Adds `docs/review-context/PROTECTION.md` as the local ruleset and branch-boundary record.
- Scopes the review-context workflow to the vault branch and removes stale master-validate follow-up wording.

## Test Plan
- `python3 docs/review-context/gates/validate_review_context.py`
- `python3 -m pytest tests/test_review_context_vault.py -q`
- `git diff --cached --check`
- `gh api repos/vulca-org/vulca/rules/branches/master --jq '.[] | {type,parameters}'`
- `gh api repos/vulca-org/vulca/rules/branches/codex%2Fvulca-context-vault --jq '.[] | {type,parameters}'`