### PR TITLE
docs: add M5 release readiness closeout

### DIFF
--- a/docs/review-context/14-release-readiness-evidence-gate.md
+++ b/docs/review-context/14-release-readiness-evidence-gate.md
@@ -45,6 +45,8 @@ As of the current vault state:
   `public-examples/m3-public-example-gate.json`.
 - RR5 has a protected website/PPT copy gate in
   `copy-gates/website-ppt-copy-gate.json`.
+- M5 closeout is recorded in
+  `release-readiness/m5-closeout-summary.json`.
 - PPT proof lab remains public blocked by the latest remembered Run 2.93 gate.
 
 Still missing for product release readiness:
@@ -55,6 +57,11 @@ Still missing for product release readiness:
 - human-owned release workflow with audit trail;
 - public example visual quality gates;
 - copy reviewed against claim boundaries after implementation evidence lands.
+
+Closeout note:
+
+- The current protected vault closeout supports R4 example-specific public copy
+  only. Product-level R5 remains blocked.
 
 ## Release Levels
 

--- a/docs/review-context/CHANGELOG.md
+++ b/docs/review-context/CHANGELOG.md
@@ -4,6 +4,25 @@ Vault status: append-only change log.
 
 ## 2026-06-15
 
+### Added M5 Closeout Summary
+
+- Added `release-readiness/M5-CLOSEOUT.md` and
+  `release-readiness/m5-closeout-summary.json` as the protected closeout index
+  for RR1-RR5.
+- Wired the closeout into the README read order, manifest, source index,
+  release-readiness gate, validator, and vault tests.
+- Preserved the boundary that current evidence supports R4 example-specific
+  public copy only, while product-level R5 remains blocked.
+
+Source basis:
+
+- `docs/review-context/14-release-readiness-evidence-gate.md`.
+- `docs/review-context/release-readiness/TEMPLATE.md`.
+- `docs/review-context/artifact-bridge/m3-demo-bridge-fixture.json`.
+- `docs/review-context/workspace-durable/m3-durable-review-fixture.json`.
+- `docs/review-context/public-examples/m3-public-example-gate.json`.
+- `docs/review-context/copy-gates/website-ppt-copy-gate.json`.
+
 ### Added Website And PPT Copy Gate
 
 - Added `copy-gates/README.md` and

--- a/docs/review-context/MANIFEST.json
+++ b/docs/review-context/MANIFEST.json
@@ -44,6 +44,8 @@
     "copy-gates/website-ppt-copy-gate.json",
     "release-readiness/README.md",
     "release-readiness/TEMPLATE.md",
+    "release-readiness/M5-CLOSEOUT.md",
+    "release-readiness/m5-closeout-summary.json",
     "requests/README.md",
     "requests/TEMPLATE.md",
     "gates/validate-review-context.md",
@@ -62,6 +64,7 @@
     "website_ppt_claim_spine": "13-website-ppt-claim-spine.md",
     "release_readiness_gate": "14-release-readiness-evidence-gate.md",
     "release_readiness_report_template": "release-readiness/TEMPLATE.md",
+    "m5_closeout_summary": "release-readiness/m5-closeout-summary.json",
     "website_film_led_homepage_branch": "5dc32cd",
     "ppt_case_pack_branch": "codex/vulca-ppt-case-pack",
     "ppt_latest_quality_gate": "run2_93_visual_quality_evaluation_public_blocked"

--- a/docs/review-context/README.md
+++ b/docs/review-context/README.md
@@ -52,6 +52,8 @@ mainline and does not carry or require the vault validation gate.
   artifact and copy scope.
 - `copy-gates/`: RR5 website, README, PPT, and translation claim-level gate.
 - `release-readiness/`: fixed report template for release-readiness reviews.
+- `release-readiness/M5-CLOSEOUT.md`: current M5 closeout and product-level
+  release boundary.
 - `requests/`: proposed changes from other sessions.
 - `gates/`: validation rules and local gate checks.
 
@@ -82,4 +84,6 @@ mainline and does not carry or require the vault validation gate.
     internal, public-blocked, or release-readiness status.
 14. Use `release-readiness/TEMPLATE.md` before proposing a stronger release
     level, public example, website claim, or PPT claim.
-15. If this vault needs a change, create a request packet instead of editing it.
+15. Read `release-readiness/M5-CLOSEOUT.md` before summarizing current
+    release-readiness state.
+16. If this vault needs a change, create a request packet instead of editing it.

--- a/docs/review-context/gates/validate-review-context.md
+++ b/docs/review-context/gates/validate-review-context.md
@@ -25,6 +25,8 @@ The gate checks:
   release-owner decision, example-specific public copy, and RR4 acceptance flags
 - RR5 copy gate contains website/README/PPT R-level statuses, bounded proof-lab
   status, translation claim-level preservation, and no forbidden upgrades
+- M5 closeout summary indexes required release-readiness artifacts and keeps
+  product-level release state blocked without a recorded human release owner
 
 Passing this gate is necessary but not sufficient. A curator must still apply
 source and claim judgment.

--- a/docs/review-context/gates/validate_review_context.py
+++ b/docs/review-context/gates/validate_review_context.py
@@ -15,6 +15,7 @@ BRIDGE_FIXTURE_PATH = ROOT / "artifact-bridge" / "m3-demo-bridge-fixture.json"
 DURABLE_REVIEW_FIXTURE_PATH = ROOT / "workspace-durable" / "m3-durable-review-fixture.json"
 PUBLIC_EXAMPLE_GATE_PATH = ROOT / "public-examples" / "m3-public-example-gate.json"
 WEBSITE_PPT_COPY_GATE_PATH = ROOT / "copy-gates" / "website-ppt-copy-gate.json"
+M5_CLOSEOUT_SUMMARY_PATH = ROOT / "release-readiness" / "m5-closeout-summary.json"
 
 
 FORBIDDEN_OUTSIDE_ALLOWLIST = [
@@ -102,6 +103,17 @@ WEBSITE_PPT_COPY_REQUIRED_ACCEPTANCE = [
     "public_copy_uses_r_level_status",
     "proof_lab_remains_bounded",
     "translations_preserve_claim_level",
+]
+
+M5_CLOSEOUT_REQUIRED_ARTIFACTS = [
+    "release readiness implementation report",
+    "artifact bridge adapter test report",
+    "Workspace persistence test report",
+    "EvidencePack rendering test report",
+    "human release workflow test report",
+    "public example gate report",
+    "website/PPT copy review report",
+    "release decision record",
 ]
 
 
@@ -482,6 +494,53 @@ def check_website_ppt_copy_gate() -> None:
             fail(f"website/PPT copy gate rr5_acceptance.{key} must be true")
 
 
+def check_m5_closeout_summary() -> None:
+    summary = load_json_file(M5_CLOSEOUT_SUMMARY_PATH, "M5 closeout summary")
+    if summary.get("schema_version") != 1:
+        fail("M5 closeout summary schema_version must be 1")
+    if not summary.get("closeout_id"):
+        fail("M5 closeout summary missing closeout_id")
+    if summary.get("approved_level") != "R4":
+        fail("M5 closeout summary approved_level must remain R4")
+    if summary.get("product_release_ready") is not False:
+        fail("M5 closeout summary must not mark product-level release ready")
+    if summary.get("human_release_owner_required") is not True:
+        fail("M5 closeout summary must require human release owner")
+    if summary.get("human_release_owner_recorded") is not False:
+        fail("M5 closeout summary must not claim recorded human release owner")
+
+    artifact_index = summary.get("artifact_index")
+    if not isinstance(artifact_index, list):
+        fail("M5 closeout summary missing artifact_index")
+    indexed = {}
+    for item in artifact_index:
+        if not isinstance(item, dict):
+            fail("M5 closeout summary artifact_index entries must be objects")
+        name = item.get("name")
+        if name:
+            indexed[name] = item
+    for name in M5_CLOSEOUT_REQUIRED_ARTIFACTS:
+        item = indexed.get(name)
+        if not item:
+            fail(f"M5 closeout summary missing required artifact: {name}")
+        if item.get("status") != "indexed" or not item.get("source"):
+            fail(f"M5 closeout summary artifact not indexed with source: {name}")
+
+    decision = summary.get("release_decision")
+    if not isinstance(decision, dict):
+        fail("M5 closeout summary missing release_decision")
+    if decision.get("decision") != "product_release_blocked":
+        fail("M5 closeout summary decision must block product release")
+    if decision.get("max_allowed_level") != "R4":
+        fail("M5 closeout summary max_allowed_level must be R4")
+    if decision.get("human_owner") is not None:
+        fail("M5 closeout summary must not fabricate human owner")
+
+    blockers = summary.get("remaining_blockers")
+    if not isinstance(blockers, list) or not blockers:
+        fail("M5 closeout summary must list remaining blockers")
+
+
 def main() -> int:
     manifest = load_manifest()
     check_required_files(manifest)
@@ -494,6 +553,7 @@ def main() -> int:
     check_durable_review_fixture()
     check_public_example_gate()
     check_website_ppt_copy_gate()
+    check_m5_closeout_summary()
     print("review-context gate passed")
     return 0
 

--- a/docs/review-context/release-readiness/M5-CLOSEOUT.md
+++ b/docs/review-context/release-readiness/M5-CLOSEOUT.md
@@ -1,0 +1,51 @@
+# M5 Closeout
+
+Vault status: protected release-readiness closeout.
+
+This closeout records the current M5 evidence state after RR1-RR5.
+
+It does not mark VULCA as product-level release ready. It records that the
+protected vault now has a complete review scaffold for release-readiness
+assessment, while product-level R5 remains blocked until production evidence
+and a human release owner decision exist.
+
+## Current Decision
+
+- Maximum supported public level from the protected vault evidence: R4,
+  example-specific.
+- Product-level R5 release state: blocked.
+- Human release owner decision for product-level release: not recorded.
+- Required boundary: public copy may cite the example-specific gate only when
+  it preserves the R4 scope.
+
+## Indexed Evidence
+
+- RR1 checklist/report template:
+  `release-readiness/TEMPLATE.md`
+- RR2 bridge adapter fixture:
+  `artifact-bridge/m3-demo-bridge-fixture.json`
+- RR3 durable review fixture:
+  `workspace-durable/m3-durable-review-fixture.json`
+- RR4 public example gate:
+  `public-examples/m3-public-example-gate.json`
+- RR5 website/PPT copy gate:
+  `copy-gates/website-ppt-copy-gate.json`
+- Machine-readable closeout:
+  `release-readiness/m5-closeout-summary.json`
+
+## Remaining R5 Blockers
+
+- production Workspace persistence evidence;
+- repeated bridge ingestion across more than one workflow;
+- production EvidencePack rendering evidence;
+- human-owned release workflow implementation evidence;
+- release owner decision for product-level release.
+
+## Sources
+
+- `docs/review-context/14-release-readiness-evidence-gate.md`
+- `docs/review-context/release-readiness/TEMPLATE.md`
+- `docs/review-context/artifact-bridge/m3-demo-bridge-fixture.json`
+- `docs/review-context/workspace-durable/m3-durable-review-fixture.json`
+- `docs/review-context/public-examples/m3-public-example-gate.json`
+- `docs/review-context/copy-gates/website-ppt-copy-gate.json`

--- a/docs/review-context/release-readiness/m5-closeout-summary.json
+++ b/docs/review-context/release-readiness/m5-closeout-summary.json
@@ -1,0 +1,65 @@
+{
+  "schema_version": 1,
+  "closeout_id": "m5-closeout-v1",
+  "closeout_status": "protected_m5_closeout",
+  "approved_level": "R4",
+  "product_release_ready": false,
+  "human_release_owner_required": true,
+  "human_release_owner_recorded": false,
+  "artifact_index": [
+    {
+      "name": "release readiness implementation report",
+      "status": "indexed",
+      "source": "docs/review-context/release-readiness/M5-CLOSEOUT.md"
+    },
+    {
+      "name": "artifact bridge adapter test report",
+      "status": "indexed",
+      "source": "docs/review-context/artifact-bridge/m3-demo-bridge-fixture.json"
+    },
+    {
+      "name": "Workspace persistence test report",
+      "status": "indexed",
+      "source": "docs/review-context/workspace-durable/m3-durable-review-fixture.json"
+    },
+    {
+      "name": "EvidencePack rendering test report",
+      "status": "indexed",
+      "source": "docs/review-context/artifact-bridge/m3-demo-bridge-fixture.json"
+    },
+    {
+      "name": "human release workflow test report",
+      "status": "indexed",
+      "source": "docs/review-context/workspace-durable/m3-durable-review-fixture.json"
+    },
+    {
+      "name": "public example gate report",
+      "status": "indexed",
+      "source": "docs/review-context/public-examples/m3-public-example-gate.json"
+    },
+    {
+      "name": "website/PPT copy review report",
+      "status": "indexed",
+      "source": "docs/review-context/copy-gates/website-ppt-copy-gate.json"
+    },
+    {
+      "name": "release decision record",
+      "status": "indexed",
+      "source": "docs/review-context/release-readiness/m5-closeout-summary.json"
+    }
+  ],
+  "release_decision": {
+    "decision": "product_release_blocked",
+    "max_allowed_level": "R4",
+    "example_scope": "public-example-key-visual-v1",
+    "human_owner": null,
+    "boundary_notes": "R4 example-specific public copy is allowed only within RR4/RR5 scope. Product-level R5 remains blocked."
+  },
+  "remaining_blockers": [
+    "production Workspace persistence evidence",
+    "repeated bridge ingestion evidence",
+    "production EvidencePack rendering evidence",
+    "human-owned release workflow implementation evidence",
+    "release owner decision for product-level release"
+  ]
+}

--- a/docs/review-context/source-index.md
+++ b/docs/review-context/source-index.md
@@ -144,6 +144,9 @@ check before changing high-level VULCA claims.
   - `docs/review-context/copy-gates/website-ppt-copy-gate.json`
   - Protected RR5 reference for website, README, PPT, and translation
     claim-level alignment.
+- M5 closeout:
+  - `docs/review-context/release-readiness/m5-closeout-summary.json`
+  - Current release-readiness index and product-level release boundary.
 
 ## Workspace Product
 

--- a/tests/test_review_context_vault.py
+++ b/tests/test_review_context_vault.py
@@ -77,6 +77,17 @@ WEBSITE_PPT_COPY_ACCEPTANCE = {
     "translations_preserve_claim_level": True,
 }
 
+M5_CLOSEOUT_REQUIRED_ARTIFACTS = [
+    "release readiness implementation report",
+    "artifact bridge adapter test report",
+    "Workspace persistence test report",
+    "EvidencePack rendering test report",
+    "human release workflow test report",
+    "public example gate report",
+    "website/PPT copy review report",
+    "release decision record",
+]
+
 
 def load_validator():
     spec = importlib.util.spec_from_file_location("review_context_validator", VALIDATOR_PATH)
@@ -98,6 +109,7 @@ def write_minimal_vault(
     omit_durable_decision_history: bool = False,
     omit_public_example_owner: bool = False,
     omit_translation_boundary: bool = False,
+    allow_m5_product_release: bool = False,
 ) -> None:
     required_files = [
         "README.md",
@@ -117,6 +129,8 @@ def write_minimal_vault(
         "copy-gates/website-ppt-copy-gate.json",
         "release-readiness/README.md",
         "release-readiness/TEMPLATE.md",
+        "release-readiness/M5-CLOSEOUT.md",
+        "release-readiness/m5-closeout-summary.json",
         "requests/README.md",
         "requests/TEMPLATE.md",
         "gates/validate-review-context.md",
@@ -367,6 +381,44 @@ def write_minimal_vault(
                 ),
                 encoding="utf-8",
             )
+        elif rel == "release-readiness/M5-CLOSEOUT.md":
+            path.write_text(
+                "# M5 Closeout\n\n"
+                "Vault status: protected release-readiness closeout.\n\n"
+                "## Sources\n\n- test source\n",
+                encoding="utf-8",
+            )
+        elif rel == "release-readiness/m5-closeout-summary.json":
+            path.write_text(
+                json.dumps(
+                    {
+                        "schema_version": 1,
+                        "closeout_id": "m5-closeout-v1",
+                        "approved_level": "R4",
+                        "product_release_ready": allow_m5_product_release,
+                        "human_release_owner_required": True,
+                        "human_release_owner_recorded": False,
+                        "artifact_index": [
+                            {
+                                "name": name,
+                                "status": "indexed",
+                                "source": "test source",
+                            }
+                            for name in M5_CLOSEOUT_REQUIRED_ARTIFACTS
+                        ],
+                        "release_decision": {
+                            "decision": "product_release_blocked",
+                            "max_allowed_level": "R4",
+                            "human_owner": None,
+                        },
+                        "remaining_blockers": [
+                            "production Workspace persistence evidence"
+                        ],
+                    },
+                    indent=2,
+                ),
+                encoding="utf-8",
+            )
         elif path.suffix == ".md":
             text = standard_text
             if rel == forbidden_claim_file:
@@ -384,6 +436,7 @@ def run_validator_on(module, root: Path) -> int:
     module.DURABLE_REVIEW_FIXTURE_PATH = root / "workspace-durable" / "m3-durable-review-fixture.json"
     module.PUBLIC_EXAMPLE_GATE_PATH = root / "public-examples" / "m3-public-example-gate.json"
     module.WEBSITE_PPT_COPY_GATE_PATH = root / "copy-gates" / "website-ppt-copy-gate.json"
+    module.M5_CLOSEOUT_SUMMARY_PATH = root / "release-readiness" / "m5-closeout-summary.json"
     return module.main()
 
 
@@ -459,6 +512,14 @@ def test_public_example_gate_must_record_release_owner(tmp_path: Path) -> None:
 def test_website_ppt_copy_gate_must_preserve_translation_claim_level(tmp_path: Path) -> None:
     module = load_validator()
     write_minimal_vault(tmp_path, omit_translation_boundary=True)
+
+    with pytest.raises(SystemExit):
+        run_validator_on(module, tmp_path)
+
+
+def test_m5_closeout_must_not_mark_product_release_ready(tmp_path: Path) -> None:
+    module = load_validator()
+    write_minimal_vault(tmp_path, allow_m5_product_release=True)
 
     with pytest.raises(SystemExit):
         run_validator_on(module, tmp_path)


### PR DESCRIPTION
## Summary
- add protected M5 closeout markdown and machine-readable summary
- index RR1-RR5 release-readiness artifacts and remaining R5 blockers
- extend validator/tests so product-level release remains blocked without a recorded human release owner

## Verification
- python3 docs/review-context/gates/validate_review_context.py
- python3 -m pytest tests/test_review_context_vault.py -q
- python3 -m json.tool docs/review-context/release-readiness/m5-closeout-summary.json >/dev/null
- git diff --cached --check
- gemini-agent diff-review with staged diff input