### PR TITLE
docs: add website and PPT claim spine

### DIFF
--- a/docs/review-context/10-integration-spine.md
+++ b/docs/review-context/10-integration-spine.md
@@ -237,9 +237,9 @@ This should be preview-gated until real persistence and SDK/MCP ingestion land.
 
 ### M4: Website and deck alignment
 
-Status: next after demo-path standardization.
+Status: specified in `13-website-ppt-claim-spine.md`.
 
-The website and PPT should share one claim spine:
+The protected website/PPT claim spine defines:
 
 - what VULCA is;
 - what Workspace does;
@@ -249,7 +249,7 @@ The website and PPT should share one claim spine:
 
 ### M5: Release readiness
 
-Status: blocked until stronger implementation evidence.
+Status: next, blocked until stronger implementation evidence.
 
 Release readiness requires:
 

--- a/docs/review-context/12-complete-demo-path.md
+++ b/docs/review-context/12-complete-demo-path.md
@@ -413,8 +413,8 @@ Acceptance:
 
 ### DP4: Website/PPT Alignment
 
-Use the same scenario for public story and internal deck work with explicit
-preview-gated language.
+Use `13-website-ppt-claim-spine.md` and this scenario for public story and
+internal deck work with explicit preview-gated language.
 
 Acceptance:
 

--- a/docs/review-context/13-website-ppt-claim-spine.md
+++ b/docs/review-context/13-website-ppt-claim-spine.md
@@ -1,0 +1,329 @@
+# Website And PPT Claim Spine
+
+Vault status: protected public-story standard.
+
+## Purpose
+
+This file defines the shared claim spine for VULCA's website, README-facing
+copy, public one-pagers, investor or partner decks, and internal PPT proof
+materials.
+
+The goal is one coherent external story:
+
+```text
+VULCA is moving toward a Workspace / Creative Repo product model.
+The SDK/MCP layer produces artifacts and evidence.
+Workspace organizes review, checks, decisions, and release gates.
+The website explains the product and routes pilots or partners.
+PPT is an internal proof and packaging lab until its gates clear.
+```
+
+This file does not replace `09-claim-boundaries.md`. It applies those boundaries
+to the public website and presentation surfaces.
+
+## Shared Public Thesis
+
+Use this as the common top-level claim:
+
+> VULCA is a Creative Repo for AI-native visual work: briefs, motif branches,
+> visual variants, evidence packs, and release gates in one reviewable system.
+
+Supporting explanation:
+
+- Agents and MCP tools execute work inside the system.
+- SDK/MCP outputs become artifacts, evidence, and review records.
+- Human reviewers own release decisions.
+- Unsupported public claims remain blocked.
+
+Avoid making agents the product identity. Agents are collaborators and
+operators inside VULCA; the durable product is the repo, evidence, review, and
+release-control model.
+
+## Audience-Specific Framing
+
+| Surface | Primary audience | Primary job | Boundary |
+| --- | --- | --- | --- |
+| Website | pilots, partners, researchers, investors | explain product direction and request paths | no raw proof logs as first story |
+| README | developers and technical evaluators | explain SDK/MCP and Workspace relationship | no production Workspace claim |
+| Product deck | partners, investors, internal strategy | explain market, system, and demo path | qualify preview and internal proof |
+| PPT proof lab | internal product/design review | test story, QA, visual proof, and deck workflows | public blocked until fresh gate clears |
+| Workspace demo | product reviewers | show review workflow and evidence surfaces | preview-gated without persistence |
+
+## Claim Levels
+
+### Level A: Public Stable
+
+Allowed when the source remains current:
+
+- VULCA has SDK, CLI, MCP, and skill surfaces.
+- VULCA supports visual discovery, prompt control, generation, decomposition,
+  layer editing, redraw, inpaint, evaluation, archive, and case records.
+- VULCA is moving toward a Workspace / Creative Repo product model.
+- VULCA can structure creative work through briefs, motif branches, variants,
+  evidence packs, review requests, and release gates.
+
+### Level B: Public With Qualification
+
+Allowed only with status language:
+
+- Workspace: preview product direction.
+- Website: public positioning surface.
+- PPT and deck work: internal proof or gated deck workflow.
+- Provider-backed image quality: example-specific and evidence-bound.
+- Cultural evaluation: review support, not final cultural authority.
+- Redraw or target refinement: implemented contracts with quality evidence.
+
+Required qualifiers:
+
+- preview;
+- internal proof;
+- public blocked;
+- requires human review;
+- source-backed;
+- gate pending.
+
+### Level C: Internal Only
+
+Use inside planning, vault, review, or product strategy:
+
+- raw run IDs;
+- branch names;
+- quality-gate failure details;
+- private proof logs;
+- visual QA critique;
+- model/provider troubleshooting;
+- blocked deck outputs;
+- unreviewed generated artifacts.
+
+### Level D: Blocked
+
+Do not use on the website, in public decks, or in customer-facing copy:
+
+- claims of production Workspace readiness;
+- claims that automated review can approve public release;
+- claims that internal PPT outputs are production quality;
+- claims that public release is cleared when a gate says blocked;
+- claims that AI-assisted labels are human-confirmed.
+
+## Website Spine
+
+The website should follow this order:
+
+```text
+1. What VULCA is
+2. Why AI-native visual work needs evidence and release control
+3. How Creative Repo objects work
+4. What SDK/MCP executes under the surface
+5. What the preview demo path shows
+6. Who should contact VULCA
+```
+
+### Website First Screen
+
+First-viewport signal:
+
+- VULCA name;
+- Creative Repo / Workspace direction;
+- review, evidence, and release-control language;
+- one strong product visual or demo scene;
+- pilot/partner/research routes.
+
+Do not lead with:
+
+- branch names;
+- raw proof logs;
+- dense tool lists;
+- PPT run numbers;
+- unsupported production claims.
+
+### Website Proof Section
+
+Allowed proof blocks:
+
+- SDK/MCP capability overview;
+- artifact bridge concept;
+- complete demo path;
+- internal proof pipeline with boundary language;
+- release-gate discipline.
+
+Required boundary copy:
+
+```text
+Preview workflow; public release remains gated by human review and stronger
+implementation evidence.
+```
+
+## PPT Spine
+
+PPT work should use the same product spine as the website, but it can go deeper
+into market, proof, and implementation details.
+
+Recommended deck order:
+
+```text
+1. Problem: AI-native visual work loses context, evidence, and release control
+2. Product: VULCA Creative Repo
+3. System: Workspace + SDK/MCP + Artifact Bridge
+4. Demo: brief -> variant -> evidence -> human decision -> gate
+5. Proof: implemented SDK/MCP capabilities and internal proof lab
+6. Boundary: preview-gated, public blocked where relevant
+7. Ask: pilot, partner, research, or investment route
+```
+
+## PPT Proof Lab Rules
+
+The PPT proof lab is useful for:
+
+- claim-spine testing;
+- story structure;
+- deck visual QA;
+- renderer and layout experiments;
+- comparison prompts;
+- proof that VULCA keeps blocked outputs blocked.
+
+The PPT proof lab is not public evidence for polished deck generation until a
+fresh visual quality gate clears the specific artifact.
+
+Use this label:
+
+```text
+Internal proof lab: valuable for story and gate discipline; public release
+blocked until a fresh visual quality gate passes.
+```
+
+## Shared Demo Language
+
+Use `12-complete-demo-path.md` as the shared example across website and decks.
+
+Allowed short version:
+
+```text
+A brief enters VULCA, becomes a motif branch and visual variant, gathers SDK/MCP
+evidence, enters Workspace review, and stays behind a human release gate.
+```
+
+Allowed longer version:
+
+```text
+Brief -> MotifBranch -> VisualVariant -> AgentRun -> EvidencePack ->
+ReviewRequest -> human decision -> ReleaseGate.
+```
+
+Required release boundary:
+
+```text
+public_ready=false until a human-owned release workflow clears the blockers.
+```
+
+## Copy Blocks
+
+### Homepage Hero
+
+Use:
+
+```text
+VULCA is a Creative Repo for AI-native visual work.
+```
+
+Support:
+
+```text
+Briefs, motif branches, visual variants, evidence packs, and release gates in
+one reviewable system.
+```
+
+### Technical Proof
+
+Use:
+
+```text
+The SDK/MCP layer executes discovery, generation, decomposition, redraw,
+evaluation, and archive workflows. Workspace organizes the outputs for review.
+```
+
+### Release Control
+
+Use:
+
+```text
+Agent and system checks can flag, recommend, and block. Human reviewers own
+release decisions.
+```
+
+### PPT Boundary
+
+Use:
+
+```text
+The deck workflow is an internal proof lab until visual quality gates clear a
+specific public artifact.
+```
+
+## Translation Rule
+
+English and Chinese website/PPT copy may differ in phrasing, but the claim
+level must remain identical. A Chinese phrase cannot upgrade a preview claim
+into a production claim. An English deck cannot downgrade a blocked gate into an
+implicit approval.
+
+Every bilingual surface should preserve:
+
+- Creative Repo / Workspace as the product center;
+- SDK/MCP as execution layer;
+- evidence packs and release gates;
+- human-owned release decisions;
+- preview/internal/public-blocked status where required.
+
+## Review Checklist
+
+Before publishing website copy or PPT slides:
+
+- Does the story start from Workspace / Creative Repo rather than agents alone?
+- Does SDK/MCP appear as execution and evidence, not the whole product?
+- Are PPT proof-lab outputs clearly internal or gated?
+- Does any public example trace to the complete demo path or source-backed
+  evidence?
+- Are provider-backed visual quality claims qualified?
+- Are cultural evaluation claims framed as review support?
+- Does every release claim preserve human review?
+- Are blocked artifacts still described as blocked?
+
+## M4 Acceptance Criteria
+
+M4 is satisfied when:
+
+- the website, README, PPT, and Workspace demo all use the same product spine;
+- public copy uses Level A or Level B claims only;
+- PPT proof-lab material is labeled internal or gated;
+- `12-complete-demo-path.md` is the shared demo reference;
+- every public scenario keeps release boundary language;
+- future website/PPT sessions read this file before writing copy.
+
+## Next Milestone
+
+M5 is release readiness. It should not begin from copy polish. It should begin
+from implementation evidence:
+
+- real artifact ingestion into Workspace;
+- persistent Creative Repo and review state;
+- stable evidence-pack rendering;
+- human release workflow;
+- fresh visual quality gates for public examples;
+- copy reviewed against this claim spine.
+
+## Sources
+
+- `docs/review-context/08-website-and-ppt-boundaries.md`
+- `docs/review-context/09-claim-boundaries.md`
+- `docs/review-context/10-integration-spine.md`
+- `docs/review-context/11-artifact-bridge-spec.md`
+- `docs/review-context/12-complete-demo-path.md`
+- `origin/master:docs/product/workspace-current-state-audit.md`
+- Website branch `codex/vulcaart-film-led-homepage` at platform commit
+  `5dc32cd`
+- Platform website content:
+  `/Users/yhryzy/dev/vulca-platform/wenxin-moyun/src/content/homeCommercial.ts`
+- Platform homepage plans:
+  `/Users/yhryzy/dev/vulca-platform/docs/superpowers/plans/2026-06-13-vulcaart-film-led-homepage.md`
+  `/Users/yhryzy/dev/vulca-platform/docs/superpowers/plans/2026-06-14-vulcaart-flora-method-homepage-redesign.md`
+- PPT proof lab source index entry and Run 2.93 public-blocked gate

--- a/docs/review-context/CHANGELOG.md
+++ b/docs/review-context/CHANGELOG.md
@@ -4,6 +4,23 @@ Vault status: append-only change log.
 
 ## 2026-06-15
 
+### Added Website And PPT Claim Spine
+
+- Added `13-website-ppt-claim-spine.md` as the protected M4 standard for
+  website, README-facing copy, public decks, and PPT proof-lab summaries.
+- Wired the claim spine into the README read order, manifest, source index,
+  validator, and vault tests.
+- Updated the integration spine so M4 points to the dedicated claim-spine
+  document and M5 becomes the next release-readiness milestone.
+
+Source basis:
+
+- `docs/review-context/08-website-and-ppt-boundaries.md`.
+- `docs/review-context/09-claim-boundaries.md`.
+- `docs/review-context/12-complete-demo-path.md`.
+- Platform website content and homepage plans at commit `5dc32cd`.
+- PPT proof lab source index entry and Run 2.93 public-blocked gate.
+
 ### Added Complete Demo Path Standard
 
 - Added `12-complete-demo-path.md` as the protected M3 standard for one

--- a/docs/review-context/MANIFEST.json
+++ b/docs/review-context/MANIFEST.json
@@ -32,6 +32,7 @@
     "10-integration-spine.md",
     "11-artifact-bridge-spec.md",
     "12-complete-demo-path.md",
+    "13-website-ppt-claim-spine.md",
     "requests/README.md",
     "requests/TEMPLATE.md",
     "gates/validate-review-context.md",
@@ -43,6 +44,7 @@
     "workspace_latest_observed": "5f4a666",
     "artifact_bridge_spec": "11-artifact-bridge-spec.md",
     "complete_demo_path": "12-complete-demo-path.md",
+    "website_ppt_claim_spine": "13-website-ppt-claim-spine.md",
     "website_film_led_homepage_branch": "5dc32cd",
     "ppt_case_pack_branch": "codex/vulca-ppt-case-pack",
     "ppt_latest_quality_gate": "run2_93_visual_quality_evaluation_public_blocked"

--- a/docs/review-context/README.md
+++ b/docs/review-context/README.md
@@ -41,6 +41,8 @@ mainline and does not carry or require the vault validation gate.
 - `11-artifact-bridge-spec.md`: SDK/MCP artifact to Workspace object bridge.
 - `12-complete-demo-path.md`: standard brief-to-evidence-to-release-gate demo
   path.
+- `13-website-ppt-claim-spine.md`: shared website, README, PPT, and public
+  story claim spine.
 - `requests/`: proposed changes from other sessions.
 - `gates/`: validation rules and local gate checks.
 
@@ -57,4 +59,6 @@ mainline and does not carry or require the vault validation gate.
    Workspace imports, evidence packs, review checks, or demo paths.
 7. Read `12-complete-demo-path.md` before building or describing the standard
    VULCA demo scenario.
-8. If this vault needs a change, create a request packet instead of editing it.
+8. Read `13-website-ppt-claim-spine.md` before writing website copy, README
+   positioning, public decks, or PPT proof-lab summaries.
+9. If this vault needs a change, create a request packet instead of editing it.

--- a/docs/review-context/gates/validate_review_context.py
+++ b/docs/review-context/gates/validate_review_context.py
@@ -37,6 +37,7 @@ CORE_HISTORY_FILES = [
     "10-integration-spine.md",
     "11-artifact-bridge-spec.md",
     "12-complete-demo-path.md",
+    "13-website-ppt-claim-spine.md",
 ]
 
 

--- a/docs/review-context/source-index.md
+++ b/docs/review-context/source-index.md
@@ -152,6 +152,10 @@ Workspace product code lives in the separate `vulca-platform` repository.
 
 Website code lives in the separate `vulca-platform` repository.
 
+- Claim spine:
+  - `docs/review-context/13-website-ppt-claim-spine.md`
+  - Shared public-story standard for website, README-facing copy, PPT, and
+    internal proof-lab summaries.
 - Branch: `codex/vulcaart-film-led-homepage`
 - Commit: `5dc32cd docs: plan flora-method homepage redesign`
 - Important files:
@@ -166,6 +170,10 @@ Website code lives in the separate `vulca-platform` repository.
 
 ## PPT Proof Lab
 
+- Claim spine:
+  - `docs/review-context/13-website-ppt-claim-spine.md`
+  - Defines how PPT proof-lab material can support public story only when
+    labeled internal, preview-gated, or public blocked as appropriate.
 - Branch: `codex/vulca-ppt-case-pack`
 - Important files:
   - `docs/product/ppt-case-pack-v1/`

--- a/tests/test_review_context_vault.py
+++ b/tests/test_review_context_vault.py
@@ -24,6 +24,7 @@ CORE_HISTORY_FILES = [
     "10-integration-spine.md",
     "11-artifact-bridge-spec.md",
     "12-complete-demo-path.md",
+    "13-website-ppt-claim-spine.md",
 ]
 
 REQUEST_TEMPLATE_CHECKS = [


### PR DESCRIPTION
## Summary
- Add `13-website-ppt-claim-spine.md` as the protected M4 standard for website, README-facing copy, public decks, and PPT proof-lab summaries.
- Wire the claim spine into the vault README, manifest, source index, changelog, validator, and tests.
- Update the integration spine and demo path so website/PPT work references the dedicated claim spine.

## Test Plan
- [x] `python3 docs/review-context/gates/validate_review_context.py`
- [x] `python3 -m pytest tests/test_review_context_vault.py -q`
- [x] `git diff --check`
- [x] `git diff --cached --check`