### PR TITLE
docs: add release readiness evidence gate

### DIFF
--- a/docs/review-context/10-integration-spine.md
+++ b/docs/review-context/10-integration-spine.md
@@ -249,9 +249,9 @@ The protected website/PPT claim spine defines:
 
 ### M5: Release readiness
 
-Status: next, blocked until stronger implementation evidence.
+Status: specified in `14-release-readiness-evidence-gate.md`.
 
-Release readiness requires:
+The protected release-readiness gate requires:
 
 - real artifact ingestion into Workspace;
 - persistence for Creative Repos and review state;

--- a/docs/review-context/13-website-ppt-claim-spine.md
+++ b/docs/review-context/13-website-ppt-claim-spine.md
@@ -301,8 +301,9 @@ M4 is satisfied when:
 
 ## Next Milestone
 
-M5 is release readiness. It should not begin from copy polish. It should begin
-from implementation evidence:
+M5 release readiness is specified in
+`14-release-readiness-evidence-gate.md`. It should not begin from copy polish.
+It should begin from implementation evidence:
 
 - real artifact ingestion into Workspace;
 - persistent Creative Repo and review state;

--- a/docs/review-context/14-release-readiness-evidence-gate.md
+++ b/docs/review-context/14-release-readiness-evidence-gate.md
@@ -1,0 +1,311 @@
+# Release Readiness Evidence Gate
+
+Vault status: protected release-readiness gate.
+
+## Purpose
+
+This file defines M5: the evidence gate for moving VULCA work from preview or
+internal proof toward release-ready claims.
+
+Release readiness is not copy polish. It requires implementation evidence,
+review evidence, public-example evidence, and human release decisions.
+
+The gate covers:
+
+```text
+Workspace persistence
+  -> real artifact ingestion
+  -> evidence-pack rendering
+  -> human release workflow
+  -> public example quality gates
+  -> claim-spine review
+  -> release status decision
+```
+
+Until those gates pass, VULCA should keep using preview, internal proof,
+public blocked, or human review required language.
+
+## Current Status
+
+As of the current vault state:
+
+- `master` README exposes the Workspace direction.
+- Workspace preview implements review triage, asset review, context drawer,
+  checks, decisions, manual upload intake, and visible release boundaries.
+- SDK/MCP has implemented execution capabilities and case/evidence substrates.
+- The artifact bridge, demo path, and website/PPT claim spine are specified in
+  protected vault documents.
+- PPT proof lab remains public blocked by the latest remembered Run 2.93 gate.
+
+Still missing for product release readiness:
+
+- persistent Creative Repo storage;
+- real SDK/MCP artifact ingestion into Workspace;
+- durable EvidencePack rendering;
+- human-owned release workflow with audit trail;
+- public example visual quality gates;
+- copy reviewed against claim boundaries after implementation evidence lands.
+
+## Release Levels
+
+Use these release levels across code, docs, website, PPT, and internal planning.
+
+| Level | Name | Meaning | Public copy |
+| --- | --- | --- | --- |
+| R0 | internal draft | incomplete or exploratory work | do not publish |
+| R1 | internal proof | useful evidence, not public-ready | internal only |
+| R2 | preview-gated | coherent demo or preview workflow | allowed with preview qualifier |
+| R3 | internal pilot ready | human-reviewed internal workflow | allowed with internal qualifier |
+| R4 | public example ready | specific public example passed evidence and quality gates | example-specific public use |
+| R5 | product release ready | repeated implementation, persistence, review, and release evidence | product-level public claim |
+
+Default state for Workspace, PPT, and provider-backed visual examples is R2 or
+lower unless fresh evidence proves otherwise.
+
+## Required Gates
+
+### Gate 1: Workspace Persistence
+
+Required evidence:
+
+- Creative Repo data persists beyond browser session;
+- review item state persists;
+- version history persists;
+- blockers and decisions persist;
+- release gate state persists;
+- access boundaries are defined for reviewers and release owners.
+
+Minimum verification:
+
+- backend or durable local storage implementation evidence;
+- tests for create, reload, update, and recover workflows;
+- migration or seed-data story for demo objects;
+- failure behavior when persistence fails.
+
+Blocked until:
+
+- the observed frontend/session-local preview is replaced or supplemented by
+  durable storage for the demo path.
+
+### Gate 2: Artifact Ingestion
+
+Required evidence:
+
+- SDK/MCP outputs enter Workspace through the artifact bridge;
+- bridge records preserve source operation, artifact paths, provider/model
+  metadata, warnings, claim state, and review labels;
+- generated/imported assets become `VisualVariant` records;
+- tool executions become `AgentRun` records;
+- case records remain evidence substrate, not human labels.
+
+Minimum verification:
+
+- bridge schema or adapter tests;
+- ingestion tests for `generate_image`, `layers_split`, `layers_redraw`, and
+  `evaluate_artwork`;
+- negative test that automated evidence cannot set final public release;
+- fixture showing the M3 demo path imported into Workspace.
+
+Blocked until:
+
+- the M2 bridge spec has a real adapter and Workspace import preview.
+
+### Gate 3: EvidencePack Rendering
+
+Required evidence:
+
+- EvidencePack renders brief, motif, artifact, provider, prompt, layer,
+  evaluation, warning, and source refs;
+- reviewers can inspect evidence on demand;
+- missing evidence is visible as a blocker, not silently ignored;
+- evidence packs link back to bridge records or source artifacts.
+
+Minimum verification:
+
+- component tests for EvidencePack rendering;
+- fixture with complete and partial evidence;
+- UI test that context drawer or evidence surface is hidden until requested but
+  available before decision;
+- source-boundary copy for incomplete evidence.
+
+Blocked until:
+
+- reviewers can see enough evidence to decide without opening raw logs first.
+
+### Gate 4: Human Release Workflow
+
+Required evidence:
+
+- release owner role exists;
+- human decision actions are explicit;
+- request-changes, block-release, and internal-approval paths are represented;
+- public-release state cannot be set by agent/system/external checks;
+- decision history records actor, action, summary, and timestamp;
+- release gate blockers remain visible.
+
+Minimum verification:
+
+- tests proving agent/system checks have `canSetPublicReady = false`;
+- tests for decision state transitions;
+- tests for blocker persistence;
+- audit/history fixture for human decisions;
+- copy review that distinguishes internal approval from public release.
+
+Blocked until:
+
+- human release decisions are durable and auditable.
+
+### Gate 5: Public Example Quality
+
+Required evidence for any public visual example:
+
+- source artifacts are preserved;
+- final preview image or artifact is inspectable;
+- visual quality review passes for the specific example;
+- cultural/evidence review is qualified and source-backed;
+- release owner signs off for that example;
+- claims attached to the example match evidence.
+
+Minimum verification:
+
+- public-example checklist;
+- screenshot or artifact review;
+- visual quality gate result;
+- evidence-pack review;
+- release decision record;
+- no stale `public blocked` result is reused as a public-ready proof.
+
+Blocked until:
+
+- each public example has fresh, specific evidence. One cleared example does
+  not clear all provider-backed or PPT examples.
+
+### Gate 6: Website/PPT Claim Review
+
+Required evidence:
+
+- copy follows `13-website-ppt-claim-spine.md`;
+- website, README, and PPT use the same product spine;
+- preview/internal/public-blocked status is preserved;
+- public examples trace to the M3 demo path or equivalent source-backed path;
+- translations preserve the same claim level.
+
+Minimum verification:
+
+- copy checklist review;
+- forbidden-claim search;
+- bilingual claim-level check when applicable;
+- source index links for proof claims;
+- explicit downgrade language for incomplete evidence.
+
+Blocked until:
+
+- implementation evidence exists first. Copy cannot upgrade a preview system.
+
+## Release Decision Matrix
+
+| Evidence state | Allowed status | Required wording |
+| --- | --- | --- |
+| docs/spec only | R0/R1 | planned, specified, protected context |
+| frontend-only preview | R2 | preview-gated, browser/session-local if relevant |
+| durable demo with imported artifacts | R2/R3 | preview workflow or internal pilot |
+| human-reviewed internal workflow | R3 | internal pilot ready, human reviewed |
+| one public example cleared | R4 | public example ready, example-specific |
+| repeated persisted workflows with release audit | R5 | product release ready |
+
+If evidence is mixed, use the lowest applicable status.
+
+## Required Artifacts For M5 Completion
+
+M5 is complete only when these artifacts exist and are source-backed:
+
+- release readiness implementation report;
+- artifact bridge adapter test report;
+- Workspace persistence test report;
+- EvidencePack rendering test report;
+- human release workflow test report;
+- public example gate report;
+- website/PPT copy review report;
+- release decision record with human owner.
+
+These can live outside the vault in product or platform branches, but the vault
+must index them before any status upgrade is treated as durable memory.
+
+## Implementation Sequence
+
+### RR1: Static Release Gate Checklist
+
+Create a machine-readable checklist or Markdown report template for the M5
+gates.
+
+Acceptance:
+
+- includes Gates 1-6;
+- records evidence links;
+- records reviewer/owner;
+- defaults public release to blocked when evidence is missing.
+
+### RR2: Bridge Adapter And Fixture
+
+Implement or document one real bridge adapter path for the M3 demo.
+
+Acceptance:
+
+- generated or imported asset becomes a bridge record;
+- bridge record projects into Workspace objects;
+- missing evidence remains visible.
+
+### RR3: Workspace Durable Review Path
+
+Implement persistence or a clearly bounded durable demo store.
+
+Acceptance:
+
+- reload preserves review item, evidence, blocker, and decision state;
+- agent/system checks cannot finalize public release;
+- human decision history is auditable.
+
+### RR4: Public Example Gate
+
+Run one example through visual, evidence, copy, and release review.
+
+Acceptance:
+
+- evidence pack exists;
+- visual quality is reviewed;
+- release owner records decision;
+- public copy remains example-specific.
+
+### RR5: Website/PPT Copy Gate
+
+Apply the M4 claim spine to website and deck copy after implementation evidence
+exists.
+
+Acceptance:
+
+- public copy uses R-level status accurately;
+- proof-lab outputs remain internal or public blocked unless cleared;
+- translations do not upgrade claims.
+
+## Non-Negotiable Boundaries
+
+- Release readiness cannot be inferred from a passing unit test alone.
+- Public copy cannot upgrade a missing implementation.
+- Agent/system checks cannot clear public release.
+- Case records are evidence substrate until reviewed.
+- Public examples are cleared one at a time.
+- PPT proof-lab outputs remain blocked until their own fresh gates pass.
+- A human release owner must record final release decisions.
+
+## Sources
+
+- `docs/review-context/09-claim-boundaries.md`
+- `docs/review-context/10-integration-spine.md`
+- `docs/review-context/11-artifact-bridge-spec.md`
+- `docs/review-context/12-complete-demo-path.md`
+- `docs/review-context/13-website-ppt-claim-spine.md`
+- `origin/master:docs/product/workspace-current-state-audit.md`
+- `docs/platform/release-readiness-status.md`
+- Platform Workspace baseline `6efef07 fix: align workspace context review controls`
+- Latest observed local Workspace preview `5f4a666 feat: add manual upload intake workflow`
+- PPT proof lab source index entry and Run 2.93 public-blocked gate

--- a/docs/review-context/CHANGELOG.md
+++ b/docs/review-context/CHANGELOG.md
@@ -4,6 +4,26 @@ Vault status: append-only change log.
 
 ## 2026-06-15
 
+### Added Release Readiness Evidence Gate
+
+- Added `14-release-readiness-evidence-gate.md` as the protected M5 standard
+  for upgrading preview/internal/public-blocked work toward release-ready
+  claims.
+- Wired the release gate into the README read order, manifest, source index,
+  validator, and vault tests.
+- Updated the integration spine and website/PPT claim spine so M5 points to the
+  dedicated evidence-gate document.
+
+Source basis:
+
+- `docs/review-context/09-claim-boundaries.md`.
+- `docs/review-context/10-integration-spine.md`.
+- `docs/review-context/11-artifact-bridge-spec.md`.
+- `docs/review-context/12-complete-demo-path.md`.
+- `docs/review-context/13-website-ppt-claim-spine.md`.
+- `docs/platform/release-readiness-status.md`.
+- `origin/master:docs/product/workspace-current-state-audit.md`.
+
 ### Added Website And PPT Claim Spine
 
 - Added `13-website-ppt-claim-spine.md` as the protected M4 standard for

--- a/docs/review-context/MANIFEST.json
+++ b/docs/review-context/MANIFEST.json
@@ -33,6 +33,7 @@
     "11-artifact-bridge-spec.md",
     "12-complete-demo-path.md",
     "13-website-ppt-claim-spine.md",
+    "14-release-readiness-evidence-gate.md",
     "requests/README.md",
     "requests/TEMPLATE.md",
     "gates/validate-review-context.md",
@@ -45,6 +46,7 @@
     "artifact_bridge_spec": "11-artifact-bridge-spec.md",
     "complete_demo_path": "12-complete-demo-path.md",
     "website_ppt_claim_spine": "13-website-ppt-claim-spine.md",
+    "release_readiness_gate": "14-release-readiness-evidence-gate.md",
     "website_film_led_homepage_branch": "5dc32cd",
     "ppt_case_pack_branch": "codex/vulca-ppt-case-pack",
     "ppt_latest_quality_gate": "run2_93_visual_quality_evaluation_public_blocked"

--- a/docs/review-context/README.md
+++ b/docs/review-context/README.md
@@ -43,6 +43,7 @@ mainline and does not carry or require the vault validation gate.
   path.
 - `13-website-ppt-claim-spine.md`: shared website, README, PPT, and public
   story claim spine.
+- `14-release-readiness-evidence-gate.md`: M5 release-readiness evidence gate.
 - `requests/`: proposed changes from other sessions.
 - `gates/`: validation rules and local gate checks.
 
@@ -61,4 +62,6 @@ mainline and does not carry or require the vault validation gate.
    VULCA demo scenario.
 8. Read `13-website-ppt-claim-spine.md` before writing website copy, README
    positioning, public decks, or PPT proof-lab summaries.
-9. If this vault needs a change, create a request packet instead of editing it.
+9. Read `14-release-readiness-evidence-gate.md` before upgrading any preview,
+   internal, public-blocked, or release-readiness status.
+10. If this vault needs a change, create a request packet instead of editing it.

--- a/docs/review-context/gates/validate_review_context.py
+++ b/docs/review-context/gates/validate_review_context.py
@@ -38,6 +38,7 @@ CORE_HISTORY_FILES = [
     "11-artifact-bridge-spec.md",
     "12-complete-demo-path.md",
     "13-website-ppt-claim-spine.md",
+    "14-release-readiness-evidence-gate.md",
 ]
 
 

--- a/docs/review-context/source-index.md
+++ b/docs/review-context/source-index.md
@@ -95,6 +95,10 @@ check before changing high-level VULCA claims.
   - Agent surfaces and provider capability matrix.
 - `docs/platform/release-readiness-status.md`
   - Public claim boundaries and manual gates.
+- `docs/review-context/14-release-readiness-evidence-gate.md`
+  - Protected M5 release-readiness gate for Workspace persistence, artifact
+    ingestion, evidence rendering, human release workflow, public examples,
+    and website/PPT copy review.
 
 ## Artifact Bridge
 

--- a/tests/test_review_context_vault.py
+++ b/tests/test_review_context_vault.py
@@ -25,6 +25,7 @@ CORE_HISTORY_FILES = [
     "11-artifact-bridge-spec.md",
     "12-complete-demo-path.md",
     "13-website-ppt-claim-spine.md",
+    "14-release-readiness-evidence-gate.md",
 ]
 
 REQUEST_TEMPLATE_CHECKS = [


### PR DESCRIPTION
## Summary
- Add `14-release-readiness-evidence-gate.md` as the protected M5 standard for moving preview/internal/public-blocked work toward release-ready claims.
- Define release levels, Gates 1-6, required M5 artifacts, and implementation sequence.
- Wire the M5 gate into the vault README, manifest, source index, changelog, validator, and tests.

## Test Plan
- [x] `python3 docs/review-context/gates/validate_review_context.py`
- [x] `python3 -m pytest tests/test_review_context_vault.py -q`
- [x] `git diff --check`
- [x] `git diff --cached --check`