### PR TITLE
docs: record workspace db persistence merge

### DIFF
--- a/docs/review-context/14-release-readiness-evidence-gate.md
+++ b/docs/review-context/14-release-readiness-evidence-gate.md
@@ -108,19 +108,23 @@ Current evidence:
 - Platform PR #34 adds a shared in-process backend review-state API and
   frontend Workspace load/save mirroring, with backend-side
   `public_ready=false` locking.
+- Platform PR #35 upgrades that compatibility endpoint from process memory to
+  SQLAlchemy-backed database persistence for the whole review-state snapshot.
 - `15-workspace-production-persistence-spec.md` defines the product design for
   database-backed storage, authorization, conflict handling, audit events, and
   multi-instance behavior.
 
 Remaining boundary:
 
-- PR #34 does not prove production database-backed durability, authorization,
-  conflict handling, or multi-instance behavior.
+- PR #35 proves database-backed compatibility snapshot persistence, but does
+  not prove authorization, conflict handling, typed Workspace aggregates,
+  append-only audit events, or multi-instance acceptance behavior.
 
 Blocked until:
 
-- the local/in-process slices are replaced or supplemented by production-grade
-  durable storage and access boundaries for the demo path.
+- the compatibility snapshot slice is supplemented by production-grade access
+  boundaries, conflict handling, audit events, typed durable records, and
+  multi-instance evidence for the demo path.
 
 ### Gate 2: Artifact Ingestion
 

--- a/docs/review-context/15-workspace-production-persistence-spec.md
+++ b/docs/review-context/15-workspace-production-persistence-spec.md
@@ -15,7 +15,7 @@ readiness.
 
 ## Current Baseline
 
-The current platform state has three relevant merged slices:
+The current platform state has four relevant merged slices:
 
 - PR #31 adds the Workspace review product shell.
 - PR #32 adds local durable review state and release-owner audit trail
@@ -23,10 +23,14 @@ The current platform state has three relevant merged slices:
 - PR #34 adds a shared in-process backend review-state API at
   `/api/v1/workspace/review-state/{repo_id}` and frontend Workspace load/save
   mirroring.
+- PR #35 replaces the #34 process-memory store behind that compatibility
+  endpoint with a SQLAlchemy `workspace_review_states` table and tests that
+  prove the saved snapshot survives a process-local store reset.
 
-The baseline proves the product direction and a shared API surface. It does not
-prove production persistence, authorization, conflict handling, or
-multi-instance behavior.
+The baseline now proves product direction, a shared API surface, and
+database-backed compatibility snapshot persistence. It does not prove the full
+production persistence model, authorization, conflict handling, append-only
+audit events, typed object aggregates, or multi-instance acceptance behavior.
 
 ## Product Position
 
@@ -197,7 +201,7 @@ Rules:
 
 ## Migration From Current Slice
 
-Migration from PR #34 should be staged:
+Migration from PR #34 and PR #35 should be staged:
 
 1. Keep the existing review-state endpoint as the frontend compatibility route.
 2. Add database tables and service-layer operations behind the endpoint.
@@ -208,6 +212,17 @@ Migration from PR #34 should be staged:
    objects directly.
 6. Add authorization and revision checks before any public demo uses shared
    production data.
+
+Current implementation evidence:
+
+- PR #35 completes the first database-backed compatibility slice of step 2 by
+  persisting the whole review-state snapshot in `workspace_review_states`.
+- PR #35 does not yet implement typed service-layer operations for
+  `CreativeRepo`, `ReviewItem`, `EvidencePack`, `ReleaseGate`, or
+  `AuditEvent`.
+- PR #35 does not yet implement authorization, stale-write conflict handling,
+  seeded repo migration, operation-specific frontend writes, or multi-instance
+  acceptance evidence.
 
 ## Acceptance Gates
 
@@ -245,3 +260,4 @@ This spec does not upgrade current release status by itself.
 - `yha9806/vulca-platform` PR #31.
 - `yha9806/vulca-platform` PR #32.
 - `yha9806/vulca-platform` PR #34.
+- `yha9806/vulca-platform` PR #35.

--- a/docs/review-context/CHANGELOG.md
+++ b/docs/review-context/CHANGELOG.md
@@ -4,6 +4,25 @@ Vault status: append-only change log.
 
 ## 2026-06-16
 
+### Recorded Platform DB-Backed Workspace Review-State Merge
+
+- Recorded platform PR #35 as merged to `master` with database-backed
+  Workspace review-state compatibility persistence behind the existing
+  `/api/v1/workspace/review-state/{repo_id}` endpoint.
+- Clarified that #35 upgrades the #34 in-process store to a SQLAlchemy-backed
+  snapshot table, but does not complete the full production persistence spec:
+  authorization, conflict handling, typed object aggregates, append-only audit
+  events, and multi-instance acceptance evidence remain gated.
+- Updated the source index, durable Workspace status, M5 closeout, release
+  readiness gate, and manifest so future sessions inherit the correct
+  implementation boundary.
+
+Source basis:
+
+- `yha9806/vulca-platform` PR #35.
+- Merge commit `24efaab5101494cfa7777aa3ded6d8c27e923870`.
+- Remote checks: `Run Tests` and `security` passed on PR #35.
+
 ### Added Workspace Production Persistence Spec
 
 - Added `15-workspace-production-persistence-spec.md` as the protected product

--- a/docs/review-context/MANIFEST.json
+++ b/docs/review-context/MANIFEST.json
@@ -55,8 +55,9 @@
   "core_sources": {
     "sdk_mainline": "cb6d52fe",
     "workspace_context_baseline": "6efef07",
-    "workspace_latest_observed": "d06a713b",
+    "workspace_latest_observed": "24efaab5",
     "workspace_shared_review_state_merge": "d06a713b",
+    "workspace_db_review_state_merge": "24efaab5",
     "artifact_bridge_spec": "11-artifact-bridge-spec.md",
     "m3_bridge_fixture": "artifact-bridge/m3-demo-bridge-fixture.json",
     "m3_durable_review_fixture": "workspace-durable/m3-durable-review-fixture.json",

--- a/docs/review-context/release-readiness/M5-CLOSEOUT.md
+++ b/docs/review-context/release-readiness/M5-CLOSEOUT.md
@@ -38,12 +38,20 @@ As of 2026-06-16:
   mirroring, backend-side `public_ready=false` locking, OpenAPI/module-boundary
   updates, and E2E isolation for shared review state. Its PR gate passed
   remote `Run Tests` and `security`.
+- Platform PR #35, `feat: persist workspace review state in db`, merged to
+  `master` at `24efaab5101494cfa7777aa3ded6d8c27e923870` from head
+  `563e1dd`. It replaces the #34 in-process store with a SQLAlchemy
+  `workspace_review_states` table behind the existing compatibility endpoint,
+  preserves backend-side `public_ready=false` locking, and adds tests for
+  cross-client DB persistence, process-local reset survival, table
+  registration, clearing, OpenAPI contract stability, and DB dependency
+  fallback. Its PR gate passed remote `Run Tests` and `security`.
 
 These PRs improve R5 evidence, but they do not change the product-level
 decision above.
 
-The next product-design reference for closing the persistence blocker is
-`15-workspace-production-persistence-spec.md`.
+The next product-design reference for closing the remaining persistence
+blocker is `15-workspace-production-persistence-spec.md`.
 
 ## Indexed Evidence
 
@@ -64,9 +72,9 @@ The next product-design reference for closing the persistence blocker is
 
 ## Remaining R5 Blockers
 
-- production-grade Workspace persistence beyond the local durable PR and
-  in-process shared backend slice, including durable storage,
-  authorization, conflict handling, and multi-instance behavior;
+- production-grade Workspace persistence beyond the DB-backed compatibility
+  snapshot, including typed durable records, authorization, conflict handling,
+  append-only audit events, and multi-instance behavior;
 - repeated bridge ingestion across more than one workflow;
 - production EvidencePack rendering evidence;
 - human-owned release workflow implementation evidence;
@@ -84,3 +92,4 @@ The next product-design reference for closing the persistence blocker is
 - `yha9806/vulca-platform` PR #31.
 - `yha9806/vulca-platform` PR #32.
 - `yha9806/vulca-platform` PR #34.
+- `yha9806/vulca-platform` PR #35.

--- a/docs/review-context/release-readiness/m5-closeout-summary.json
+++ b/docs/review-context/release-readiness/m5-closeout-summary.json
@@ -28,6 +28,11 @@
       "source": "docs/review-context/workspace-durable/README.md"
     },
     {
+      "name": "database-backed Workspace review-state compatibility evidence",
+      "status": "indexed",
+      "source": "docs/review-context/workspace-durable/README.md"
+    },
+    {
       "name": "Workspace production persistence product spec",
       "status": "indexed",
       "source": "docs/review-context/15-workspace-production-persistence-spec.md"
@@ -63,11 +68,13 @@
     "max_allowed_level": "R4",
     "example_scope": "public-example-key-visual-v1",
     "human_owner": null,
-    "boundary_notes": "R4 example-specific public copy is allowed only within RR4/RR5 scope. Product-level R5 remains blocked. Platform PR #34 adds shared in-process review-state evidence, not production-grade release readiness."
+    "boundary_notes": "R4 example-specific public copy is allowed only within RR4/RR5 scope. Product-level R5 remains blocked. Platform PR #35 adds database-backed review-state compatibility persistence, not full production authorization, conflict, audit, typed aggregate, or multi-instance release readiness."
   },
   "remaining_blockers": [
-    "production database-backed/multi-instance Workspace persistence evidence",
+    "typed Workspace persistence records beyond the compatibility snapshot",
     "Workspace authorization and conflict handling evidence",
+    "append-only Workspace audit event evidence",
+    "multi-instance Workspace persistence acceptance evidence",
     "repeated bridge ingestion evidence",
     "production EvidencePack rendering evidence",
     "human-owned release workflow implementation evidence",

--- a/docs/review-context/source-index.md
+++ b/docs/review-context/source-index.md
@@ -142,6 +142,10 @@ check before changing high-level VULCA claims.
     release blockers, decision state, and human decision history.
   - Platform PR #34 adds shared in-process backend review-state API evidence
     for the Workspace page, while production persistence remains gated.
+  - Platform PR #35 upgrades the compatibility review-state endpoint to a
+    SQLAlchemy-backed `workspace_review_states` table, while full production
+    authorization, conflict handling, typed aggregates, append-only audit
+    events, and multi-instance acceptance remain gated.
 - Public example gate:
   - `docs/review-context/public-examples/m3-public-example-gate.json`
   - Protected RR4 reference for one example-specific public artifact and copy
@@ -166,8 +170,8 @@ Workspace product code lives in the separate `vulca-platform` repository.
   `/Users/yhryzy/.config/superpowers/worktrees/vulca-platform/workspace-interactive-demo`
 - Context baseline: `6efef07 fix: align workspace context review controls`
 - Latest merged platform master:
-  `d06a713bf490ad870fe9273f933c310e2955b4e9` from PR #34,
-  `[codex] Shared Workspace review persistence`.
+  `24efaab5101494cfa7777aa3ded6d8c27e923870` from PR #35,
+  `feat: persist workspace review state in db`.
 - Important files:
   - `wenxin-moyun/src/content/workspaceDemo.ts`
   - `wenxin-moyun/src/components/workspace/`
@@ -190,6 +194,18 @@ Workspace product code lives in the separate `vulca-platform` repository.
   - Merge commit: `d06a713bf490ad870fe9273f933c310e2955b4e9`.
   - Boundary: in-process shared backend state only; not production
     database-backed, authorized, conflict-safe, or multi-instance persistence.
+- DB-backed review-state compatibility merge:
+  - `yha9806/vulca-platform` PR #35.
+  - Merge commit: `24efaab5101494cfa7777aa3ded6d8c27e923870`.
+  - Evidence: SQLAlchemy `WorkspaceReviewState` model, existing
+    `/api/v1/workspace/review-state/{repo_id}` API backed by DB persistence,
+    backend-side `public_ready=false` normalization retained, and tests for
+    cross-client load, process-local reset survival, table registration, clear,
+    OpenAPI contract, and DB dependency fallback.
+  - Boundary: compatibility snapshot persistence only; not full typed
+    CreativeRepo/ReviewItem/EvidencePack/ReleaseGate persistence, not
+    authorization, not stale-write conflict handling, not append-only audit
+    events, and not multi-instance acceptance evidence.
 - Production persistence design:
   - `docs/review-context/15-workspace-production-persistence-spec.md`.
   - This is the next product-layer design reference before changing the

--- a/docs/review-context/workspace-durable/README.md
+++ b/docs/review-context/workspace-durable/README.md
@@ -12,7 +12,7 @@ blocker, decision-state, and human-audit boundaries.
 
 ## Product Implementation Status
 
-As of 2026-06-16, the platform implementation has three merged PRs on
+As of 2026-06-16, the platform implementation has four merged PRs on
 `yha9806/vulca-platform` `master`:
 
 - PR #31, `[codex] Workspace review product shell`, merged at
@@ -28,15 +28,23 @@ As of 2026-06-16, the platform implementation has three merged PRs on
   `/api/v1/workspace/review-state/{repo_id}`, frontend load/save mirroring for
   the Workspace page, backend-side `public_ready=false` normalization, and
   E2E isolation for the shared review-state API.
+- PR #35, `feat: persist workspace review state in db`, merged at
+  `24efaab5101494cfa7777aa3ded6d8c27e923870`. It adds a SQLAlchemy
+  `workspace_review_states` table behind the existing compatibility endpoint,
+  preserves backend-side release gate normalization, and adds SQLite-backed
+  tests for cross-client persistence, process-local reset survival, table
+  registration, and clearing.
 
 PR #32 is intentionally a local durability slice. PR #34 is intentionally a
-shared in-process backend slice. Together they improve Workspace persistence
-evidence, but they do not certify production persistence, authorization,
-conflict handling, multi-instance durability, or product-level release
-readiness.
+shared in-process backend slice. PR #35 upgrades that compatibility route to
+database-backed snapshot persistence. Together they improve Workspace
+persistence evidence, but they do not certify the full production model:
+authorization, conflict handling, typed CreativeRepo/ReviewItem/EvidencePack
+aggregates, append-only audit events, multi-instance acceptance, or
+product-level release readiness.
 
 Use `../15-workspace-production-persistence-spec.md` for the product design
-that turns these slices into production database-backed persistence.
+that turns these slices into the full production persistence model.
 
 ## Current Fixtures
 
@@ -63,3 +71,4 @@ that turns these slices into production database-backed persistence.
 - `yha9806/vulca-platform` PR #31.
 - `yha9806/vulca-platform` PR #32.
 - `yha9806/vulca-platform` PR #34.
+- `yha9806/vulca-platform` PR #35.


### PR DESCRIPTION
## Summary
- record yha9806/vulca-platform PR #35 and merge commit 24efaab5101494cfa7777aa3ded6d8c27e923870
- update the Workspace persistence spec, source index, durable-review status, release-readiness gate, M5 closeout, and manifest
- preserve the boundary that PR #35 is DB-backed compatibility snapshot persistence, not full production authorization/conflict/audit/typed-aggregate/multi-instance readiness

## Verification
- python3 docs/review-context/gates/validate_review_context.py
- python3 -m pytest tests/test_review_context_vault.py -q
- git diff --check
- git diff --cached | gemini-agent diff-review --stdin
