### PR TITLE
[codex] Record platform CI actions hygiene in vault

### DIFF
--- a/docs/review-context/CHANGELOG.md
+++ b/docs/review-context/CHANGELOG.md
@@ -4,6 +4,19 @@ Vault status: append-only change log.
 
 ## 2026-06-15
 
+### Recorded Platform CI Hygiene Merge
+
+- Recorded platform PR #33 as merged to `master` with Node 24-compatible
+  GitHub Actions pins for checkout, setup-node, setup-python, and
+  gitleaks-action.
+- Recorded that #33 passed `Run Tests` and `security`; the deploy job remained
+  skipped for the PR event.
+
+Source basis:
+
+- `yha9806/vulca-platform` PR #33.
+- GitHub latest-release API checks for the upgraded actions on 2026-06-15.
+
 ### Recorded Platform PR And Protection Status
 
 - Recorded platform PR #31 as merged to `master` with a Workspace-focused PR

--- a/docs/review-context/PROTECTION.md
+++ b/docs/review-context/PROTECTION.md
@@ -69,6 +69,23 @@ the context-vault rule shape: require pull requests, block deletion, block
 non-fast-forward updates, configure no bypass actors by default, and require
 `Run Tests` plus `security` for `master`.
 
+### Platform CI Hygiene
+
+As of 2026-06-15, `yha9806/vulca-platform` PR #33,
+`[codex] Update GitHub Actions for Node 24`, merged to `master` at
+`0a7dd392de1eb24eacd245e91cb3c2d0234a5f81`.
+
+That PR updated the platform workflows to current Node 24-compatible action
+pins:
+
+- `actions/checkout@v6.0.3`
+- `actions/setup-node@v6.4.0`
+- `actions/setup-python@v6.2.0`
+- `gitleaks/gitleaks-action@v3.0.0`
+
+Its PR gate passed `Run Tests` and `security`; the deploy job remained skipped
+for the PR event.
+
 ## Modification Path
 
 Reader sessions may:
@@ -106,5 +123,6 @@ If a critical repair requires temporary bypass:
 
 - Repository rulesets verified through the GitHub API on 2026-06-15.
 - `yha9806/vulca-platform` protection and ruleset API checks on 2026-06-15.
+- `yha9806/vulca-platform` PR #33.
 - Context-vault branch: `codex/vulca-context-vault`.
 - GitHub user owner in `.github/CODEOWNERS`: `@yha9806`.


### PR DESCRIPTION
## Summary
- Record platform PR #33 as merged to `master`.
- Capture the Node 24-compatible GitHub Actions pins now used by the platform workflows.
- Preserve the existing platform protection limitation and no-direct-master operational rule.

## Validation
- `git diff --check`
- `python3 docs/review-context/gates/validate_review_context.py`

## Notes
- This updates vault documentation only.
- No manifest change is required because no protected context inventory file was added or removed.