### PR TITLE
docs: add release readiness checklist template

### DIFF
--- a/docs/review-context/14-release-readiness-evidence-gate.md
+++ b/docs/review-context/14-release-readiness-evidence-gate.md
@@ -35,6 +35,8 @@ As of the current vault state:
 - SDK/MCP has implemented execution capabilities and case/evidence substrates.
 - The artifact bridge, demo path, and website/PPT claim spine are specified in
   protected vault documents.
+- RR1 has a fixed release-readiness report template in
+  `release-readiness/TEMPLATE.md`.
 - PPT proof lab remains public blocked by the latest remembered Run 2.93 gate.
 
 Still missing for product release readiness:
@@ -237,6 +239,8 @@ must index them before any status upgrade is treated as durable memory.
 
 Create a machine-readable checklist or Markdown report template for the M5
 gates.
+
+Status: represented by `release-readiness/TEMPLATE.md`.
 
 Acceptance:
 

--- a/docs/review-context/CHANGELOG.md
+++ b/docs/review-context/CHANGELOG.md
@@ -4,6 +4,21 @@ Vault status: append-only change log.
 
 ## 2026-06-15
 
+### Added Release Readiness Report Template
+
+- Added `release-readiness/README.md` and
+  `release-readiness/TEMPLATE.md` as the protected RR1 checklist/report format
+  for M5 release-readiness reviews.
+- Wired the template into the README read order, manifest, source index,
+  validator, and vault tests.
+- Updated the M5 gate record so RR1 now points to the fixed report template.
+
+Source basis:
+
+- `docs/review-context/14-release-readiness-evidence-gate.md`.
+- `docs/review-context/13-website-ppt-claim-spine.md`.
+- `docs/review-context/09-claim-boundaries.md`.
+
 ### Added Release Readiness Evidence Gate
 
 - Added `14-release-readiness-evidence-gate.md` as the protected M5 standard

--- a/docs/review-context/MANIFEST.json
+++ b/docs/review-context/MANIFEST.json
@@ -34,6 +34,8 @@
     "12-complete-demo-path.md",
     "13-website-ppt-claim-spine.md",
     "14-release-readiness-evidence-gate.md",
+    "release-readiness/README.md",
+    "release-readiness/TEMPLATE.md",
     "requests/README.md",
     "requests/TEMPLATE.md",
     "gates/validate-review-context.md",
@@ -47,6 +49,7 @@
     "complete_demo_path": "12-complete-demo-path.md",
     "website_ppt_claim_spine": "13-website-ppt-claim-spine.md",
     "release_readiness_gate": "14-release-readiness-evidence-gate.md",
+    "release_readiness_report_template": "release-readiness/TEMPLATE.md",
     "website_film_led_homepage_branch": "5dc32cd",
     "ppt_case_pack_branch": "codex/vulca-ppt-case-pack",
     "ppt_latest_quality_gate": "run2_93_visual_quality_evaluation_public_blocked"

--- a/docs/review-context/README.md
+++ b/docs/review-context/README.md
@@ -44,6 +44,7 @@ mainline and does not carry or require the vault validation gate.
 - `13-website-ppt-claim-spine.md`: shared website, README, PPT, and public
   story claim spine.
 - `14-release-readiness-evidence-gate.md`: M5 release-readiness evidence gate.
+- `release-readiness/`: fixed report template for release-readiness reviews.
 - `requests/`: proposed changes from other sessions.
 - `gates/`: validation rules and local gate checks.
 
@@ -64,4 +65,6 @@ mainline and does not carry or require the vault validation gate.
    positioning, public decks, or PPT proof-lab summaries.
 9. Read `14-release-readiness-evidence-gate.md` before upgrading any preview,
    internal, public-blocked, or release-readiness status.
-10. If this vault needs a change, create a request packet instead of editing it.
+10. Use `release-readiness/TEMPLATE.md` before proposing a stronger release
+    level, public example, website claim, or PPT claim.
+11. If this vault needs a change, create a request packet instead of editing it.

--- a/docs/review-context/gates/validate-review-context.md
+++ b/docs/review-context/gates/validate-review-context.md
@@ -15,6 +15,8 @@ The gate checks:
 - core history files include source references
 - protected claim phrases do not appear outside allowed boundary files
 - request template contains required gate checklist items
+- release-readiness template contains required Gates 1-6, evidence index,
+  owner, and decision controls
 
 Passing this gate is necessary but not sufficient. A curator must still apply
 source and claim judgment.

--- a/docs/review-context/gates/validate_review_context.py
+++ b/docs/review-context/gates/validate_review_context.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 MANIFEST_PATH = ROOT / "MANIFEST.json"
+RELEASE_READINESS_TEMPLATE_PATH = ROOT / "release-readiness" / "TEMPLATE.md"
 
 
 FORBIDDEN_OUTSIDE_ALLOWLIST = [
@@ -39,6 +40,20 @@ CORE_HISTORY_FILES = [
     "12-complete-demo-path.md",
     "13-website-ppt-claim-spine.md",
     "14-release-readiness-evidence-gate.md",
+]
+
+RELEASE_READINESS_TEMPLATE_REQUIRED_ITEMS = [
+    "Public release remains blocked until every required gate below is passed and a human release owner records approval.",
+    "Evidence Index",
+    "Gate 1: Workspace Persistence",
+    "Gate 2: Artifact Ingestion",
+    "Gate 3: EvidencePack Rendering",
+    "Gate 4: Human Release Workflow",
+    "Gate 5: Public Example Quality",
+    "Gate 6: Website/PPT Claim Review",
+    "Human release owner",
+    "Release Decision",
+    "blocked / internal_only / preview_gated / internal_pilot / public_example / product_release",
 ]
 
 
@@ -108,6 +123,15 @@ def check_request_template() -> None:
             fail(f"request template missing checklist item: {item}")
 
 
+def check_release_readiness_template() -> None:
+    if not RELEASE_READINESS_TEMPLATE_PATH.exists():
+        fail(f"missing release readiness template: {RELEASE_READINESS_TEMPLATE_PATH}")
+    template = RELEASE_READINESS_TEMPLATE_PATH.read_text(encoding="utf-8")
+    for item in RELEASE_READINESS_TEMPLATE_REQUIRED_ITEMS:
+        if item not in template:
+            fail(f"release readiness template missing item: {item}")
+
+
 def main() -> int:
     manifest = load_manifest()
     check_required_files(manifest)
@@ -115,6 +139,7 @@ def main() -> int:
     check_sources()
     check_forbidden_claims(manifest)
     check_request_template()
+    check_release_readiness_template()
     print("review-context gate passed")
     return 0
 

--- a/docs/review-context/release-readiness/README.md
+++ b/docs/review-context/release-readiness/README.md
@@ -1,0 +1,29 @@
+# Release Readiness Reports
+
+Vault status: protected release-readiness workflow.
+
+This folder contains the fixed report template for applying
+`14-release-readiness-evidence-gate.md`.
+
+Use `TEMPLATE.md` whenever a session proposes to upgrade a feature, demo,
+website/PPT claim, public example, or Workspace workflow from draft, preview,
+internal, or public-blocked status toward a stronger release level.
+
+Other sessions may copy the template into a feature branch or request packet.
+They must not edit this folder directly outside a context-curator branch.
+
+## Report Rules
+
+- Default public release state is blocked until evidence is attached.
+- Every gate must be marked pass, blocked, or not applicable with a reason.
+- Evidence links must be concrete paths, commits, PRs, test runs, screenshots,
+  or reviewed artifacts.
+- Agent/system results may support review but cannot be recorded as human
+  release approval.
+- A human owner must be recorded before any release status upgrade.
+
+## Sources
+
+- `docs/review-context/14-release-readiness-evidence-gate.md`
+- `docs/review-context/13-website-ppt-claim-spine.md`
+- `docs/review-context/09-claim-boundaries.md`

--- a/docs/review-context/release-readiness/TEMPLATE.md
+++ b/docs/review-context/release-readiness/TEMPLATE.md
@@ -1,0 +1,194 @@
+# Release Readiness Report
+
+Vault status: protected release-readiness report template.
+
+Use this template for any request to upgrade VULCA work from draft, preview,
+internal proof, or public-blocked status toward a stronger release level.
+
+## Metadata
+
+| Field | Value |
+| --- | --- |
+| Report id | TBD |
+| Workstream | Workspace / SDK-MCP / website / PPT / provider-backed example / other |
+| Current release level | R0 / R1 / R2 / R3 / R4 / R5 |
+| Requested release level | R0 / R1 / R2 / R3 / R4 / R5 |
+| Human release owner | TBD |
+| Prepared by | TBD |
+| Date | YYYY-MM-DD |
+| Target branch or PR | TBD |
+| Source vault commit | TBD |
+
+## Default Boundary
+
+- [ ] Public release remains blocked until every required gate below is passed and a human release owner records approval.
+- [ ] Missing evidence is recorded as blocked, not silently ignored.
+- [ ] Agent/system checks are evidence inputs only and do not make the final release decision.
+- [ ] If evidence is mixed, the approved level uses the lowest applicable R-level.
+
+## Evidence Index
+
+| Evidence item | Required for gate | Path, URL, commit, or PR | Reviewer | Status |
+| --- | --- | --- | --- | --- |
+| TBD | Gate 1 | TBD | TBD | blocked / pass / not applicable |
+| TBD | Gate 2 | TBD | TBD | blocked / pass / not applicable |
+| TBD | Gate 3 | TBD | TBD | blocked / pass / not applicable |
+| TBD | Gate 4 | TBD | TBD | blocked / pass / not applicable |
+| TBD | Gate 5 | TBD | TBD | blocked / pass / not applicable |
+| TBD | Gate 6 | TBD | TBD | blocked / pass / not applicable |
+
+## Gate 1: Workspace Persistence
+
+Gate result: blocked / pass / not applicable
+
+Required evidence:
+
+- [ ] Creative Repo or review data persists beyond a browser session.
+- [ ] Review item state persists.
+- [ ] Version history persists.
+- [ ] Blockers and decisions persist.
+- [ ] Release gate state persists.
+- [ ] Reviewer and release-owner access boundaries are defined.
+
+Verification links:
+
+- TBD
+
+Blocked notes:
+
+- TBD
+
+## Gate 2: Artifact Ingestion
+
+Gate result: blocked / pass / not applicable
+
+Required evidence:
+
+- [ ] SDK/MCP outputs enter Workspace through the artifact bridge.
+- [ ] Source operation, artifact paths, provider/model metadata, warnings,
+  claim state, and review labels are preserved.
+- [ ] Generated or imported assets become `VisualVariant` records.
+- [ ] Tool executions become `AgentRun` records.
+- [ ] Case records remain evidence substrate, not human labels.
+
+Verification links:
+
+- TBD
+
+Blocked notes:
+
+- TBD
+
+## Gate 3: EvidencePack Rendering
+
+Gate result: blocked / pass / not applicable
+
+Required evidence:
+
+- [ ] EvidencePack renders brief, motif, artifact, provider, prompt, layer,
+  evaluation, warning, and source refs.
+- [ ] Reviewers can inspect evidence on demand.
+- [ ] Missing evidence is visible as a blocker.
+- [ ] Evidence packs link back to bridge records or source artifacts.
+
+Verification links:
+
+- TBD
+
+Blocked notes:
+
+- TBD
+
+## Gate 4: Human Release Workflow
+
+Gate result: blocked / pass / not applicable
+
+Required evidence:
+
+- [ ] Release owner role exists.
+- [ ] Human decision actions are explicit.
+- [ ] Request-changes, block-release, and internal-approval paths are
+  represented.
+- [ ] Public-release state cannot be set by agent/system/external checks.
+- [ ] Decision history records actor, action, summary, and timestamp.
+- [ ] Release gate blockers remain visible.
+
+Verification links:
+
+- TBD
+
+Blocked notes:
+
+- TBD
+
+## Gate 5: Public Example Quality
+
+Gate result: blocked / pass / not applicable
+
+Required evidence:
+
+- [ ] Source artifacts are preserved.
+- [ ] Final preview image or artifact is inspectable.
+- [ ] Visual quality review passes for the specific example.
+- [ ] Cultural/evidence review is qualified and source-backed.
+- [ ] Release owner signs off for that example.
+- [ ] Claims attached to the example match evidence.
+
+Verification links:
+
+- TBD
+
+Blocked notes:
+
+- TBD
+
+## Gate 6: Website/PPT Claim Review
+
+Gate result: blocked / pass / not applicable
+
+Required evidence:
+
+- [ ] Copy follows `13-website-ppt-claim-spine.md`.
+- [ ] Website, README, and PPT use the same product spine.
+- [ ] Preview/internal/public-blocked status is preserved.
+- [ ] Public examples trace to the M3 demo path or an equivalent source-backed
+  path.
+- [ ] Translations preserve the same claim level.
+
+Verification links:
+
+- TBD
+
+Blocked notes:
+
+- TBD
+
+## Release Decision
+
+| Field | Value |
+| --- | --- |
+| Requested R-level | R0 / R1 / R2 / R3 / R4 / R5 |
+| Approved R-level | R0 / R1 / R2 / R3 / R4 / R5 / blocked |
+| Decision | blocked / internal_only / preview_gated / internal_pilot / public_example / product_release |
+| Human release owner | TBD |
+| Decision timestamp | YYYY-MM-DDTHH:MM:SSZ |
+| Evidence packet path | TBD |
+| Boundary notes | TBD |
+
+## Required Downgrade If Blocked
+
+If any required gate is blocked, the approved status must be downgraded to the
+lowest applicable release level and public copy must preserve that boundary.
+
+Record the downgrade here:
+
+- Blocked gate(s): TBD
+- Downgraded approved level: TBD
+- Copy boundary to use: TBD
+- Follow-up owner: TBD
+
+## Sources
+
+- `docs/review-context/14-release-readiness-evidence-gate.md`
+- `docs/review-context/13-website-ppt-claim-spine.md`
+- `docs/review-context/09-claim-boundaries.md`

--- a/docs/review-context/source-index.md
+++ b/docs/review-context/source-index.md
@@ -99,6 +99,9 @@ check before changing high-level VULCA claims.
   - Protected M5 release-readiness gate for Workspace persistence, artifact
     ingestion, evidence rendering, human release workflow, public examples,
     and website/PPT copy review.
+- `docs/review-context/release-readiness/TEMPLATE.md`
+  - Protected RR1 report template for recording evidence links, reviewer/owner
+    fields, Gate 1-6 status, and release decisions.
 
 ## Artifact Bridge
 

--- a/tests/test_review_context_vault.py
+++ b/tests/test_review_context_vault.py
@@ -35,6 +35,20 @@ REQUEST_TEMPLATE_CHECKS = [
     "This request preserves `docs/review-context/LOCK.md`.",
 ]
 
+RELEASE_READINESS_TEMPLATE_CHECKS = [
+    "Public release remains blocked until every required gate below is passed and a human release owner records approval.",
+    "Evidence Index",
+    "Gate 1: Workspace Persistence",
+    "Gate 2: Artifact Ingestion",
+    "Gate 3: EvidencePack Rendering",
+    "Gate 4: Human Release Workflow",
+    "Gate 5: Public Example Quality",
+    "Gate 6: Website/PPT Claim Review",
+    "Human release owner",
+    "Release Decision",
+    "blocked / internal_only / preview_gated / internal_pilot / public_example / product_release",
+]
+
 
 def load_validator():
     spec = importlib.util.spec_from_file_location("review_context_validator", VALIDATOR_PATH)
@@ -51,6 +65,7 @@ def write_minimal_vault(
     missing_required_file: str | None = None,
     forbidden_claim_file: str | None = None,
     omit_request_lock_item: bool = False,
+    omit_release_gate_item: bool = False,
 ) -> None:
     required_files = [
         "README.md",
@@ -60,6 +75,8 @@ def write_minimal_vault(
         "MANIFEST.json",
         "source-index.md",
         *CORE_HISTORY_FILES,
+        "release-readiness/README.md",
+        "release-readiness/TEMPLATE.md",
         "requests/README.md",
         "requests/TEMPLATE.md",
         "gates/validate-review-context.md",
@@ -92,6 +109,19 @@ def write_minimal_vault(
                 "# Request\n\n" + "\n".join(f"- [ ] {item}" for item in checks) + "\n",
                 encoding="utf-8",
             )
+        elif rel == "release-readiness/TEMPLATE.md":
+            checks = (
+                RELEASE_READINESS_TEMPLATE_CHECKS[:-1]
+                if omit_release_gate_item
+                else RELEASE_READINESS_TEMPLATE_CHECKS
+            )
+            path.write_text(
+                "# Release Readiness Report\n\n"
+                "Vault status: test.\n\n"
+                + "\n".join(f"- {item}" for item in checks)
+                + "\n\n## Sources\n\n- test source\n",
+                encoding="utf-8",
+            )
         elif path.suffix == ".md":
             text = standard_text
             if rel == forbidden_claim_file:
@@ -104,6 +134,7 @@ def write_minimal_vault(
 def run_validator_on(module, root: Path) -> int:
     module.ROOT = root
     module.MANIFEST_PATH = root / "MANIFEST.json"
+    module.RELEASE_READINESS_TEMPLATE_PATH = root / "release-readiness" / "TEMPLATE.md"
     return module.main()
 
 
@@ -132,6 +163,14 @@ def test_forbidden_claim_outside_allowlist_fails(tmp_path: Path) -> None:
 def test_request_template_must_preserve_lock_checklist(tmp_path: Path) -> None:
     module = load_validator()
     write_minimal_vault(tmp_path, omit_request_lock_item=True)
+
+    with pytest.raises(SystemExit):
+        run_validator_on(module, tmp_path)
+
+
+def test_release_readiness_template_must_include_all_gate_controls(tmp_path: Path) -> None:
+    module = load_validator()
+    write_minimal_vault(tmp_path, omit_release_gate_item=True)
 
     with pytest.raises(SystemExit):
         run_validator_on(module, tmp_path)


### PR DESCRIPTION
## Summary
- add the protected RR1 release-readiness report template
- wire the template into the vault README, manifest, source index, M5 gate, and changelog
- extend the vault validator and tests so the template must keep Gates 1-6, evidence index, owner, and decision controls

## Verification
- python3 docs/review-context/gates/validate_review_context.py
- python3 -m pytest tests/test_review_context_vault.py -q
- git diff --cached --check
- gemini-agent diff-review --smart-diff