### PR TITLE
[codex] Record platform Workspace PR status in vault

### DIFF
--- a/docs/review-context/CHANGELOG.md
+++ b/docs/review-context/CHANGELOG.md
@@ -6,11 +6,11 @@ Vault status: append-only change log.
 
 ### Recorded Platform PR And Protection Status
 
-- Recorded platform PR #31 as ready for review with a Workspace-focused PR
+- Recorded platform PR #31 as merged to `master` with a Workspace-focused PR
   gate and legacy full E2E suite moved to manual advisory.
-- Recorded platform PR #32 as the stacked durable Workspace persistence draft,
-  including local durable review state, staged decision persistence, advisory
-  agent completion persistence, and release-owner audit trail scope.
+- Recorded platform PR #32 as merged to `master`, including local durable
+  review state, staged decision persistence, advisory agent completion
+  persistence, and release-owner audit trail scope.
 - Clarified that these PRs improve R5 evidence but do not change product-level
   release readiness, which remains blocked.
 - Recorded the GitHub protection limitation for the private

--- a/docs/review-context/CHANGELOG.md
+++ b/docs/review-context/CHANGELOG.md
@@ -4,6 +4,26 @@ Vault status: append-only change log.
 
 ## 2026-06-15
 
+### Recorded Platform PR And Protection Status
+
+- Recorded platform PR #31 as ready for review with a Workspace-focused PR
+  gate and legacy full E2E suite moved to manual advisory.
+- Recorded platform PR #32 as the stacked durable Workspace persistence draft,
+  including local durable review state, staged decision persistence, advisory
+  agent completion persistence, and release-owner audit trail scope.
+- Clarified that these PRs improve R5 evidence but do not change product-level
+  release readiness, which remains blocked.
+- Recorded the GitHub protection limitation for the private
+  `yha9806/vulca-platform` repository and the temporary no-direct-master
+  operational rule until GitHub branch protection becomes available.
+
+Source basis:
+
+- `yha9806/vulca-platform` PR #31.
+- `yha9806/vulca-platform` PR #32.
+- GitHub ruleset/protection API checks on 2026-06-15.
+- Local verification for `codex/vulca-workspace-durable-review`.
+
 ### Added M5 Closeout Summary
 
 - Added `release-readiness/M5-CLOSEOUT.md` and

--- a/docs/review-context/PROTECTION.md
+++ b/docs/review-context/PROTECTION.md
@@ -47,6 +47,28 @@ While the repository has only one maintainer, the shared pull-request rule uses
 `require_code_owner_review: false` to avoid a solo-maintainer lockout. Code
 owner review can be re-enabled only after a second valid reviewer or team exists.
 
+## Related Platform Repository Protection
+
+As of 2026-06-15, `yha9806/vulca-platform` is a private repository. GitHub's
+branch-protection and ruleset APIs returned HTTP 403 with the message that the
+feature requires GitHub Pro or a public repository. Therefore, the platform
+repository cannot currently enforce the same hard no-direct-push rule through
+GitHub branch protection.
+
+Operational rule until the repository is upgraded or made public:
+
+- do not push directly to `master`;
+- push product work to `codex/*` branches;
+- use PRs for `master` integration;
+- treat `Run Tests` and `security` as required evidence even when GitHub cannot
+  technically enforce them;
+- record any exception in this vault before merging.
+
+Once GitHub protection becomes available for `yha9806/vulca-platform`, mirror
+the context-vault rule shape: require pull requests, block deletion, block
+non-fast-forward updates, configure no bypass actors by default, and require
+`Run Tests` plus `security` for `master`.
+
 ## Modification Path
 
 Reader sessions may:
@@ -83,5 +105,6 @@ If a critical repair requires temporary bypass:
 ## Sources
 
 - Repository rulesets verified through the GitHub API on 2026-06-15.
+- `yha9806/vulca-platform` protection and ruleset API checks on 2026-06-15.
 - Context-vault branch: `codex/vulca-context-vault`.
 - GitHub user owner in `.github/CODEOWNERS`: `@yha9806`.

--- a/docs/review-context/release-readiness/M5-CLOSEOUT.md
+++ b/docs/review-context/release-readiness/M5-CLOSEOUT.md
@@ -18,17 +18,19 @@ and a human release owner decision exist.
 - Required boundary: public copy may cite the example-specific gate only when
   it preserves the R4 scope.
 
-## Current Platform PR State
+## Current Platform Merge State
 
 As of 2026-06-15:
 
-- Platform PR #31, `[codex] Workspace review product shell`, is ready for
-  review. Its PR gate includes `tests/e2e/specs/workspace.spec.ts`, while the
-  legacy full E2E suite is manual advisory because it still covers retired
-  `/login` and `/canvas` flows.
-- Platform PR #32, `[codex] Durable workspace review persistence`, is a
-  stacked draft on PR #31. It implements local durable review state and the
-  release-owner audit trail, with local verification and remote security scan.
+- Platform PR #31, `[codex] Workspace review product shell`, merged to
+  `master` at `6810e67ca967a47782b5d9f83d751148d1eb6d26`. Its PR gate
+  includes `tests/e2e/specs/workspace.spec.ts`, while the legacy full E2E suite
+  is manual advisory because it still covers retired `/login` and `/canvas`
+  flows.
+- Platform PR #32, `[codex] Durable workspace review persistence`, merged to
+  `master` at `61da8e9f296b7c1e66f61720e487e8e42d4eb6ce`. It implements local
+  durable review state and the release-owner audit trail, with local
+  verification plus remote `Run Tests` and `security` gates.
 
 These PRs improve R5 evidence, but they do not change the product-level
 decision above.

--- a/docs/review-context/release-readiness/M5-CLOSEOUT.md
+++ b/docs/review-context/release-readiness/M5-CLOSEOUT.md
@@ -18,6 +18,21 @@ and a human release owner decision exist.
 - Required boundary: public copy may cite the example-specific gate only when
   it preserves the R4 scope.
 
+## Current Platform PR State
+
+As of 2026-06-15:
+
+- Platform PR #31, `[codex] Workspace review product shell`, is ready for
+  review. Its PR gate includes `tests/e2e/specs/workspace.spec.ts`, while the
+  legacy full E2E suite is manual advisory because it still covers retired
+  `/login` and `/canvas` flows.
+- Platform PR #32, `[codex] Durable workspace review persistence`, is a
+  stacked draft on PR #31. It implements local durable review state and the
+  release-owner audit trail, with local verification and remote security scan.
+
+These PRs improve R5 evidence, but they do not change the product-level
+decision above.
+
 ## Indexed Evidence
 
 - RR1 checklist/report template:
@@ -35,7 +50,7 @@ and a human release owner decision exist.
 
 ## Remaining R5 Blockers
 
-- production Workspace persistence evidence;
+- production/shared Workspace persistence evidence beyond the local durable PR;
 - repeated bridge ingestion across more than one workflow;
 - production EvidencePack rendering evidence;
 - human-owned release workflow implementation evidence;
@@ -49,3 +64,5 @@ and a human release owner decision exist.
 - `docs/review-context/workspace-durable/m3-durable-review-fixture.json`
 - `docs/review-context/public-examples/m3-public-example-gate.json`
 - `docs/review-context/copy-gates/website-ppt-copy-gate.json`
+- `yha9806/vulca-platform` PR #31.
+- `yha9806/vulca-platform` PR #32.

--- a/docs/review-context/workspace-durable/README.md
+++ b/docs/review-context/workspace-durable/README.md
@@ -10,6 +10,23 @@ Product branches may implement it with a backend, database, local durable demo
 store, or test fixture, but they must preserve the same review evidence,
 blocker, decision-state, and human-audit boundaries.
 
+## Product Implementation Status
+
+As of 2026-06-15, the platform implementation is split into two protected PRs:
+
+- PR #31, `[codex] Workspace review product shell`, is ready for review on
+  `yha9806/vulca-platform` with head `codex/workspace-interactive-demo`.
+  Its PR gate blocks on TypeScript, quiet ESLint, frontend unit tests, backend
+  tests, backend coverage, and `tests/e2e/specs/workspace.spec.ts`.
+- PR #32, `[codex] Durable workspace review persistence`, is a stacked draft
+  on `codex/workspace-interactive-demo` with head
+  `codex/vulca-workspace-durable-review`. It adds local durable review state,
+  staged decision persistence, advisory-agent completion persistence, and the
+  release-owner audit trail.
+
+PR #32 is intentionally a local durability slice. It does not certify shared
+production persistence or product-level release readiness.
+
 ## Current Fixtures
 
 - `m3-durable-review-fixture.json`: RR3 reference fixture showing the M3
@@ -31,3 +48,5 @@ blocker, decision-state, and human-audit boundaries.
 - `docs/review-context/12-complete-demo-path.md`
 - `docs/review-context/14-release-readiness-evidence-gate.md`
 - `docs/review-context/artifact-bridge/m3-demo-bridge-fixture.json`
+- `yha9806/vulca-platform` PR #31.
+- `yha9806/vulca-platform` PR #32.

--- a/docs/review-context/workspace-durable/README.md
+++ b/docs/review-context/workspace-durable/README.md
@@ -12,17 +12,17 @@ blocker, decision-state, and human-audit boundaries.
 
 ## Product Implementation Status
 
-As of 2026-06-15, the platform implementation is split into two protected PRs:
+As of 2026-06-15, the platform implementation has two merged PRs on
+`yha9806/vulca-platform` `master`:
 
-- PR #31, `[codex] Workspace review product shell`, is ready for review on
-  `yha9806/vulca-platform` with head `codex/workspace-interactive-demo`.
-  Its PR gate blocks on TypeScript, quiet ESLint, frontend unit tests, backend
-  tests, backend coverage, and `tests/e2e/specs/workspace.spec.ts`.
-- PR #32, `[codex] Durable workspace review persistence`, is a stacked draft
-  on `codex/workspace-interactive-demo` with head
-  `codex/vulca-workspace-durable-review`. It adds local durable review state,
-  staged decision persistence, advisory-agent completion persistence, and the
-  release-owner audit trail.
+- PR #31, `[codex] Workspace review product shell`, merged at
+  `6810e67ca967a47782b5d9f83d751148d1eb6d26`. Its PR gate blocked on
+  TypeScript, quiet ESLint, frontend unit tests, backend tests, backend
+  coverage, and `tests/e2e/specs/workspace.spec.ts`.
+- PR #32, `[codex] Durable workspace review persistence`, merged at
+  `61da8e9f296b7c1e66f61720e487e8e42d4eb6ce`. It adds local durable review
+  state, staged decision persistence, advisory-agent completion persistence,
+  and the release-owner audit trail.
 
 PR #32 is intentionally a local durability slice. It does not certify shared
 production persistence or product-level release readiness.


### PR DESCRIPTION
## Summary
- Record the current platform Workspace PR state: PR #31 ready-for-review and PR #32 as a stacked durability draft.
- Capture the current platform branch-protection limitation for `yha9806/vulca-platform` and the temporary no-direct-master process rule.
- Keep the vault update scoped to review-context docs only; no manifest or product-code changes.

## Validation
- `git diff --check`
- `python3 docs/review-context/gates/validate_review_context.py`

## Notes
- Base target is the protected context vault branch `codex/vulca-context-vault`.
- This PR is the auditable request path for updating durable context, rather than direct-pushing into the vault branch.