### PR TITLE
docs: record workspace conflict audit merge

### DIFF
--- a/docs/review-context/14-release-readiness-evidence-gate.md
+++ b/docs/review-context/14-release-readiness-evidence-gate.md
@@ -110,21 +110,25 @@ Current evidence:
   `public_ready=false` locking.
 - Platform PR #35 upgrades that compatibility endpoint from process memory to
   SQLAlchemy-backed database persistence for the whole review-state snapshot.
+- Platform PR #36 adds revision metadata, optional `baseRevision` 409 conflict
+  checks, stale-after-clear protection, write/delete row locking, and
+  append-only save/clear audit events for the compatibility snapshot route.
 - `15-workspace-production-persistence-spec.md` defines the product design for
   database-backed storage, authorization, conflict handling, audit events, and
   multi-instance behavior.
 
 Remaining boundary:
 
-- PR #35 proves database-backed compatibility snapshot persistence, but does
-  not prove authorization, conflict handling, typed Workspace aggregates,
-  append-only audit events, or multi-instance acceptance behavior.
+- PR #36 proves compatibility snapshot revision conflict checks and audit
+  events, but does not prove authorization, typed Workspace aggregates,
+  release-owner audit semantics, operation-specific writes, or multi-instance
+  acceptance behavior.
 
 Blocked until:
 
 - the compatibility snapshot slice is supplemented by production-grade access
-  boundaries, conflict handling, audit events, typed durable records, and
-  multi-instance evidence for the demo path.
+  boundaries, typed durable records, operation-specific frontend writes,
+  release-owner audit semantics, and multi-instance evidence for the demo path.
 
 ### Gate 2: Artifact Ingestion
 

--- a/docs/review-context/15-workspace-production-persistence-spec.md
+++ b/docs/review-context/15-workspace-production-persistence-spec.md
@@ -15,7 +15,7 @@ readiness.
 
 ## Current Baseline
 
-The current platform state has four relevant merged slices:
+The current platform state has five relevant merged slices:
 
 - PR #31 adds the Workspace review product shell.
 - PR #32 adds local durable review state and release-owner audit trail
@@ -26,11 +26,15 @@ The current platform state has four relevant merged slices:
 - PR #35 replaces the #34 process-memory store behind that compatibility
   endpoint with a SQLAlchemy `workspace_review_states` table and tests that
   prove the saved snapshot survives a process-local store reset.
+- PR #36 adds revision metadata, optional `baseRevision` stale-write 409
+  checks, stale-after-clear protection, row locking on write/delete paths, and
+  append-only save/clear audit events for the same compatibility endpoint.
 
 The baseline now proves product direction, a shared API surface, and
-database-backed compatibility snapshot persistence. It does not prove the full
-production persistence model, authorization, conflict handling, append-only
-audit events, typed object aggregates, or multi-instance acceptance behavior.
+database-backed compatibility snapshot persistence with basic revision conflict
+and audit evidence. It does not prove the full production persistence model,
+authorization, typed object aggregates, release-owner audit semantics,
+operation-specific writes, or multi-instance acceptance behavior.
 
 ## Product Position
 
@@ -201,7 +205,7 @@ Rules:
 
 ## Migration From Current Slice
 
-Migration from PR #34 and PR #35 should be staged:
+Migration from PR #34, PR #35, and PR #36 should be staged:
 
 1. Keep the existing review-state endpoint as the frontend compatibility route.
 2. Add database tables and service-layer operations behind the endpoint.
@@ -217,12 +221,16 @@ Current implementation evidence:
 
 - PR #35 completes the first database-backed compatibility slice of step 2 by
   persisting the whole review-state snapshot in `workspace_review_states`.
+- PR #36 extends that compatibility slice with API revision metadata,
+  optional `baseRevision` 409 checks, stale-after-clear protection, write-path
+  row locks, append-only snapshot audit events, and an Alembic migration for
+  the audit table.
 - PR #35 does not yet implement typed service-layer operations for
   `CreativeRepo`, `ReviewItem`, `EvidencePack`, `ReleaseGate`, or
   `AuditEvent`.
-- PR #35 does not yet implement authorization, stale-write conflict handling,
-  seeded repo migration, operation-specific frontend writes, or multi-instance
-  acceptance evidence.
+- PR #36 does not yet implement authorization, typed service-layer operations,
+  release-owner audit semantics, seeded repo migration, operation-specific
+  frontend writes, or multi-instance acceptance evidence.
 
 ## Acceptance Gates
 
@@ -261,3 +269,4 @@ This spec does not upgrade current release status by itself.
 - `yha9806/vulca-platform` PR #32.
 - `yha9806/vulca-platform` PR #34.
 - `yha9806/vulca-platform` PR #35.
+- `yha9806/vulca-platform` PR #36.

--- a/docs/review-context/CHANGELOG.md
+++ b/docs/review-context/CHANGELOG.md
@@ -4,6 +4,25 @@ Vault status: append-only change log.
 
 ## 2026-06-16
 
+### Recorded Platform Review Revision Conflict And Audit Merge
+
+- Recorded platform PR #36 as merged to `master` with revision metadata,
+  optional `baseRevision` 409 conflict checks, and append-only save/clear audit
+  events for the existing Workspace review-state compatibility endpoint.
+- Clarified that #36 strengthens the DB-backed snapshot route from #35, but
+  still does not complete full production persistence: authorization, typed
+  object aggregates, release-owner audit semantics, operation-specific writes,
+  and multi-instance acceptance evidence remain gated.
+- Updated the source index, durable Workspace status, M5 closeout, release
+  readiness gate, production persistence spec, and manifest so future sessions
+  inherit the correct boundary.
+
+Source basis:
+
+- `yha9806/vulca-platform` PR #36.
+- Merge commit `3310093131132268ec9658736d3bd172ecccbe58`.
+- Remote checks: `Run Tests` and `security` passed on PR #36.
+
 ### Recorded Platform DB-Backed Workspace Review-State Merge
 
 - Recorded platform PR #35 as merged to `master` with database-backed

--- a/docs/review-context/MANIFEST.json
+++ b/docs/review-context/MANIFEST.json
@@ -55,9 +55,10 @@
   "core_sources": {
     "sdk_mainline": "cb6d52fe",
     "workspace_context_baseline": "6efef07",
-    "workspace_latest_observed": "24efaab5",
+    "workspace_latest_observed": "3310093",
     "workspace_shared_review_state_merge": "d06a713b",
     "workspace_db_review_state_merge": "24efaab5",
+    "workspace_revision_conflict_audit_merge": "3310093",
     "artifact_bridge_spec": "11-artifact-bridge-spec.md",
     "m3_bridge_fixture": "artifact-bridge/m3-demo-bridge-fixture.json",
     "m3_durable_review_fixture": "workspace-durable/m3-durable-review-fixture.json",

--- a/docs/review-context/release-readiness/M5-CLOSEOUT.md
+++ b/docs/review-context/release-readiness/M5-CLOSEOUT.md
@@ -46,6 +46,12 @@ As of 2026-06-16:
   cross-client DB persistence, process-local reset survival, table
   registration, clearing, OpenAPI contract stability, and DB dependency
   fallback. Its PR gate passed remote `Run Tests` and `security`.
+- Platform PR #36, `feat: add workspace review revision conflicts`, merged to
+  `master` at `3310093131132268ec9658736d3bd172ecccbe58` from head
+  `2c1bd63`. It adds revision metadata, optional `baseRevision` 409 conflict
+  checks, stale-after-clear protection, write/delete row locking, append-only
+  save/clear audit events, and an Alembic migration for the audit table. Its
+  PR gate passed remote `Run Tests` and `security`.
 
 These PRs improve R5 evidence, but they do not change the product-level
 decision above.
@@ -73,8 +79,8 @@ blocker is `15-workspace-production-persistence-spec.md`.
 ## Remaining R5 Blockers
 
 - production-grade Workspace persistence beyond the DB-backed compatibility
-  snapshot, including typed durable records, authorization, conflict handling,
-  append-only audit events, and multi-instance behavior;
+  snapshot, including typed durable records, authorization, release-owner
+  audit semantics, operation-specific writes, and multi-instance behavior;
 - repeated bridge ingestion across more than one workflow;
 - production EvidencePack rendering evidence;
 - human-owned release workflow implementation evidence;
@@ -93,3 +99,4 @@ blocker is `15-workspace-production-persistence-spec.md`.
 - `yha9806/vulca-platform` PR #32.
 - `yha9806/vulca-platform` PR #34.
 - `yha9806/vulca-platform` PR #35.
+- `yha9806/vulca-platform` PR #36.

--- a/docs/review-context/release-readiness/m5-closeout-summary.json
+++ b/docs/review-context/release-readiness/m5-closeout-summary.json
@@ -33,6 +33,11 @@
       "source": "docs/review-context/workspace-durable/README.md"
     },
     {
+      "name": "Workspace review-state revision conflict and audit evidence",
+      "status": "indexed",
+      "source": "docs/review-context/workspace-durable/README.md"
+    },
+    {
       "name": "Workspace production persistence product spec",
       "status": "indexed",
       "source": "docs/review-context/15-workspace-production-persistence-spec.md"
@@ -68,12 +73,13 @@
     "max_allowed_level": "R4",
     "example_scope": "public-example-key-visual-v1",
     "human_owner": null,
-    "boundary_notes": "R4 example-specific public copy is allowed only within RR4/RR5 scope. Product-level R5 remains blocked. Platform PR #35 adds database-backed review-state compatibility persistence, not full production authorization, conflict, audit, typed aggregate, or multi-instance release readiness."
+    "boundary_notes": "R4 example-specific public copy is allowed only within RR4/RR5 scope. Product-level R5 remains blocked. Platform PR #36 adds compatibility snapshot revision conflict checks and save/clear audit events, not full production authorization, typed aggregate, release-owner audit semantics, operation-specific writes, or multi-instance release readiness."
   },
   "remaining_blockers": [
     "typed Workspace persistence records beyond the compatibility snapshot",
-    "Workspace authorization and conflict handling evidence",
-    "append-only Workspace audit event evidence",
+    "Workspace authorization evidence",
+    "release-owner audit semantics beyond compatibility snapshot events",
+    "operation-specific Workspace write evidence",
     "multi-instance Workspace persistence acceptance evidence",
     "repeated bridge ingestion evidence",
     "production EvidencePack rendering evidence",

--- a/docs/review-context/source-index.md
+++ b/docs/review-context/source-index.md
@@ -146,6 +146,11 @@ check before changing high-level VULCA claims.
     SQLAlchemy-backed `workspace_review_states` table, while full production
     authorization, conflict handling, typed aggregates, append-only audit
     events, and multi-instance acceptance remain gated.
+  - Platform PR #36 adds revision metadata, optional `baseRevision` stale-write
+    409 checks, and append-only save/clear audit events for that compatibility
+    snapshot route, while authorization, typed aggregates, release-owner audit
+    semantics, operation-specific writes, and multi-instance acceptance remain
+    gated.
 - Public example gate:
   - `docs/review-context/public-examples/m3-public-example-gate.json`
   - Protected RR4 reference for one example-specific public artifact and copy
@@ -170,8 +175,8 @@ Workspace product code lives in the separate `vulca-platform` repository.
   `/Users/yhryzy/.config/superpowers/worktrees/vulca-platform/workspace-interactive-demo`
 - Context baseline: `6efef07 fix: align workspace context review controls`
 - Latest merged platform master:
-  `24efaab5101494cfa7777aa3ded6d8c27e923870` from PR #35,
-  `feat: persist workspace review state in db`.
+  `3310093131132268ec9658736d3bd172ecccbe58` from PR #36,
+  `feat: add workspace review revision conflicts`.
 - Important files:
   - `wenxin-moyun/src/content/workspaceDemo.ts`
   - `wenxin-moyun/src/components/workspace/`
@@ -206,6 +211,18 @@ Workspace product code lives in the separate `vulca-platform` repository.
     CreativeRepo/ReviewItem/EvidencePack/ReleaseGate persistence, not
     authorization, not stale-write conflict handling, not append-only audit
     events, and not multi-instance acceptance evidence.
+- Revision conflict and audit compatibility merge:
+  - `yha9806/vulca-platform` PR #36.
+  - Merge commit: `3310093131132268ec9658736d3bd172ecccbe58`.
+  - Evidence: `revision` returned by the existing review-state API,
+    optional wrapped payloads with `baseRevision`, stale-write 409 responses,
+    stale-after-clear 409 responses, row locking on write/delete paths,
+    append-only `workspace_review_audit_events` save/clear records, and an
+    Alembic migration for the audit table.
+  - Boundary: compatibility snapshot conflict/audit only; not authorization,
+    not typed CreativeRepo/ReviewItem/EvidencePack/ReleaseGate aggregates, not
+    operation-specific frontend writes, not release-owner audit semantics, and
+    not multi-instance acceptance evidence.
 - Production persistence design:
   - `docs/review-context/15-workspace-production-persistence-spec.md`.
   - This is the next product-layer design reference before changing the

--- a/docs/review-context/workspace-durable/README.md
+++ b/docs/review-context/workspace-durable/README.md
@@ -12,7 +12,7 @@ blocker, decision-state, and human-audit boundaries.
 
 ## Product Implementation Status
 
-As of 2026-06-16, the platform implementation has four merged PRs on
+As of 2026-06-16, the platform implementation has five merged PRs on
 `yha9806/vulca-platform` `master`:
 
 - PR #31, `[codex] Workspace review product shell`, merged at
@@ -34,14 +34,20 @@ As of 2026-06-16, the platform implementation has four merged PRs on
   preserves backend-side release gate normalization, and adds SQLite-backed
   tests for cross-client persistence, process-local reset survival, table
   registration, and clearing.
+- PR #36, `feat: add workspace review revision conflicts`, merged at
+  `3310093131132268ec9658736d3bd172ecccbe58`. It adds revision metadata,
+  optional `baseRevision` 409 conflict checks, stale-after-clear protection,
+  row locking on write/delete paths, append-only save/clear audit events, and
+  an Alembic migration for the audit table.
 
 PR #32 is intentionally a local durability slice. PR #34 is intentionally a
 shared in-process backend slice. PR #35 upgrades that compatibility route to
-database-backed snapshot persistence. Together they improve Workspace
+database-backed snapshot persistence. PR #36 adds compatibility-route revision
+conflict checks and snapshot audit events. Together they improve Workspace
 persistence evidence, but they do not certify the full production model:
-authorization, conflict handling, typed CreativeRepo/ReviewItem/EvidencePack
-aggregates, append-only audit events, multi-instance acceptance, or
-product-level release readiness.
+authorization, typed CreativeRepo/ReviewItem/EvidencePack aggregates,
+release-owner audit semantics, operation-specific writes, multi-instance
+acceptance, or product-level release readiness.
 
 Use `../15-workspace-production-persistence-spec.md` for the product design
 that turns these slices into the full production persistence model.
@@ -72,3 +78,4 @@ that turns these slices into the full production persistence model.
 - `yha9806/vulca-platform` PR #32.
 - `yha9806/vulca-platform` PR #34.
 - `yha9806/vulca-platform` PR #35.
+- `yha9806/vulca-platform` PR #36.


### PR DESCRIPTION
## Summary
- record yha9806/vulca-platform PR #36 and merge commit 3310093131132268ec9658736d3bd172ecccbe58
- update the Workspace production persistence spec, source index, durable-review status, release-readiness gate, M5 closeout, and manifest
- preserve the boundary that PR #36 is compatibility snapshot revision/conflict/audit evidence, not full production authorization, typed aggregates, release-owner audit semantics, operation-specific writes, or multi-instance readiness

## Verification
- python3 docs/review-context/gates/validate_review_context.py
- python3 -m pytest tests/test_review_context_vault.py -q
- git diff --check
- git diff --cached | gemini-agent diff-review --stdin
