### PR TITLE
docs: add complete demo path standard

### DIFF
--- a/docs/review-context/10-integration-spine.md
+++ b/docs/review-context/10-integration-spine.md
@@ -220,9 +220,9 @@ status, and human decision boundaries.
 
 ### M3: One complete demo path
 
-Status: next after the artifact bridge spec.
+Status: specified in `12-complete-demo-path.md`.
 
-Build a single preview scenario:
+The protected demo-path standard defines a single preview scenario:
 
 ```text
 brief
@@ -237,7 +237,7 @@ This should be preview-gated until real persistence and SDK/MCP ingestion land.
 
 ### M4: Website and deck alignment
 
-Status: after M2/M3.
+Status: next after demo-path standardization.
 
 The website and PPT should share one claim spine:
 

--- a/docs/review-context/11-artifact-bridge-spec.md
+++ b/docs/review-context/11-artifact-bridge-spec.md
@@ -401,7 +401,8 @@ release workflow, persistence, and source-backed release audit trail.
 
 ## Minimal Demo Path
 
-The next implementation demo should use one path end to end:
+The complete demo standard lives in `12-complete-demo-path.md`. The
+implementation demo should use one path end to end:
 
 ```text
 Brief
@@ -459,7 +460,7 @@ Minimum acceptance:
 ### AB4: One Complete Scenario
 
 Create the first full demo path from brief to blocked or internally approved
-release gate.
+release gate, using `12-complete-demo-path.md` as the product standard.
 
 Minimum acceptance:
 

--- a/docs/review-context/12-complete-demo-path.md
+++ b/docs/review-context/12-complete-demo-path.md
@@ -1,0 +1,443 @@
+# Complete Demo Path
+
+Vault status: protected demo-path standard.
+
+## Purpose
+
+This file defines the first complete VULCA preview scenario. It is the M3
+standard that future Workspace, SDK/MCP, website, and PPT work should reference
+when they need one coherent example instead of scattered proof fragments.
+
+The path is:
+
+```text
+Brief
+  -> MotifBranch
+  -> visual plan
+  -> generated or imported VisualVariant
+  -> SDK/MCP AgentRun evidence
+  -> Artifact Bridge record
+  -> EvidencePack
+  -> ReviewRequest
+  -> human decision
+  -> ReleaseGate remains blocked or internally approved
+```
+
+This is a preview scenario. It proves linkage, evidence discipline, and review
+flow. It does not prove production Workspace persistence, hosted ingestion, or
+public release readiness.
+
+## Scenario
+
+Use one standard demo project:
+
+```text
+Creative Repo:
+  VULCA Cultural Key Visual Review
+
+Business task:
+  Prepare a campaign key visual for an internal pilot review.
+
+Visual task:
+  Generate or import one candidate image, decompose or redraw a target region,
+  evaluate cultural and visual fit, and route the result through Workspace
+  review checks.
+
+Release state:
+  public_ready=false
+```
+
+The demo should keep the asset type simple: one static key visual. A static
+visual exercises the important VULCA primitives without adding deck, video, or
+multi-page complexity too early.
+
+## Object Spine
+
+Use these object names unless implementation constraints require stable IDs:
+
+| Product object | Demo value | Purpose |
+| --- | --- | --- |
+| `CreativeRepo` | `repo-cultural-key-visual-review` | one review workspace |
+| `Brief` | `brief-cultural-key-visual` | task, audience, constraints, success criteria |
+| `MotifBranch` | `motif-proof-spine` | selected creative direction |
+| `VisualVariant` | `variant-key-visual-v1` | generated or imported candidate |
+| `AgentRun` | `agentrun-generate-decompose-evaluate-v1` | SDK/MCP execution trace |
+| `EvidencePack` | `evidencepack-key-visual-v1` | reviewer proof bundle |
+| `ReviewRequest` | `review-key-visual-v1` | human review workflow |
+| `ReleaseGate` | `releasegate-key-visual-v1` | release blockers and decision state |
+
+The implementation may create more granular `AgentRun` records, but it should
+still present one readable chain in Workspace.
+
+## Step 1: Brief
+
+The demo brief should include:
+
+- objective: create an internally reviewed campaign key visual;
+- audience: internal creative, evidence, and release reviewers;
+- constraints: one static visual, source-backed prompt, no unsupported public
+  claims, human release review required;
+- claims: draft claim candidates only;
+- success criteria: visual clarity, source boundary preserved, L1-L5 review
+  available, release blockers visible.
+
+Bridge source:
+
+- visual discovery record;
+- brainstorm proposal;
+- visual spec;
+- manual intake brief text if the asset starts from upload.
+
+Workspace projection:
+
+- `Brief.objective`;
+- `Brief.audience`;
+- `Brief.constraints`;
+- `Brief.claims`;
+- `Brief.successCriteria`.
+
+## Step 2: Motif Branch
+
+The selected motif branch should capture the creative direction under review:
+
+- motif contract;
+- prompt policy;
+- visual language;
+- changed-from-main rationale;
+- cultural or visual tradition context.
+
+Bridge source:
+
+- `/visual-brainstorm`;
+- `/visual-spec`;
+- `/visual-plan`;
+- `compose_prompt_from_design`;
+- tradition guide and L1-L5 rubric.
+
+Workspace projection:
+
+- `MotifBranch.status = in_review`;
+- prompt policy is visible in evidence context;
+- branch is not treated as release approval.
+
+## Step 3: Candidate Visual
+
+The candidate visual can enter through either path:
+
+### Generated path
+
+```text
+generate_image
+  -> image_path
+  -> provider metadata
+  -> prompt refs
+  -> bridge record
+  -> VisualVariant
+```
+
+Required evidence:
+
+- prompt text or prompt reference;
+- provider;
+- model when available;
+- generation parameters that affect output;
+- `image_path`;
+- cost and latency when available;
+- warnings or provider metadata.
+
+### Manual upload path
+
+```text
+manual upload intake
+  -> file metadata
+  -> intake brief
+  -> bridge record
+  -> VisualVariant
+```
+
+Required evidence:
+
+- file name;
+- MIME type;
+- size label;
+- source tool set to upload/import;
+- intake brief;
+- visible note that browser-session upload metadata is not durable storage in
+  the observed preview.
+
+## Step 4: Structure Or Edit Evidence
+
+The demo should include at least one SDK/MCP evidence operation beyond raw
+generation or upload.
+
+Preferred minimal path:
+
+```text
+layers_split
+  -> manifest_path
+  -> semantic layer list
+  -> detection report when available
+  -> decompose bridge record
+```
+
+Optional edit path:
+
+```text
+layers_redraw
+  -> redrawn layer path
+  -> source pasteback preview
+  -> advisory fields
+  -> redraw bridge record
+```
+
+Use `layers_redraw` only when the demo needs a targeted edit. Do not make the
+first scenario depend on advanced redraw quality unless it has fresh evidence.
+
+Workspace projection:
+
+- `VisualVariant` version context;
+- `AgentRun` output paths;
+- `EvidencePack` artifact refs;
+- `ReviewCheck` warnings or blockers.
+
+## Step 5: Evaluation Evidence
+
+The demo should run or represent `evaluate_artwork` evidence when available:
+
+```text
+evaluate_artwork
+  -> score
+  -> dimensions
+  -> rationales
+  -> recommendations
+  -> risk flags
+  -> EvidencePack
+```
+
+Evaluation output is review support. It is not final cultural authority or
+release approval.
+
+Workspace projection:
+
+- `ReviewCheck.modeId = cultural-review`;
+- `ReviewCheck.source = agent` or `system`;
+- `ReviewCheck.canSetPublicReady = false`;
+- risk flags become blockers or warnings.
+
+## Step 6: Bridge Record
+
+Each meaningful SDK/MCP step should normalize into a bridge record using
+`11-artifact-bridge-spec.md`.
+
+Minimum demo record requirements:
+
+- `bridge_record_id`;
+- `source_operation`;
+- `source_refs.tool`;
+- artifact paths as strings;
+- provider/model where available;
+- prompt refs when available;
+- quality or evaluation fields when available;
+- `claim_state.public_ready = false`;
+- human review labels left empty until a human decision exists.
+
+The demo may use one aggregate bridge record for the first preview if all
+source refs remain visible. Later implementations should prefer one record per
+operation plus a small rollup record.
+
+## Step 7: Evidence Pack
+
+The EvidencePack should answer reviewer questions without forcing them to open
+raw logs first.
+
+Minimum sections:
+
+- brief and motif summary;
+- primary visual artifact;
+- generation or upload provenance;
+- layer/decompose evidence;
+- redraw evidence if present;
+- L1-L5 or visual evaluation snapshot;
+- warnings, blockers, and boundary notes;
+- source refs and artifact refs.
+
+The pack should include enough evidence for a reviewer to decide:
+
+- request changes;
+- keep blocked;
+- approve for internal use with boundary notes.
+
+It should not include a public-release approval unless a future human-owned
+release workflow creates one.
+
+## Step 8: Review Request
+
+Create one ReviewRequest:
+
+```text
+review-key-visual-v1
+  required checks:
+    - visual-qa
+    - cultural-review
+    - release-review
+  required roles:
+    - Creative reviewer
+    - Evidence reviewer
+    - Release owner
+```
+
+Default decision state:
+
+```text
+decision = blocked
+humanOverride = ""
+```
+
+Allowed human decisions in the preview:
+
+- request changes;
+- block release;
+- approve internal use with explicit boundary notes.
+
+The preview should not expose a public approval action.
+
+## Step 9: Review Checks
+
+Use three checks:
+
+| Check | Source | Blocks release? | Notes |
+| --- | --- | --- | --- |
+| Visual QA | agent or human | may block | layout, target fidelity, edit quality |
+| Cultural Review | agent or human | may block | L1-L5 evidence, motif risk, source boundary |
+| Release Review | human | yes | claim boundary, final owner, public copy status |
+
+Agent or system checks can recommend and block. They cannot set final public
+release state.
+
+## Step 10: Release Gate
+
+The demo ReleaseGate starts with:
+
+```json
+{
+  "publicReady": false,
+  "label": "public_ready=false",
+  "blockers": [
+    "Human release decision required",
+    "Public claim copy not approved",
+    "Preview artifact ingestion is not production persistence"
+  ],
+  "finalApprover": "Release owner",
+  "boundaryNotes": "Internal pilot review only."
+}
+```
+
+If a human reviewer approves internal use, the gate can record internal
+approval with boundary notes. It should still preserve the public release
+boundary unless a later production release workflow exists and is verified.
+
+## Demo Acceptance Criteria
+
+A complete demo path is acceptable when:
+
+- one Brief links to one MotifBranch;
+- one VisualVariant links to at least one AgentRun;
+- one bridge record preserves source operation, artifact paths, and claim
+  state;
+- one EvidencePack links to the visible review item;
+- visual, cultural, and release checks are visible;
+- agent/system checks cannot set final public release state;
+- a human decision is required before any release claim changes;
+- the release gate visibly remains blocked or internally approved with notes.
+
+## Website And PPT Use
+
+Website copy may use this scenario as:
+
+- a preview workflow example;
+- a Creative Repo explanation;
+- an evidence and release-control story.
+
+PPT may use it as:
+
+- a product narrative spine;
+- an internal proof deck scenario;
+- a release-gated example.
+
+Required qualifier:
+
+```text
+Preview workflow; public release remains gated by human review and stronger
+implementation evidence.
+```
+
+Do not use this scenario to claim production Workspace readiness, public
+customer deployment, or final cultural/legal approval.
+
+## Implementation Order
+
+### DP1: Static Demo Packet
+
+Create a checked-in JSON/Markdown packet that represents the full path without
+running providers.
+
+Acceptance:
+
+- object IDs match this file;
+- bridge record validates against the M2 spec;
+- release gate starts blocked;
+- evidence pack includes source refs.
+
+### DP2: SDK/MCP Sample Export
+
+Generate or import one candidate asset and export bridge records from actual
+SDK/MCP outputs.
+
+Acceptance:
+
+- artifact paths exist;
+- provider metadata is preserved when available;
+- evaluation and warnings are carried into evidence.
+
+### DP3: Workspace Preview Import
+
+Load the demo packet into the Workspace preview.
+
+Acceptance:
+
+- Review Inbox shows one item;
+- Single Asset Review shows version/provenance;
+- Context Drawer shows evidence on demand;
+- Decision Panel preserves advisory-agent boundary;
+- release gate label remains visible.
+
+### DP4: Website/PPT Alignment
+
+Use the same scenario for public story and internal deck work with explicit
+preview-gated language.
+
+Acceptance:
+
+- no unsupported public-readiness claim;
+- no raw proof log as first story;
+- same object spine appears across README/website/PPT where needed.
+
+## Non-Goals
+
+- Do not add backend persistence in this vault file.
+- Do not require live provider calls for the first static demo packet.
+- Do not treat automated evaluation as human approval.
+- Do not present internal pilot approval as public release.
+- Do not mix deck-generation proof output into the first key-visual demo unless
+  the deck gate has fresh evidence.
+
+## Sources
+
+- `docs/review-context/10-integration-spine.md`
+- `docs/review-context/11-artifact-bridge-spec.md`
+- `docs/review-context/07-workspace-product-model.md`
+- `docs/review-context/09-claim-boundaries.md`
+- `origin/master:docs/product/workspace-current-state-audit.md`
+- `src/vulca/mcp_server.py`
+- Platform Workspace file:
+  `/Users/yhryzy/.config/superpowers/worktrees/vulca-platform/workspace-interactive-demo/wenxin-moyun/src/content/workspaceDemo.ts`

--- a/docs/review-context/CHANGELOG.md
+++ b/docs/review-context/CHANGELOG.md
@@ -4,6 +4,22 @@ Vault status: append-only change log.
 
 ## 2026-06-15
 
+### Added Complete Demo Path Standard
+
+- Added `12-complete-demo-path.md` as the protected M3 standard for one
+  complete VULCA preview scenario from brief to evidence pack and release gate.
+- Wired the demo path into the README read order, manifest, source index,
+  validator, and vault tests.
+- Updated the integration spine and artifact bridge spec so M3 points to the
+  dedicated demo-path standard.
+
+Source basis:
+
+- `docs/review-context/10-integration-spine.md`.
+- `docs/review-context/11-artifact-bridge-spec.md`.
+- `origin/master:docs/product/workspace-current-state-audit.md`.
+- Workspace `workspaceDemo.ts` object model.
+
 ### Added Artifact Bridge Specification
 
 - Added `11-artifact-bridge-spec.md` as the protected M2 specification for

--- a/docs/review-context/MANIFEST.json
+++ b/docs/review-context/MANIFEST.json
@@ -31,6 +31,7 @@
     "09-claim-boundaries.md",
     "10-integration-spine.md",
     "11-artifact-bridge-spec.md",
+    "12-complete-demo-path.md",
     "requests/README.md",
     "requests/TEMPLATE.md",
     "gates/validate-review-context.md",
@@ -41,6 +42,7 @@
     "workspace_context_baseline": "6efef07",
     "workspace_latest_observed": "5f4a666",
     "artifact_bridge_spec": "11-artifact-bridge-spec.md",
+    "complete_demo_path": "12-complete-demo-path.md",
     "website_film_led_homepage_branch": "5dc32cd",
     "ppt_case_pack_branch": "codex/vulca-ppt-case-pack",
     "ppt_latest_quality_gate": "run2_93_visual_quality_evaluation_public_blocked"

--- a/docs/review-context/README.md
+++ b/docs/review-context/README.md
@@ -39,6 +39,8 @@ mainline and does not carry or require the vault validation gate.
 - `10-integration-spine.md`: routing layer across Workspace, SDK/MCP, website,
   PPT, and vault context.
 - `11-artifact-bridge-spec.md`: SDK/MCP artifact to Workspace object bridge.
+- `12-complete-demo-path.md`: standard brief-to-evidence-to-release-gate demo
+  path.
 - `requests/`: proposed changes from other sessions.
 - `gates/`: validation rules and local gate checks.
 
@@ -53,4 +55,6 @@ mainline and does not carry or require the vault validation gate.
    website, PPT, or vault workstreams.
 6. Read `11-artifact-bridge-spec.md` before designing artifact ingestion,
    Workspace imports, evidence packs, review checks, or demo paths.
-7. If this vault needs a change, create a request packet instead of editing it.
+7. Read `12-complete-demo-path.md` before building or describing the standard
+   VULCA demo scenario.
+8. If this vault needs a change, create a request packet instead of editing it.

--- a/docs/review-context/gates/validate_review_context.py
+++ b/docs/review-context/gates/validate_review_context.py
@@ -36,6 +36,7 @@ CORE_HISTORY_FILES = [
     "09-claim-boundaries.md",
     "10-integration-spine.md",
     "11-artifact-bridge-spec.md",
+    "12-complete-demo-path.md",
 ]
 
 

--- a/docs/review-context/source-index.md
+++ b/docs/review-context/source-index.md
@@ -100,6 +100,9 @@ check before changing high-level VULCA claims.
 
 - `docs/review-context/11-artifact-bridge-spec.md`
   - Protected bridge spec for SDK/MCP outputs entering Workspace review.
+- `docs/review-context/12-complete-demo-path.md`
+  - Protected M3 standard for the brief-to-evidence-to-release-gate preview
+    scenario.
 - `src/vulca/mcp_server.py`
   - `generate_image` returns `image_path`, cost, latency, provider, MIME, and
     provider metadata.

--- a/tests/test_review_context_vault.py
+++ b/tests/test_review_context_vault.py
@@ -23,6 +23,7 @@ CORE_HISTORY_FILES = [
     "09-claim-boundaries.md",
     "10-integration-spine.md",
     "11-artifact-bridge-spec.md",
+    "12-complete-demo-path.md",
 ]
 
 REQUEST_TEMPLATE_CHECKS = [


### PR DESCRIPTION
## Summary
- Add `12-complete-demo-path.md` as the protected M3 standard for one complete VULCA preview scenario.
- Wire the demo path into README read order, manifest, source index, changelog, validator, and tests.
- Update the integration spine and artifact bridge spec so M3 points to the dedicated demo-path standard.

## Test Plan
- [x] `python3 docs/review-context/gates/validate_review_context.py`
- [x] `python3 -m pytest tests/test_review_context_vault.py -q`
- [x] `git diff --check`
- [x] `git diff --cached --check`